### PR TITLE
Generate catalog URL when status changes to Validation.

### DIFF
--- a/application/libraries/Catalog_item.php
+++ b/application/libraries/Catalog_item.php
@@ -106,7 +106,7 @@ class Catalog_item {
 	private function _create_project_slug($project_info)
 	{
 		// if we are marking "complete" we need to create the slug
-		if ($project_info['status'] == PROJECT_STATUS_COMPLETE && empty($project_info['url_librivox']))
+		if ($project_info['status'] == PROJECT_STATUS_VALIDATION && empty($project_info['url_librivox']))
 		{
 			$config = array(
 			    'field' => 'url_librivox',


### PR DESCRIPTION
Previously the URL was generated when the status changed to Complete.

This implements the request from issue #41.