### PR TITLE
Add "readers who completed something" to the general stats

### DIFF
--- a/application/models/stats_model.php
+++ b/application/models/stats_model.php
@@ -143,8 +143,18 @@ class Stats_model extends CI_Model {
 
 	function reader_count_with_completed()
 	{
-		
-	}		
+		$sql = '
+			SELECT
+				COUNT(DISTINCT sr.reader_id) AS reader_count
+			FROM section_readers sr
+				JOIN sections s ON s.id = sr.section_id
+			WHERE s.status = ?
+			';
+
+		$query = $this->db->query($sql, SECTION_STATUS_PL_OK);
+
+		return $query->row()->reader_count;
+	}
 
 
 	function active_projects()


### PR DESCRIPTION
This data is regularly posted in the "LibriVox monthly statistics"
forum thread, therefore all numbers should be there.