### PR TITLE
Fix searches that contain certain special symbols.

### DIFF
--- a/application/views/catalog/partials/footer.php
+++ b/application/views/catalog/partials/footer.php
@@ -267,7 +267,7 @@
 		$.ajax({
 		  	url: CI_ROOT  + 'advanced_search',
 		  	type: 'get',
-		  	data: $('#advanced_search_form').serialize() + '&q=' + q ,
+		  	data: $('#advanced_search_form').serialize() + '&q=' + encodeURIComponent(q),
 		  	beforeSend: function(){
 		  		$('.browse-list').html(spinner);
 		  		$('.page-number-nav').html('');
@@ -356,7 +356,8 @@
 
 		if (current_page != 'search') 
 		{
-			window.location.href = CI_ROOT + 'search/q/' + q;
+			window.location.href = CI_ROOT + 'search?search_form=get_results&q=' + encodeURIComponent(q);
+			return;
 		}
 
 		librivox_search();


### PR DESCRIPTION
There were two spots causing issues:
1. The ajax get request to perform the actual search was not URI encoding
   the query. This still worked for most symbols but some such as "&" and
   "+" were failing.
2. When performing a search from a page other than the search results
   page it was encoding the search query into the URL path in the form of
   "search/q/{query}". But this fails for many different symbols. Even if
   you try to URI encode the query a "/" will still break it. This commit
   changes the URL to be "search?search_form=get_results&q={query}" and
   URI encodes the query. This seems to work fine for every possible
   query with special symbols I could think of. This exact same issue
   is also present in the Wordpress theme.