### PR TITLE
Improve RSS sorting

### DIFF
--- a/application/views/rss/rss.php
+++ b/application/views/rss/rss.php
@@ -8,6 +8,7 @@
   <description><![CDATA[<?= strip_tags($project->description) ?>]]></description>
   <!--<genre>project element=Genre</genre>-->
   <!--<language>project element=lang.code</language>-->
+  <itunes:type>serial</itunes:type>
   <itunes:author>LibriVox</itunes:author>
   <itunes:summary><![CDATA[<?= strip_tags($project->description) ?>]]></itunes:summary>
   <itunes:owner>
@@ -21,6 +22,7 @@
   <?php foreach($sections as $section): ?>
   <item>
     <title><![CDATA[<?= $section->title?>]]></title>
+    <itunes:episode><![CDATA[<?= $section->section_number?>]]></itunes:episode>
     <!--<reader>file element=reader</reader> -->
     <link><![CDATA[<?=  $project->url_librivox?>]]></link>
       <?php /* 1 kbps is equivalent to 125 bytes per second. Our 64kbps


### PR DESCRIPTION
Currently some podcast clients have issues displaying LibriVox recordings in the correct order, this is presumably because you don't have `pubDate` like standard podcasts.

However LibriVox can provide `section_number` as the episode number so podcast clients can use that to sort.

I have also added iTunes `type` = `serial`, this is used to identify podcasts where order is important, apposed to the majority of podcasts where they are time relevant, and the latest episode is emphasised. This should help compatible podcast clients prompt the user to listen from the start, in the correct order.

NOTE: It looks fine to me but I don't have a PHP environment set up so I can't test this. The only potential issue I can see would be `section_number` as I don't fully understand the objects in this project. But I'm fairly confidant this should work fine.