### PR TITLE
Fix play time formatting overflow at 24 hours.

### DIFF
--- a/application/controllers/private/iarchive_upload.php
+++ b/application/controllers/private/iarchive_upload.php
@@ -137,12 +137,13 @@ class Iarchive_upload extends Private_Controller
 
 	function _update_total_runtime($project)
 	{
+		$this->load->helper('previewer');
 		$this->load->model('section_model');
 		$runtime = $this->section_model->get_total_project_runtime($project->id);
 
 		if (empty($runtime)) $runtime = 0;
 
-		$totaltime = gmdate("H:i:s", $runtime);
+		$totaltime = format_playtime($runtime);
 
 		$this->load->model('project_model');
 		$this->project_model->update($project->id, array('totaltime' => $totaltime));

--- a/application/controllers/private/section_compiler.php
+++ b/application/controllers/private/section_compiler.php
@@ -222,7 +222,7 @@ class Section_compiler extends Private_Controller
 			$section->author_name = $author->first_name . ' ' . $author->last_name;
 		}
 
-		if (!empty($section->playtime)) $section->playtime = gmdate("H:i:s", $section->playtime);
+		if (!empty($section->playtime)) $section->playtime = format_playtime($section->playtime);
 
 		$this->ajax_output(array('section' => $section), TRUE, FALSE);
 	}

--- a/application/helpers/previewer_helper.php
+++ b/application/helpers/previewer_helper.php
@@ -173,3 +173,13 @@ function build_author_years($author)
 		? ""
 		: sprintf("(%s - %s)", $author->dob, $author->dod);
 }
+
+function format_playtime($seconds)
+{
+	$remainder = $seconds;
+	$seconds   = $remainder % 60;
+	$remainder = ($remainder - $seconds) / 60;
+	$minutes   = $remainder % 60;
+	$hours     = ($remainder - $minutes) / 60;
+	return sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);
+}

--- a/application/models/section_model.php
+++ b/application/models/section_model.php
@@ -10,6 +10,8 @@ class Section_model extends MY_Model {
 
     function get_full_sections_info($project_id)
     {
+		$this->load->helper('previewer');
+
         $result = $this->db->where(array('project_id'=>$project_id))
         ->order_by('section_number', 'asc')
         ->get($this->_table);
@@ -19,7 +21,7 @@ class Section_model extends MY_Model {
         {
             foreach ($sections as $key => $section) {
                 $sections[$key]->readers = $this->_get_section_reader($section->id);
-                $sections[$key]->time   = gmdate("H:i:s", $section->playtime);
+                $sections[$key]->time = format_playtime($section->playtime);
 
             }
         }  


### PR DESCRIPTION
The code was using gmdate("H:i:s", playtime) to format play time values
but this will overflow at 24 hours. Instead a new format_playtime function
was added to previewer_helper which properly handles larger values.

This addresses issue #73.

Note that the formatted total times are stored in the database after the project is uploaded to archive.org. This fix will generally only help for new projects going forward. Ones that are already in the database wrong will still be wrong and need to be updated manually.

The fix will in theory fix a 24 hour overflow in a section play time display but I don't think there are any individual sections that long. It also seems it would be better to store the total project time in the database as seconds (like it is for each section) but that is a more complex change to make.