### PR TITLE
Fix advanced language search for compilations

### DIFF
--- a/application/libraries/Librivox_search.php
+++ b/application/libraries/Librivox_search.php
@@ -85,8 +85,8 @@ class Librivox_search{
 
 			$language_clause = ' AND ( p.language_id = ' . $recorded_language . ' OR p.id IN (' . implode(',', $section_project_ids) . ') ) ';
 			$section_language_clause = '
-				AND ( p.language_id = ' . $recorded_language . '
-					OR st.section_language_id = ' . $recorded_language . ') ';
+				AND ( p.language_id <> ' . $recorded_language . '
+					AND st.section_language_id = ' . $recorded_language . ') ';
 		}
 
 


### PR DESCRIPTION
There are compilations where every section has the same language as the
corresponding project (examples: Sammlung deutscher Gedichte). When
searching by language, the individual sections are not interesting,
only the project itself should be listed.