### PR TITLE
feed api returns wrongs keys when extended results are requested

### DIFF
--- a/application/libraries/Librivox_API.php
+++ b/application/libraries/Librivox_API.php
@@ -158,9 +158,9 @@ class Librivox_API{
 
 				if (!empty($project['sections']))
 				{
-					foreach ($project['sections'] as $key=>$section)
+					foreach ($project['sections'] as $ks=>$section)
 					{
-						$project['sections'][$key]['readers'] =$this->_get_readers($section['id']);
+						$project['sections'][$ks]['readers'] =$this->_get_readers($section['id']);
 					}
 				}
 


### PR DESCRIPTION
`$key` is used in both loop - this should fix the broken results returned by https://librivox.org/api/feed/audiobooks/?extended=1&format=json