### PR TITLE
add issue templates

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+
+<!--
+  Provide a clear and concise description of what the problem is.
+  If you would like to report an error with data in the catalogue 
+  rather than a technical issue, do so here: https://forum.librivox.org/viewtopic.php?f=29&t=48506
+-->
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/ISSUE_TEMPLATE/feature_time.md
+++ b/ISSUE_TEMPLATE/feature_time.md
@@ -1,0 +1,43 @@
+---
+name: Feature time
+about: Create a report to help us decide what to do next
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+
+### Is your proposal related to a problem?
+
+<!--
+  Provide a clear and concise description of what the problem is.
+  For example, "I'm always frustrated when..."
+-->
+
+(Write your answer here.)
+
+### Describe the solution you'd like
+
+<!--
+  Provide a clear and concise description of what you want to happen.
+-->
+
+(Describe your proposed solution here.)
+
+### Describe alternatives you've considered
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+(Write your answer here.)
+
+### Additional context
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->
+
+(Write your answer here.)


### PR DESCRIPTION
Adding issue templates.

I think these are at least a small step to make it a little easier for someone to contribute in terms of reporting a bug. Templates are pretty common in other popular repos. We discussed it a bit [here](https://forum.librivox.org/viewtopic.php?f=17&t=81235).

These will show up when someone clicks the "new issue" button.

No changes are needed in the repo setting. It will function like the example in my repo [here](https://github.com/RayBB/issue-template-test).

Let me know if there's a better way to phrase the template, this is just a starting point. 