### PR TITLE
Display author information concisely and update it correctly

### DIFF
--- a/application/controllers/cron/project_status_stats.php
+++ b/application/controllers/cron/project_status_stats.php
@@ -22,6 +22,11 @@ class Project_status_stats extends CI_Controller
 
 	public function author()
 	{
+		$this->db->query('
+			UPDATE authors
+			SET meta_complete = 0,
+				meta_in_progress = 0');
+
 		$sql = '
 			UPDATE authors
 			JOIN 

--- a/application/helpers/previewer_helper.php
+++ b/application/helpers/previewer_helper.php
@@ -204,3 +204,9 @@ function build_author_years($author)
 		? ""
 		: sprintf("(%s - %s)", $author->dob, $author->dod);
 }
+
+/** Example: translate_plural("%d book", "%d books", $n) => "1 book" or "13 books" */
+function translate_plural($one, $other, $n)
+{
+	return sprintf(ngettext($one, $other, $n), $n);
+}

--- a/application/views/catalog/item_blades/author_blade.php
+++ b/application/views/catalog/item_blades/author_blade.php
@@ -6,7 +6,15 @@
 
 	<div class="result-data">
 		<h3><a href="<?= base_url('author/'. $item['author_id']) ?>"><?= build_author_name((object) $item)?> <span class="dod-dob"><?= build_author_years((object) $item) ?></span></a></h3>
-		<p class="book-meta">Completed: <span><?= $item['meta_complete']?> books</span> | In progress: <span><?= $item['meta_in_progress']?> books</span></p>
+		<p class="book-meta">
+			<?php if ($item['meta_complete'] > 0): ?>
+				Completed: <span><?= translate_plural("%d book", "%d books", $item['meta_complete']) ?></span>
+			<?php endif; ?>
+			<?= $item['meta_complete'] > 0 && $item['meta_in_progress'] > 0 ? '|' : '' ?>
+			<?php if ($item['meta_in_progress'] > 0): ?>
+				In progress: <span><?= translate_plural("%d book", "%d books", $item['meta_in_progress']) ?></span>
+			<?php endif; ?>
+		</p>
 	</div>	
 	<a href="<?= base_url('author/'. $item['author_id']) ?>" class="more-result">more results</a>		
 </li>


### PR DESCRIPTION
If an author has 0 completed books, that information is not worth being
displayed. Same for 0 books in progress. Use correct plural forms for
the above information (book/books).

Authors that had "Completed: 0 books | In progress: 0 books" before do
not have any information at all now. This can later be extended to count
the sections instead of the projects, for those authors that only appear
in collective works.

When updating the book statistics, also update those authors that don't
have any books at all. Without this extra cleanup, these authors will
keep the previous count of their books, which is wrong. To see the wrong
behavior:

    UPDATE authors SET meta_complete = -1, meta_in_progress = -1;

    https://librivox.org/cron/project_status_stats/author

    https://librivox.org/search

Now some of the authors still have the -1 count.