### PR TITLE
Validator bitrate fixes

### DIFF
--- a/application/libraries/Librivox_filecheck.php
+++ b/application/libraries/Librivox_filecheck.php
@@ -94,31 +94,24 @@ class Librivox_filecheck{
 	{
 		sort($map);
 
-		foreach ($map as $key=>$file_name)
+		foreach ($map as $key => $file_name)
 		{
-
 			$file_tags = $this->librivox_id3tag->_get_file_tags($this->validation_dir. $file_name);
 
-			//var_dump($file_tags);
-
-			// i think more useful than using the key...?
 			$this->file_array[$key] = array(
-				'file_name'	=> $file_name,
-				'album'		=> $file_tags['comments']['album'][0],
-				'artist'	=> $file_tags['comments']['artist'][0],
-				'chapter' 	=> $file_tags['comments']['title'][0],
-				'track' 	=> $file_tags['comments']['track_number'][0],
-				'length' 	=> $file_tags['playtime_seconds'],
-				'bitrate'   => $file_tags['bitrate'],
-				'sample'    => $file_tags['audio']['sample_rate'],
+				'file_name'    => $file_name,
+				'album'        => $file_tags['comments']['album'][0],
+				'artist'       => $file_tags['comments']['artist'][0],
+				'chapter'      => $file_tags['comments']['title'][0],
+				'track'        => $file_tags['comments']['track_number'][0],
+				'length'       => $file_tags['playtime_seconds'],
+				'bitrate_mode' => $file_tags['audio']['bitrate_mode'],
+				'bitrate'      => $file_tags['audio']['bitrate'],
+				'sample'       => $file_tags['audio']['sample_rate'],
 				'channelmode'  => $file_tags['audio']['channelmode'],
-				'id3v2'		=> array_key_exists('id3v2', $file_tags),
+				'id3v2'        => array_key_exists('id3v2', $file_tags),
 			);
-
-			unset($file_tags);
-			//var_dump($this->file_array[$file_name]);
 		}
-
 	}
 
 	function _set_project_type(&$project_type)
@@ -153,12 +146,12 @@ class Librivox_filecheck{
 
 	function check_bitrate(&$file_array)
 	{
-		return ((int)$file_array['bitrate']  == 128000);
+		return ($file_array['bitrate_mode'] == 'cbr' && $file_array['bitrate'] == 128000);
 	}
 
 	function check_samplerate(&$file_array)
 	{
-		return ((int)$file_array['sample']  == 44100);
+		return ($file_array['sample'] == 44100);
 	}
 
 	//would indicate a bug

--- a/application/libraries/Librivox_id3tag.php
+++ b/application/libraries/Librivox_id3tag.php
@@ -170,12 +170,23 @@ class Librivox_id3tag{
 				$file_array['filesize'] 	= number_format($file_data['filesize']);
 				$file_array['playtime'] 	= $file_data['playtime_string'];
 				$file_array['volume'] 		= $mp3gain_default - number_format($mp3gain_result[2], 1);
-				$file_array['bitrate'] 		= ceil($file_data['audio']['bitrate']/ 1000);
 				$file_array['sample'] 		= number_format($file_data['audio']['sample_rate']);
-
 				$file_array['track'] 		= '';
                 $file_array['delete']       = '<i data-file_name="'.$file_data['filename'].'" class="icon-remove delete_file" style="cursor:pointer"></i>';
 
+				if ($file_data['audio']['bitrate_mode'] == 'vbr')
+					$file_array['bitrate'] = 'VBR';
+				else if ($file_data['audio']['bitrate_mode'] == 'cbr')
+				{
+					$bitrate = $file_data['audio']['bitrate'];
+					$rounded = (int)round($bitrate / 1000);
+					if ($rounded * 1000 == $bitrate)
+						$file_array['bitrate'] = $rounded;
+					else
+						$file_array['bitrate'] = '~' . $rounded;
+				}
+				else
+					$file_array['bitrate'] = 0;
 
 				if (!empty($file_data['comments']))
 				{

--- a/application/libraries/getid3/extension.cache.dbm.php
+++ b/application/libraries/getid3/extension.cache.dbm.php
@@ -1,16 +1,17 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
 //                                                             //
 // extension.cache.dbm.php - part of getID3()                  //
 // Please see readme.txt for more information                  //
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 //                                                             //
-// This extension written by Allan Hansen <ahØartemis*dk>      //
+// This extension written by Allan Hansen <ahÃ˜artemis*dk>      //
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
@@ -71,9 +72,37 @@
 
 class getID3_cached_dbm extends getID3
 {
+	/**
+	 * @var resource
+	 */
+	private $dba;
 
-	// public: constructor - see top of this file for cache type and cache_options
-	public function getID3_cached_dbm($cache_type, $dbm_filename, $lock_filename) {
+	/**
+	 * @var resource|bool
+	 */
+	private $lock;
+
+	/**
+	 * @var string
+	 */
+	private $cache_type;
+
+	/**
+	 * @var string
+	 */
+	private $dbm_filename;
+
+	/**
+	 * constructor - see top of this file for cache type and cache_options
+	 *
+	 * @param string $cache_type
+	 * @param string $dbm_filename
+	 * @param string $lock_filename
+	 *
+	 * @throws Exception
+	 * @throws getid3_exception
+	 */
+	public function __construct($cache_type, $dbm_filename, $lock_filename) {
 
 		// Check for dba extension
 		if (!extension_loaded('dba')) {
@@ -135,12 +164,14 @@ class getID3_cached_dbm extends getID3
 			$this->clear_cache();
 		}
 
-		parent::getID3();
+		parent::__construct();
 	}
 
 
 
-	// public: destructor
+	/**
+	 * destructor
+	 */
 	public function __destruct() {
 
 		// Close dbm file
@@ -155,7 +186,11 @@ class getID3_cached_dbm extends getID3
 
 
 
-	// public: clear cache
+	/**
+	 * clear cache
+	 *
+	 * @throws Exception
+	 */
 	public function clear_cache() {
 
 		// Close dbm file
@@ -177,8 +212,17 @@ class getID3_cached_dbm extends getID3
 
 
 
-	// public: analyze file
-	public function analyze($filename) {
+	/**
+	 * clear cache
+	 *
+	 * @param string   $filename
+	 * @param int      $filesize
+	 * @param string   $original_filename
+	 * @param resource $fp
+	 *
+	 * @return mixed
+	 */
+	public function analyze($filename, $filesize=null, $original_filename='', $fp=null) {
 
 		if (file_exists($filename)) {
 
@@ -195,10 +239,10 @@ class getID3_cached_dbm extends getID3
 		}
 
 		// Miss
-		$result = parent::analyze($filename);
+		$result = parent::analyze($filename, $filesize, $original_filename, $fp);
 
 		// Save result
-		if (file_exists($filename)) {
+		if (isset($key) && file_exists($filename)) {
 			dba_insert($key, serialize($result), $this->dba);
 		}
 

--- a/application/libraries/getid3/extension.cache.mysqli.php
+++ b/application/libraries/getid3/extension.cache.mysqli.php
@@ -1,0 +1,263 @@
+<?php
+
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//                                                             //
+// extension.cache.mysqli.php - part of getID3()               //
+// Please see readme.txt for more information                  //
+//                                                             //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// This extension written by Allan Hansen <ahØartemis*dk>      //
+// Table name mod by Carlo Capocasa <calroØcarlocapocasa*com>  //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
+
+/**
+* This is a caching extension for getID3(). It works the exact same
+* way as the getID3 class, but return cached information very fast
+*
+* Example:  (see also demo.cache.mysql.php in /demo/)
+*
+*    Normal getID3 usage (example):
+*
+*       require_once 'getid3/getid3.php';
+*       $getID3 = new getID3;
+*       $getID3->encoding = 'UTF-8';
+*       $info1 = $getID3->analyze('file1.flac');
+*       $info2 = $getID3->analyze('file2.wv');
+*
+*    getID3_cached usage:
+*
+*       require_once 'getid3/getid3.php';
+*       require_once 'getid3/getid3/extension.cache.mysqli.php';
+*       // 5th parameter (tablename) is optional, default is 'getid3_cache'
+*       $getID3 = new getID3_cached_mysqli('localhost', 'database', 'username', 'password', 'tablename');
+*       $getID3->encoding = 'UTF-8';
+*       $info1 = $getID3->analyze('file1.flac');
+*       $info2 = $getID3->analyze('file2.wv');
+*
+*
+* Supported Cache Types    (this extension)
+*
+*   SQL Databases:
+*
+*   cache_type          cache_options
+*   -------------------------------------------------------------------
+*   mysqli              host, database, username, password
+*
+*
+*   DBM-Style Databases:    (use extension.cache.dbm)
+*
+*   cache_type          cache_options
+*   -------------------------------------------------------------------
+*   gdbm                dbm_filename, lock_filename
+*   ndbm                dbm_filename, lock_filename
+*   db2                 dbm_filename, lock_filename
+*   db3                 dbm_filename, lock_filename
+*   db4                 dbm_filename, lock_filename  (PHP5 required)
+*
+*   PHP must have write access to both dbm_filename and lock_filename.
+*
+*
+* Recommended Cache Types
+*
+*   Infrequent updates, many reads      any DBM
+*   Frequent updates                    mysqli
+*/
+
+class getID3_cached_mysqli extends getID3
+{
+	/**
+	 * @var mysqli
+	 */
+	private $mysqli;
+
+	/**
+	 * @var mysqli_result
+	 */
+	private $cursor;
+
+	/**
+	 * @var string
+	 */
+	private $table;
+
+	/**
+	 * @var bool
+	 */
+	private $db_structure_check;
+
+
+	/**
+	 * constructor - see top of this file for cache type and cache_options
+	 *
+	 * @param string $host
+	 * @param string $database
+	 * @param string $username
+	 * @param string $password
+	 * @param string $table
+	 *
+	 * @throws Exception
+	 * @throws getid3_exception
+	 */
+	public function __construct($host, $database, $username, $password, $table='getid3_cache') {
+
+		// Check for mysqli support
+		if (!function_exists('mysqli_connect')) {
+			throw new Exception('PHP not compiled with mysqli support.');
+		}
+
+		// Connect to database
+		$this->mysqli = new mysqli($host, $username, $password);
+		if ($this->mysqli->connect_error) {
+			throw new Exception('Connect Error (' . $this->mysqli->connect_errno . ') ' . $this->mysqli->connect_error);
+		}
+
+		// Select database
+		if (!$this->mysqli->select_db($database)) {
+			throw new Exception('Cannot use database '.$database);
+		}
+
+		// Set table
+		$this->table = $table;
+
+		// Create cache table if not exists
+		$this->create_table();
+
+		$this->db_structure_check = true; // set to false if you know your table structure has already been migrated to use `hash` as the primary key to avoid
+		$this->migrate_db_structure();
+
+		// Check version number and clear cache if changed
+		$version = '';
+		$SQLquery  = 'SELECT `value`';
+		$SQLquery .= ' FROM `'.$this->mysqli->real_escape_string($this->table).'`';
+		$SQLquery .= ' WHERE (`filename` = \''.$this->mysqli->real_escape_string(getID3::VERSION).'\')';
+		$SQLquery .= ' AND (`hash` = \'getID3::VERSION\')';
+		if ($this->cursor = $this->mysqli->query($SQLquery)) {
+			list($version) = $this->cursor->fetch_array();
+		}
+		if ($version != getID3::VERSION) {
+			$this->clear_cache();
+		}
+
+		parent::__construct();
+	}
+
+
+	/**
+	 * clear cache
+	 */
+	public function clear_cache() {
+		$this->mysqli->query('TRUNCATE TABLE `'.$this->mysqli->real_escape_string($this->table).'`');
+		$this->mysqli->query('INSERT INTO `'.$this->mysqli->real_escape_string($this->table).'` (`hash`, `filename`, `filesize`, `filetime`, `analyzetime`, `value`) VALUES (\'getID3::VERSION\', \''.getID3::VERSION.'\', -1, -1, -1, \''.getID3::VERSION.'\')');
+	}
+
+
+	/**
+	 * migrate database structure if needed
+	 */
+	public function migrate_db_structure() {
+		// Check for table structure
+		if ($this->db_structure_check) {
+			$SQLquery  = 'SHOW COLUMNS';
+			$SQLquery .= ' FROM `'.$this->mysqli->real_escape_string($this->table).'`';
+			$SQLquery .= ' LIKE \'hash\'';
+			$this->cursor = $this->mysqli->query($SQLquery);
+			if ($this->cursor->num_rows == 0) {
+				// table has not been migrated, add column, add hashes, change index
+				$SQLquery  = 'ALTER TABLE `getid3_cache` DROP PRIMARY KEY, ADD `hash` CHAR(32) NOT NULL DEFAULT \'\' FIRST, ADD PRIMARY KEY(`hash`)';
+				$this->mysqli->query($SQLquery);
+
+				$SQLquery  = 'UPDATE `getid3_cache` SET';
+				$SQLquery .= ' `hash` = MD5(`filename`, `filesize`, `filetime`)';
+				$SQLquery .= ' WHERE (`filesize` > -1)';
+				$this->mysqli->query($SQLquery);
+
+				$SQLquery  = 'UPDATE `getid3_cache` SET';
+				$SQLquery .= ' `hash` = \'getID3::VERSION\'';
+				$SQLquery .= ' WHERE (`filesize` = -1)';
+				$SQLquery .= '   AND (`filetime` = -1)';
+				$SQLquery .= '   AND (`filetime` = -1)';
+				$this->mysqli->query($SQLquery);
+			}
+		}
+	}
+
+
+	/**
+	 * analyze file
+	 *
+	 * @param string   $filename
+	 * @param int      $filesize
+	 * @param string   $original_filename
+	 * @param resource $fp
+	 *
+	 * @return mixed
+	 */
+	public function analyze($filename, $filesize=null, $original_filename='', $fp=null) {
+
+		$filetime = 0;
+		if (file_exists($filename)) {
+
+			// Short-hands
+			$filetime = filemtime($filename);
+			$filesize =  filesize($filename);
+
+			// Lookup file
+			$SQLquery  = 'SELECT `value`';
+			$SQLquery .= ' FROM `'.$this->mysqli->real_escape_string($this->table).'`';
+			$SQLquery .= ' WHERE (`hash` = \''.$this->mysqli->real_escape_string(md5($filename.$filesize.$filetime)).'\')';
+			$this->cursor = $this->mysqli->query($SQLquery);
+			if ($this->cursor->num_rows > 0) {
+				// Hit
+				list($result) = $this->cursor->fetch_array();
+				return unserialize(base64_decode($result));
+			}
+		}
+
+		// Miss
+		$analysis = parent::analyze($filename, $filesize, $original_filename, $fp);
+
+		// Save result
+		if (file_exists($filename)) {
+			$SQLquery  = 'INSERT INTO `'.$this->mysqli->real_escape_string($this->table).'` (`hash`, `filename`, `filesize`, `filetime`, `analyzetime`, `value`) VALUES (';
+			$SQLquery .=   '\''.$this->mysqli->real_escape_string(md5($filename.$filesize.$filetime)).'\'';
+			$SQLquery .= ', \''.$this->mysqli->real_escape_string($filename).'\'';
+			$SQLquery .= ', \''.$this->mysqli->real_escape_string($filesize).'\'';
+			$SQLquery .= ', \''.$this->mysqli->real_escape_string($filetime).'\'';
+			$SQLquery .= ', UNIX_TIMESTAMP()';
+			$SQLquery .= ', \''.$this->mysqli->real_escape_string(base64_encode(serialize($analysis))).'\'';
+			$SQLquery .= ')';
+			$this->cursor = $this->mysqli->query($SQLquery);
+		}
+		return $analysis;
+	}
+
+
+	/**
+	 * (re)create mysqli table
+	 *
+	 * @param bool $drop
+	 */
+	private function create_table($drop=false) {
+		if ($drop) {
+			$SQLquery  = 'DROP TABLE IF EXISTS `'.$this->mysqli->real_escape_string($this->table).'`';
+			$this->mysqli->query($SQLquery);
+		}
+		$SQLquery  = 'CREATE TABLE IF NOT EXISTS `'.$this->mysqli->real_escape_string($this->table).'` (';
+		$SQLquery .=   '`hash` CHAR(32) NOT NULL DEFAULT \'\'';
+		$SQLquery .= ', `filename` VARCHAR(1000) NOT NULL DEFAULT \'\'';
+		$SQLquery .= ', `filesize` INT(11) NOT NULL DEFAULT \'0\'';
+		$SQLquery .= ', `filetime` INT(11) NOT NULL DEFAULT \'0\'';
+		$SQLquery .= ', `analyzetime` INT(11) NOT NULL DEFAULT \'0\'';
+		$SQLquery .= ', `value` LONGTEXT NOT NULL';
+		$SQLquery .= ', PRIMARY KEY (`hash`))';
+		$this->cursor = $this->mysqli->query($SQLquery);
+		echo $this->mysqli->error;
+	}
+}

--- a/application/libraries/getid3/extension.cache.sqlite3.php
+++ b/application/libraries/getid3/extension.cache.sqlite3.php
@@ -1,20 +1,27 @@
 <?php
-/////////////////////////////////////////////////////////////////////////////////
-/// getID3() by James Heinrich <info@getid3.org>                               //
-//  available at http://getid3.sourceforge.net                                 //
-//            or http://www.getid3.org                                        ///
-/////////////////////////////////////////////////////////////////////////////////
-///                                                                            //
-// extension.cache.sqlite3.php - part of getID3()                              //
-// Please see readme.txt for more information                                  //
-//                                                                            ///
-/////////////////////////////////////////////////////////////////////////////////
-///                                                                            //
-// MySQL extension written by Allan Hansen <ahØartemis*dk>                     //
-// Table name mod by Carlo Capocasa <calroØcarlocapocasa*com>                  //
-// MySQL extension was reworked for SQLite3 by Karl G. Holz <newaeonØmac*com>  //
-//                                                                            ///
-/////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//                                                             //
+// extension.cache.mysqli.php - part of getID3()               //
+// Please see readme.txt for more information                  //
+//                                                             //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// extension.cache.sqlite3.php - part of getID3()              //
+// Please see readme.txt for more information                  //
+//                                                             //
+/////////////////////////////////////////////////////////////////
+///                                                            //
+// MySQL extension written by Allan Hansen <ahÃ˜artemis*dk>     //
+// Table name mod by Carlo Capocasa <calroÃ˜carlocapocasa*com>  //
+// MySQL extension was reworked for SQLite3 by                 //
+//   Karl G. Holz <newaeonÃ˜mac*com>                            //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
 /**
 * This is a caching extension for getID3(). It works the exact same
 * way as the getID3 class, but return cached information much faster
@@ -48,20 +55,20 @@
 *
 *   sqlite3             table='getid3_cache', hide=false        (PHP5)
 *
-
-***  database file will be stored in the same directory as this script,
-***  webserver must have write access to that directory!
-***  set $hide to TRUE to prefix db file with .ht to pervent access from web client
-***  this is a default setting in the Apache configuration:
-
-# The following lines prevent .htaccess and .htpasswd files from being viewed by Web clients.
-
-<Files ~ "^\.ht">
-    Order allow,deny
-    Deny from all
-    Satisfy all
-</Files>
-
+*
+* ***  database file will be stored in the same directory as this script,
+* ***  webserver must have write access to that directory!
+* ***  set $hide to TRUE to prefix db file with .ht to pervent access from web client
+* ***  this is a default setting in the Apache configuration:
+*
+* The following lines prevent .htaccess and .htpasswd files from being viewed by Web clients.
+*
+* <Files ~ "^\.ht">
+*     Order allow,deny
+*     Deny from all
+*     Satisfy all
+* </Files>
+*
 ********************************************************************************
 *
 *   -------------------------------------------------------------------
@@ -88,14 +95,35 @@
 *
 *
 */
-class getID3_cached_sqlite3 extends getID3 {
+class getID3_cached_sqlite3 extends getID3
+{
+	/**
+	 * hold the sqlite db
+	 *
+	 * @var SQLite3 Resource
+	 */
+	private $db;
 
 	/**
-	* __construct()
-	* @param string $table holds name of sqlite table
-	* @return type
-	*/
+	 * table to use for caching
+	 *
+	 * @var string $table
+	 */
+	private $table;
+
+	/**
+	 * @param string  $table holds name of sqlite table
+	 * @param boolean $hide
+	 *
+	 * @throws getid3_exception
+	 * @throws Exception
+	 */
 	public function __construct($table='getid3_cache', $hide=false) {
+		// Check for SQLite3 support
+		if (!function_exists('sqlite_open')) {
+			throw new Exception('PHP not compiled with SQLite3 support.');
+		}
+
 		$this->table = $table; // Set table
 		$file = dirname(__FILE__).'/'.basename(__FILE__, 'php').'sqlite';
 		if ($hide) {
@@ -105,7 +133,7 @@ class getID3_cached_sqlite3 extends getID3 {
 		$db = $this->db;
 		$this->create_table();   // Create cache table if not exists
 		$version = '';
-		$sql = $this->version_check;
+		$sql = $this->getQuery('version_check');
 		$stmt = $db->prepare($sql);
 		$stmt->bindValue(':filename', getID3::VERSION, SQLITE3_TEXT);
 		$result = $stmt->execute();
@@ -113,39 +141,27 @@ class getID3_cached_sqlite3 extends getID3 {
 		if ($version != getID3::VERSION) { // Check version number and clear cache if changed
 			$this->clear_cache();
 		}
-		return parent::__construct();
+		parent::__construct();
 	}
 
 	/**
-	* close the database connection
-	*/
+	 * close the database connection
+	 */
 	public function __destruct() {
 		$db=$this->db;
 		$db->close();
 	}
 
 	/**
-	* hold the sqlite db
-	* @var SQLite Resource
-	*/
-	private $db;
-
-	/**
-	* table to use for caching
-	* @var string $table
-	*/
-	private $table;
-
-	/**
-	* clear the cache
-	* @access private
-	* @return type
-	*/
+	 * clear the cache
+	 *
+	 * @return SQLite3Result
+	 */
 	private function clear_cache() {
 		$db = $this->db;
-		$sql = $this->delete_cache;
+		$sql = $this->getQuery('delete_cache');
 		$db->exec($sql);
-		$sql = $this->set_version;
+		$sql = $this->getQuery('set_version');
 		$stmt = $db->prepare($sql);
 		$stmt->bindValue(':filename', getID3::VERSION, SQLITE3_TEXT);
 		$stmt->bindValue(':dirname', getID3::VERSION, SQLITE3_TEXT);
@@ -154,72 +170,78 @@ class getID3_cached_sqlite3 extends getID3 {
 	}
 
 	/**
-	* analyze file and cache them, if cached pull from the db
-	* @param type $filename
-	* @return boolean
-	*/
-	public function analyze($filename) {
+	 * analyze file and cache them, if cached pull from the db
+	 *
+	 * @param string   $filename
+	 * @param integer  $filesize
+	 * @param string   $original_filename
+	 * @param resource $fp
+	 *
+	 * @return mixed|false
+	 */
+	public function analyze($filename, $filesize=null, $original_filename='', $fp=null) {
 		if (!file_exists($filename)) {
 			return false;
 		}
 		// items to track for caching
 		$filetime = filemtime($filename);
-		$filesize = filesize($filename);
+		$filesize_real = filesize($filename);
 		// this will be saved for a quick directory lookup of analized files
 		// ... why do 50 seperate sql quries when you can do 1 for the same result
 		$dirname  = dirname($filename);
 		// Lookup file
 		$db = $this->db;
-		$sql = $this->get_id3_data;
+		$sql = $this->getQuery('get_id3_data');
 		$stmt = $db->prepare($sql);
-		$stmt->bindValue(':filename', $filename, SQLITE3_TEXT);
-		$stmt->bindValue(':filesize', $filesize, SQLITE3_INTEGER);
-		$stmt->bindValue(':filetime', $filetime, SQLITE3_INTEGER);
+		$stmt->bindValue(':filename', $filename,      SQLITE3_TEXT);
+		$stmt->bindValue(':filesize', $filesize_real, SQLITE3_INTEGER);
+		$stmt->bindValue(':filetime', $filetime,      SQLITE3_INTEGER);
 		$res = $stmt->execute();
 		list($result) = $res->fetchArray();
 		if (count($result) > 0 ) {
 			return unserialize(base64_decode($result));
 		}
 		// if it hasn't been analyzed before, then do it now
-		$analysis = parent::analyze($filename);
+		$analysis = parent::analyze($filename, $filesize, $original_filename, $fp);
 		// Save result
-		$sql = $this->cache_file;
+		$sql = $this->getQuery('cache_file');
 		$stmt = $db->prepare($sql);
-		$stmt->bindValue(':filename', $filename, SQLITE3_TEXT);
-		$stmt->bindValue(':dirname', $dirname, SQLITE3_TEXT);
-		$stmt->bindValue(':filesize', $filesize, SQLITE3_INTEGER);
-		$stmt->bindValue(':filetime', $filetime, SQLITE3_INTEGER);
-		$stmt->bindValue(':atime', time(), SQLITE3_INTEGER);
-		$stmt->bindValue(':val', base64_encode(serialize($analysis)), SQLITE3_TEXT);
+		$stmt->bindValue(':filename', $filename,                           SQLITE3_TEXT);
+		$stmt->bindValue(':dirname',  $dirname,                            SQLITE3_TEXT);
+		$stmt->bindValue(':filesize', $filesize_real,                      SQLITE3_INTEGER);
+		$stmt->bindValue(':filetime', $filetime,                           SQLITE3_INTEGER);
+		$stmt->bindValue(':atime',    time(),                              SQLITE3_INTEGER);
+		$stmt->bindValue(':val',      base64_encode(serialize($analysis)), SQLITE3_TEXT);
 		$res = $stmt->execute();
 		return $analysis;
 	}
 
 	/**
-	* create data base table
-	* this is almost the same as MySQL, with the exception of the dirname being added
-	* @return type
-	*/
+	 * create data base table
+	 * this is almost the same as MySQL, with the exception of the dirname being added
+	 *
+	 * @return bool
+	 */
 	private function create_table() {
 		$db = $this->db;
-		$sql = $this->make_table;
+		$sql = $this->getQuery('make_table');
 		return $db->exec($sql);
 	}
 
 	/**
-	* get cached directory
-	*
-	* This function is not in the MySQL extention, it's ment to speed up requesting multiple files
-	* which is ideal for podcasting, playlists, etc.
-	*
-	* @access public
-	* @param string $dir directory to search the cache database for
-	* @return array return an array of matching id3 data
-	*/
+	 * get cached directory
+	 *
+	 * This function is not in the MySQL extention, it's ment to speed up requesting multiple files
+	 * which is ideal for podcasting, playlists, etc.
+	 *
+	 * @param string $dir directory to search the cache database for
+	 *
+	 * @return array return an array of matching id3 data
+	 */
 	public function get_cached_dir($dir) {
 		$db = $this->db;
 		$rows = array();
-		$sql = $this->get_cached_dir;
+		$sql = $this->getQuery('get_cached_dir');
 		$stmt = $db->prepare($sql);
 		$stmt->bindValue(':dirname', $dir, SQLITE3_TEXT);
 		$res = $stmt->execute();
@@ -230,35 +252,46 @@ class getID3_cached_sqlite3 extends getID3 {
 	}
 
 	/**
+	 * returns NULL if query is not found
+	 *
+	 * @param string $name
+	 *
+	 * @return null|string
+	 */
+	public function getQuery($name)
+	{
+		switch ($name) {
+			case 'version_check':
+				return "SELECT val FROM $this->table WHERE filename = :filename AND filesize = '-1' AND filetime = '-1' AND analyzetime = '-1'";
+			case 'delete_cache':
+				return "DELETE FROM $this->table";
+			case 'set_version':
+				return "INSERT INTO $this->table (filename, dirname, filesize, filetime, analyzetime, val) VALUES (:filename, :dirname, -1, -1, -1, :val)";
+			case 'get_id3_data':
+				return "SELECT val FROM $this->table WHERE filename = :filename AND filesize = :filesize AND filetime = :filetime";
+			case 'cache_file':
+				return "INSERT INTO $this->table (filename, dirname, filesize, filetime, analyzetime, val) VALUES (:filename, :dirname, :filesize, :filetime, :atime, :val)";
+			case 'make_table':
+				return "CREATE TABLE IF NOT EXISTS $this->table (filename VARCHAR(255) DEFAULT '', dirname VARCHAR(255) DEFAULT '', filesize INT(11) DEFAULT '0', filetime INT(11) DEFAULT '0', analyzetime INT(11) DEFAULT '0', val text, PRIMARY KEY (filename, filesize, filetime))";
+			case 'get_cached_dir':
+				return "SELECT val FROM $this->table WHERE dirname = :dirname";
+			default:
+				return null;
+		}
+	}
+
+	/**
 	* use the magical __get() for sql queries
 	*
 	* access as easy as $this->{case name}, returns NULL if query is not found
+	*
+	* @param string $name
+	*
+	* @return string
+	* @deprecated use getQuery() instead
 	*/
 	public function __get($name) {
-		switch($name) {
-			case 'version_check':
-				return "SELECT val FROM $this->table WHERE filename = :filename AND filesize = '-1' AND filetime = '-1' AND analyzetime = '-1'";
-				break;
-			case 'delete_cache':
-				return "DELETE FROM $this->table";
-				break;
-			case 'set_version':
-				return "INSERT INTO $this->table (filename, dirname, filesize, filetime, analyzetime, val) VALUES (:filename, :dirname, -1, -1, -1, :val)";
-				break;
-			case 'get_id3_data':
-				return "SELECT val FROM $this->table WHERE filename = :filename AND filesize = :filesize AND filetime = :filetime";
-				break;
-			case 'cache_file':
-				return "INSERT INTO $this->table (filename, dirname, filesize, filetime, analyzetime, val) VALUES (:filename, :dirname, :filesize, :filetime, :atime, :val)";
-				break;
-			case 'make_table':
-				return "CREATE TABLE IF NOT EXISTS $this->table (filename VARCHAR(255) NOT NULL DEFAULT '', dirname VARCHAR(255) NOT NULL DEFAULT '', filesize INT(11) NOT NULL DEFAULT '0', filetime INT(11) NOT NULL DEFAULT '0', analyzetime INT(11) NOT NULL DEFAULT '0', val text not null, PRIMARY KEY (filename, filesize, filetime))";
-				break;
-			case 'get_cached_dir':
-				return "SELECT val FROM $this->table WHERE dirname = :dirname";
-				break;
-		}
-		return null;
+		return $this->getQuery($name);
 	}
 
 }

--- a/application/libraries/getid3/getid3.lib.php
+++ b/application/libraries/getid3/getid3.lib.php
@@ -1,26 +1,34 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
 //                                                             //
 // getid3.lib.php - part of getID3()                           //
-// See readme.txt for more details                             //
+//  see readme.txt for more details                            //
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
 
 class getid3_lib
 {
-
+	/**
+	 * @param string      $string
+	 * @param bool        $hex
+	 * @param bool        $spaces
+	 * @param string|bool $htmlencoding
+	 *
+	 * @return string
+	 */
 	public static function PrintHexBytes($string, $hex=true, $spaces=true, $htmlencoding='UTF-8') {
 		$returnstring = '';
 		for ($i = 0; $i < strlen($string); $i++) {
 			if ($hex) {
-				$returnstring .= str_pad(dechex(ord($string{$i})), 2, '0', STR_PAD_LEFT);
+				$returnstring .= str_pad(dechex(ord($string[$i])), 2, '0', STR_PAD_LEFT);
 			} else {
-				$returnstring .= ' '.(preg_match("#[\x20-\x7E]#", $string{$i}) ? $string{$i} : '¤');
+				$returnstring .= ' '.(preg_match("#[\x20-\x7E]#", $string[$i]) ? $string[$i] : 'Â¤');
 			}
 			if ($spaces) {
 				$returnstring .= ' ';
@@ -35,9 +43,14 @@ class getid3_lib
 		return $returnstring;
 	}
 
+	/**
+	 * Truncates a floating-point number at the decimal point.
+	 *
+	 * @param float $floatnumber
+	 *
+	 * @return float|int returns int (if possible, otherwise float)
+	 */
 	public static function trunc($floatnumber) {
-		// truncates a floating-point number at the decimal point
-		// returns int (if possible, otherwise float)
 		if ($floatnumber >= 1) {
 			$truncatednumber = floor($floatnumber);
 		} elseif ($floatnumber <= -1) {
@@ -51,7 +64,12 @@ class getid3_lib
 		return $truncatednumber;
 	}
 
-
+	/**
+	 * @param int|null $variable
+	 * @param int      $increment
+	 *
+	 * @return bool
+	 */
 	public static function safe_inc(&$variable, $increment=1) {
 		if (isset($variable)) {
 			$variable += $increment;
@@ -61,6 +79,11 @@ class getid3_lib
 		return true;
 	}
 
+	/**
+	 * @param int|float $floatnum
+	 *
+	 * @return int|float
+	 */
 	public static function CastAsInt($floatnum) {
 		// convert to float if not already
 		$floatnum = (float) $floatnum;
@@ -76,6 +99,11 @@ class getid3_lib
 		return $floatnum;
 	}
 
+	/**
+	 * @param int $num
+	 *
+	 * @return bool
+	 */
 	public static function intValueSupported($num) {
 		// check if integers are 64-bit
 		static $hasINT64 = null;
@@ -92,28 +120,43 @@ class getid3_lib
 		return false;
 	}
 
+	/**
+	 * @param string $fraction
+	 *
+	 * @return float
+	 */
 	public static function DecimalizeFraction($fraction) {
 		list($numerator, $denominator) = explode('/', $fraction);
 		return $numerator / ($denominator ? $denominator : 1);
 	}
 
-
+	/**
+	 * @param string $binarynumerator
+	 *
+	 * @return float
+	 */
 	public static function DecimalBinary2Float($binarynumerator) {
 		$numerator   = self::Bin2Dec($binarynumerator);
 		$denominator = self::Bin2Dec('1'.str_repeat('0', strlen($binarynumerator)));
 		return ($numerator / $denominator);
 	}
 
-
+	/**
+	 * @link http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/binary.html
+	 *
+	 * @param string $binarypointnumber
+	 * @param int    $maxbits
+	 *
+	 * @return array
+	 */
 	public static function NormalizeBinaryPoint($binarypointnumber, $maxbits=52) {
-		// http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/binary.html
 		if (strpos($binarypointnumber, '.') === false) {
 			$binarypointnumber = '0.'.$binarypointnumber;
-		} elseif ($binarypointnumber{0} == '.') {
+		} elseif ($binarypointnumber[0] == '.') {
 			$binarypointnumber = '0'.$binarypointnumber;
 		}
 		$exponent = 0;
-		while (($binarypointnumber{0} != '1') || (substr($binarypointnumber, 1, 1) != '.')) {
+		while (($binarypointnumber[0] != '1') || (substr($binarypointnumber, 1, 1) != '.')) {
 			if (substr($binarypointnumber, 1, 1) == '.') {
 				$exponent--;
 				$binarypointnumber = substr($binarypointnumber, 2, 1).'.'.substr($binarypointnumber, 3);
@@ -121,16 +164,21 @@ class getid3_lib
 				$pointpos = strpos($binarypointnumber, '.');
 				$exponent += ($pointpos - 1);
 				$binarypointnumber = str_replace('.', '', $binarypointnumber);
-				$binarypointnumber = $binarypointnumber{0}.'.'.substr($binarypointnumber, 1);
+				$binarypointnumber = $binarypointnumber[0].'.'.substr($binarypointnumber, 1);
 			}
 		}
 		$binarypointnumber = str_pad(substr($binarypointnumber, 0, $maxbits + 2), $maxbits + 2, '0', STR_PAD_RIGHT);
 		return array('normalized'=>$binarypointnumber, 'exponent'=>(int) $exponent);
 	}
 
-
+	/**
+	 * @link http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/binary.html
+	 *
+	 * @param float $floatvalue
+	 *
+	 * @return string
+	 */
 	public static function Float2BinaryDecimal($floatvalue) {
-		// http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/binary.html
 		$maxbits = 128; // to how many bits of precision should the calculations be taken?
 		$intpart   = self::trunc($floatvalue);
 		$floatpart = abs($floatvalue - $intpart);
@@ -144,9 +192,17 @@ class getid3_lib
 		return $binarypointnumber;
 	}
 
-
+	/**
+	 * @link http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/ieee-expl.html
+	 *
+	 * @param float $floatvalue
+	 * @param int $bits
+	 *
+	 * @return string|false
+	 */
 	public static function Float2String($floatvalue, $bits) {
-		// http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/ieee-expl.html
+		$exponentbits = 0;
+		$fractionbits = 0;
 		switch ($bits) {
 			case 32:
 				$exponentbits = 8;
@@ -160,7 +216,6 @@ class getid3_lib
 
 			default:
 				return false;
-				break;
 		}
 		if ($floatvalue >= 0) {
 			$signbit = '0';
@@ -175,22 +230,34 @@ class getid3_lib
 		return self::BigEndian2String(self::Bin2Dec($signbit.$exponentbitstring.$fractionbitstring), $bits % 8, false);
 	}
 
-
+	/**
+	 * @param string $byteword
+	 *
+	 * @return float|false
+	 */
 	public static function LittleEndian2Float($byteword) {
 		return self::BigEndian2Float(strrev($byteword));
 	}
 
-
+	/**
+	 * ANSI/IEEE Standard 754-1985, Standard for Binary Floating Point Arithmetic
+	 *
+	 * @link http://www.psc.edu/general/software/packages/ieee/ieee.html
+	 * @link http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/ieee.html
+	 *
+	 * @param string $byteword
+	 *
+	 * @return float|false
+	 */
 	public static function BigEndian2Float($byteword) {
-		// ANSI/IEEE Standard 754-1985, Standard for Binary Floating Point Arithmetic
-		// http://www.psc.edu/general/software/packages/ieee/ieee.html
-		// http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/ieee.html
-
 		$bitword = self::BigEndian2Bin($byteword);
 		if (!$bitword) {
 			return 0;
 		}
-		$signbit = $bitword{0};
+		$signbit = $bitword[0];
+		$floatvalue = 0;
+		$exponentbits = 0;
+		$fractionbits = 0;
 
 		switch (strlen($byteword) * 8) {
 			case 32:
@@ -207,7 +274,7 @@ class getid3_lib
 				// 80-bit Apple SANE format
 				// http://www.mactech.com/articles/mactech/Vol.06/06.01/SANENormalized/
 				$exponentstring = substr($bitword, 1, 15);
-				$isnormalized = intval($bitword{16});
+				$isnormalized = intval($bitword[16]);
 				$fractionstring = substr($bitword, 17, 63);
 				$exponent = pow(2, self::Bin2Dec($exponentstring) - 16383);
 				$fraction = $isnormalized + self::DecimalBinary2Float($fractionstring);
@@ -216,11 +283,9 @@ class getid3_lib
 					$floatvalue *= -1;
 				}
 				return $floatvalue;
-				break;
 
 			default:
 				return false;
-				break;
 		}
 		$exponentstring = substr($bitword, 1, $exponentbits);
 		$fractionstring = substr($bitword, $exponentbits + 1, $fractionbits);
@@ -258,7 +323,14 @@ class getid3_lib
 		return (float) $floatvalue;
 	}
 
-
+	/**
+	 * @param string $byteword
+	 * @param bool   $synchsafe
+	 * @param bool   $signed
+	 *
+	 * @return int|float|false
+	 * @throws Exception
+	 */
 	public static function BigEndian2Int($byteword, $synchsafe=false, $signed=false) {
 		$intvalue = 0;
 		$bytewordlen = strlen($byteword);
@@ -268,9 +340,9 @@ class getid3_lib
 		for ($i = 0; $i < $bytewordlen; $i++) {
 			if ($synchsafe) { // disregard MSB, effectively 7-bit bytes
 				//$intvalue = $intvalue | (ord($byteword{$i}) & 0x7F) << (($bytewordlen - 1 - $i) * 7); // faster, but runs into problems past 2^31 on 32-bit systems
-				$intvalue += (ord($byteword{$i}) & 0x7F) * pow(2, ($bytewordlen - 1 - $i) * 7);
+				$intvalue += (ord($byteword[$i]) & 0x7F) * pow(2, ($bytewordlen - 1 - $i) * 7);
 			} else {
-				$intvalue += ord($byteword{$i}) * pow(256, ($bytewordlen - 1 - $i));
+				$intvalue += ord($byteword[$i]) * pow(256, ($bytewordlen - 1 - $i));
 			}
 		}
 		if ($signed && !$synchsafe) {
@@ -282,28 +354,53 @@ class getid3_lib
 				}
 			} else {
 				throw new Exception('ERROR: Cannot have signed integers larger than '.(8 * PHP_INT_SIZE).'-bits ('.strlen($byteword).') in self::BigEndian2Int()');
-				break;
 			}
 		}
 		return self::CastAsInt($intvalue);
 	}
 
-
+	/**
+	 * @param string $byteword
+	 * @param bool   $signed
+	 *
+	 * @return int|float|false
+	 */
 	public static function LittleEndian2Int($byteword, $signed=false) {
 		return self::BigEndian2Int(strrev($byteword), false, $signed);
 	}
 
+	/**
+	 * @param string $byteword
+	 *
+	 * @return string
+	 */
+	public static function LittleEndian2Bin($byteword) {
+		return self::BigEndian2Bin(strrev($byteword));
+	}
 
+	/**
+	 * @param string $byteword
+	 *
+	 * @return string
+	 */
 	public static function BigEndian2Bin($byteword) {
 		$binvalue = '';
 		$bytewordlen = strlen($byteword);
 		for ($i = 0; $i < $bytewordlen; $i++) {
-			$binvalue .= str_pad(decbin(ord($byteword{$i})), 8, '0', STR_PAD_LEFT);
+			$binvalue .= str_pad(decbin(ord($byteword[$i])), 8, '0', STR_PAD_LEFT);
 		}
 		return $binvalue;
 	}
 
-
+	/**
+	 * @param int  $number
+	 * @param int  $minbytes
+	 * @param bool $synchsafe
+	 * @param bool $signed
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
 	public static function BigEndian2String($number, $minbytes=1, $synchsafe=false, $signed=false) {
 		if ($number < 0) {
 			throw new Exception('ERROR: self::BigEndian2String() does not support negative numbers');
@@ -324,7 +421,11 @@ class getid3_lib
 		return str_pad($intstring, $minbytes, "\x00", STR_PAD_LEFT);
 	}
 
-
+	/**
+	 * @param int $number
+	 *
+	 * @return string
+	 */
 	public static function Dec2Bin($number) {
 		while ($number >= 256) {
 			$bytes[] = (($number / 256) - (floor($number / 256))) * 256;
@@ -338,11 +439,16 @@ class getid3_lib
 		return $binstring;
 	}
 
-
+	/**
+	 * @param string $binstring
+	 * @param bool   $signed
+	 *
+	 * @return int|float
+	 */
 	public static function Bin2Dec($binstring, $signed=false) {
 		$signmult = 1;
 		if ($signed) {
-			if ($binstring{0} == '1') {
+			if ($binstring[0] == '1') {
 				$signmult = -1;
 			}
 			$binstring = substr($binstring, 1);
@@ -354,7 +460,11 @@ class getid3_lib
 		return self::CastAsInt($decvalue * $signmult);
 	}
 
-
+	/**
+	 * @param string $binstring
+	 *
+	 * @return string
+	 */
 	public static function Bin2String($binstring) {
 		// return 'hi' for input of '0110100001101001'
 		$string = '';
@@ -365,7 +475,13 @@ class getid3_lib
 		return $string;
 	}
 
-
+	/**
+	 * @param int  $number
+	 * @param int  $minbytes
+	 * @param bool $synchsafe
+	 *
+	 * @return string
+	 */
 	public static function LittleEndian2String($number, $minbytes=1, $synchsafe=false) {
 		$intstring = '';
 		while ($number > 0) {
@@ -380,9 +496,14 @@ class getid3_lib
 		return str_pad($intstring, $minbytes, "\x00", STR_PAD_RIGHT);
 	}
 
-
+	/**
+	 * @param mixed $array1
+	 * @param mixed $array2
+	 *
+	 * @return array|false
+	 */
 	public static function array_merge_clobber($array1, $array2) {
-		// written by kcØhireability*com
+		// written by kcÃ˜hireability*com
 		// taken from http://www.php.net/manual/en/function.array-merge-recursive.php
 		if (!is_array($array1) || !is_array($array2)) {
 			return false;
@@ -398,7 +519,12 @@ class getid3_lib
 		return $newarray;
 	}
 
-
+	/**
+	 * @param mixed $array1
+	 * @param mixed $array2
+	 *
+	 * @return array|false
+	 */
 	public static function array_merge_noclobber($array1, $array2) {
 		if (!is_array($array1) || !is_array($array2)) {
 			return false;
@@ -414,7 +540,31 @@ class getid3_lib
 		return $newarray;
 	}
 
+	/**
+	 * @param mixed $array1
+	 * @param mixed $array2
+	 *
+	 * @return array|false|null
+	 */
+	public static function flipped_array_merge_noclobber($array1, $array2) {
+		if (!is_array($array1) || !is_array($array2)) {
+			return false;
+		}
+		# naturally, this only works non-recursively
+		$newarray = array_flip($array1);
+		foreach (array_flip($array2) as $key => $val) {
+			if (!isset($newarray[$key])) {
+				$newarray[$key] = count($newarray);
+			}
+		}
+		return array_flip($newarray);
+	}
 
+	/**
+	 * @param array $theArray
+	 *
+	 * @return bool
+	 */
 	public static function ksort_recursive(&$theArray) {
 		ksort($theArray);
 		foreach ($theArray as $key => $value) {
@@ -425,6 +575,12 @@ class getid3_lib
 		return true;
 	}
 
+	/**
+	 * @param string $filename
+	 * @param int    $numextensions
+	 *
+	 * @return string
+	 */
 	public static function fileextension($filename, $numextensions=1) {
 		if (strstr($filename, '.')) {
 			$reversedfilename = strrev($filename);
@@ -440,7 +596,11 @@ class getid3_lib
 		return '';
 	}
 
-
+	/**
+	 * @param int $seconds
+	 *
+	 * @return string
+	 */
 	public static function PlaytimeString($seconds) {
 		$sign = (($seconds < 0) ? '-' : '');
 		$seconds = round(abs($seconds));
@@ -450,30 +610,53 @@ class getid3_lib
 		return $sign.($H ? $H.':' : '').($H ? str_pad($M, 2, '0', STR_PAD_LEFT) : intval($M)).':'.str_pad($S, 2, 0, STR_PAD_LEFT);
 	}
 
-
+	/**
+	 * @param int $macdate
+	 *
+	 * @return int|float
+	 */
 	public static function DateMac2Unix($macdate) {
 		// Macintosh timestamp: seconds since 00:00h January 1, 1904
 		// UNIX timestamp:      seconds since 00:00h January 1, 1970
 		return self::CastAsInt($macdate - 2082844800);
 	}
 
-
+	/**
+	 * @param string $rawdata
+	 *
+	 * @return float
+	 */
 	public static function FixedPoint8_8($rawdata) {
 		return self::BigEndian2Int(substr($rawdata, 0, 1)) + (float) (self::BigEndian2Int(substr($rawdata, 1, 1)) / pow(2, 8));
 	}
 
-
+	/**
+	 * @param string $rawdata
+	 *
+	 * @return float
+	 */
 	public static function FixedPoint16_16($rawdata) {
 		return self::BigEndian2Int(substr($rawdata, 0, 2)) + (float) (self::BigEndian2Int(substr($rawdata, 2, 2)) / pow(2, 16));
 	}
 
-
+	/**
+	 * @param string $rawdata
+	 *
+	 * @return float
+	 */
 	public static function FixedPoint2_30($rawdata) {
 		$binarystring = self::BigEndian2Bin($rawdata);
 		return self::Bin2Dec(substr($binarystring, 0, 2)) + (float) (self::Bin2Dec(substr($binarystring, 2, 30)) / pow(2, 30));
 	}
 
 
+	/**
+	 * @param string $ArrayPath
+	 * @param string $Separator
+	 * @param mixed $Value
+	 *
+	 * @return array
+	 */
 	public static function CreateDeepArray($ArrayPath, $Separator, $Value) {
 		// assigns $Value to a nested array path:
 		//   $foo = self::CreateDeepArray('/path/to/my', '/', 'file.txt')
@@ -481,9 +664,7 @@ class getid3_lib
 		//   $foo = array('path'=>array('to'=>'array('my'=>array('file.txt'))));
 		// or
 		//   $foo['path']['to']['my'] = 'file.txt';
-		while ($ArrayPath && ($ArrayPath{0} == $Separator)) {
-			$ArrayPath = substr($ArrayPath, 1);
-		}
+		$ArrayPath = ltrim($ArrayPath, $Separator);
 		if (($pos = strpos($ArrayPath, $Separator)) !== false) {
 			$ReturnedArray[substr($ArrayPath, 0, $pos)] = self::CreateDeepArray(substr($ArrayPath, $pos + 1), $Separator, $Value);
 		} else {
@@ -492,12 +673,18 @@ class getid3_lib
 		return $ReturnedArray;
 	}
 
+	/**
+	 * @param array $arraydata
+	 * @param bool  $returnkey
+	 *
+	 * @return int|false
+	 */
 	public static function array_max($arraydata, $returnkey=false) {
 		$maxvalue = false;
-		$maxkey = false;
+		$maxkey   = false;
 		foreach ($arraydata as $key => $value) {
 			if (!is_array($value)) {
-				if ($value > $maxvalue) {
+				if (($maxvalue === false) || ($value > $maxvalue)) {
 					$maxvalue = $value;
 					$maxkey = $key;
 				}
@@ -506,12 +693,18 @@ class getid3_lib
 		return ($returnkey ? $maxkey : $maxvalue);
 	}
 
+	/**
+	 * @param array $arraydata
+	 * @param bool  $returnkey
+	 *
+	 * @return int|false
+	 */
 	public static function array_min($arraydata, $returnkey=false) {
 		$minvalue = false;
-		$minkey = false;
+		$minkey   = false;
 		foreach ($arraydata as $key => $value) {
 			if (!is_array($value)) {
-				if ($value > $minvalue) {
+				if (($minvalue === false) || ($value < $minvalue)) {
 					$minvalue = $value;
 					$minkey = $key;
 				}
@@ -520,143 +713,117 @@ class getid3_lib
 		return ($returnkey ? $minkey : $minvalue);
 	}
 
+	/**
+	 * @param string $XMLstring
+	 *
+	 * @return array|false
+	 */
 	public static function XML2array($XMLstring) {
-		if (function_exists('simplexml_load_string')) {
-			if (function_exists('get_object_vars')) {
-				$XMLobject = simplexml_load_string($XMLstring);
-				return self::SimpleXMLelement2array($XMLobject);
-			}
+		if (function_exists('simplexml_load_string') && function_exists('libxml_disable_entity_loader')) {
+			// http://websec.io/2012/08/27/Preventing-XEE-in-PHP.html
+			// https://core.trac.wordpress.org/changeset/29378
+			$loader = libxml_disable_entity_loader(true);
+			$XMLobject = simplexml_load_string($XMLstring, 'SimpleXMLElement', LIBXML_NOENT);
+			$return = self::SimpleXMLelement2array($XMLobject);
+			libxml_disable_entity_loader($loader);
+			return $return;
 		}
 		return false;
 	}
 
+	/**
+	* @param SimpleXMLElement|array|mixed $XMLobject
+	*
+	* @return mixed
+	*/
 	public static function SimpleXMLelement2array($XMLobject) {
 		if (!is_object($XMLobject) && !is_array($XMLobject)) {
 			return $XMLobject;
 		}
-		$XMLarray = (is_object($XMLobject) ? get_object_vars($XMLobject) : $XMLobject);
+		$XMLarray = $XMLobject instanceof SimpleXMLElement ? get_object_vars($XMLobject) : $XMLobject;
 		foreach ($XMLarray as $key => $value) {
 			$XMLarray[$key] = self::SimpleXMLelement2array($value);
 		}
 		return $XMLarray;
 	}
 
-
-	// Allan Hansen <ahØartemis*dk>
-	// self::md5_data() - returns md5sum for a file from startuing position to absolute end position
+	/**
+	 * Returns checksum for a file from starting position to absolute end position.
+	 *
+	 * @param string $file
+	 * @param int    $offset
+	 * @param int    $end
+	 * @param string $algorithm
+	 *
+	 * @return string|false
+	 * @throws getid3_exception
+	 */
 	public static function hash_data($file, $offset, $end, $algorithm) {
-		static $tempdir = '';
 		if (!self::intValueSupported($end)) {
 			return false;
 		}
-		switch ($algorithm) {
-			case 'md5':
-				$hash_function = 'md5_file';
-				$unix_call     = 'md5sum';
-				$windows_call  = 'md5sum.exe';
-				$hash_length   = 32;
-				break;
-
-			case 'sha1':
-				$hash_function = 'sha1_file';
-				$unix_call     = 'sha1sum';
-				$windows_call  = 'sha1sum.exe';
-				$hash_length   = 40;
-				break;
-
-			default:
-				throw new Exception('Invalid algorithm ('.$algorithm.') in self::hash_data()');
-				break;
+		if (!in_array($algorithm, array('md5', 'sha1'))) {
+			throw new getid3_exception('Invalid algorithm ('.$algorithm.') in self::hash_data()');
 		}
+
 		$size = $end - $offset;
-		while (true) {
-			if (GETID3_OS_ISWINDOWS) {
 
-				// It seems that sha1sum.exe for Windows only works on physical files, does not accept piped data
-				// Fall back to create-temp-file method:
-				if ($algorithm == 'sha1') {
-					break;
-				}
-
-				$RequiredFiles = array('cygwin1.dll', 'head.exe', 'tail.exe', $windows_call);
-				foreach ($RequiredFiles as $required_file) {
-					if (!is_readable(GETID3_HELPERAPPSDIR.$required_file)) {
-						// helper apps not available - fall back to old method
-						break 2;
-					}
-				}
-				$commandline  = GETID3_HELPERAPPSDIR.'head.exe -c '.$end.' '.escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $file)).' | ';
-				$commandline .= GETID3_HELPERAPPSDIR.'tail.exe -c '.$size.' | ';
-				$commandline .= GETID3_HELPERAPPSDIR.$windows_call;
-
-			} else {
-
-				$commandline  = 'head -c'.$end.' '.escapeshellarg($file).' | ';
-				$commandline .= 'tail -c'.$size.' | ';
-				$commandline .= $unix_call;
-
-			}
-			if (preg_match('#(1|ON)#i', ini_get('safe_mode'))) {
-				//throw new Exception('PHP running in Safe Mode - backtick operator not available, using slower non-system-call '.$algorithm.' algorithm');
-				break;
-			}
-			return substr(`$commandline`, 0, $hash_length);
+		$fp = fopen($file, 'rb');
+		fseek($fp, $offset);
+		$ctx = hash_init($algorithm);
+		while ($size > 0) {
+			$buffer = fread($fp, min($size, getID3::FREAD_BUFFER_SIZE));
+			hash_update($ctx, $buffer);
+			$size -= getID3::FREAD_BUFFER_SIZE;
 		}
+		$hash = hash_final($ctx);
+		fclose($fp);
 
-		if (empty($tempdir)) {
-			// yes this is ugly, feel free to suggest a better way
-			require_once(dirname(__FILE__).'/getid3.php');
-			$getid3_temp = new getID3();
-			$tempdir = $getid3_temp->tempdir;
-			unset($getid3_temp);
-		}
-		// try to create a temporary file in the system temp directory - invalid dirname should force to system temp dir
-		if (($data_filename = tempnam($tempdir, 'gI3')) === false) {
-			// can't find anywhere to create a temp file, just fail
-			return false;
-		}
-
-		// Init
-		$result = false;
-
-		// copy parts of file
-		try {
-			self::CopyFileParts($file, $data_filename, $offset, $end - $offset);
-			$result = $hash_function($data_filename);
-		} catch (Exception $e) {
-			throw new Exception('self::CopyFileParts() failed in getid_lib::hash_data(): '.$e->getMessage());
-		}
-		unlink($data_filename);
-		return $result;
+		return $hash;
 	}
 
+	/**
+	 * @param string $filename_source
+	 * @param string $filename_dest
+	 * @param int    $offset
+	 * @param int    $length
+	 *
+	 * @return bool
+	 * @throws Exception
+	 *
+	 * @deprecated Unused, may be removed in future versions of getID3
+	 */
 	public static function CopyFileParts($filename_source, $filename_dest, $offset, $length) {
 		if (!self::intValueSupported($offset + $length)) {
 			throw new Exception('cannot copy file portion, it extends beyond the '.round(PHP_INT_MAX / 1073741824).'GB limit');
 		}
 		if (is_readable($filename_source) && is_file($filename_source) && ($fp_src = fopen($filename_source, 'rb'))) {
 			if (($fp_dest = fopen($filename_dest, 'wb'))) {
-				if (fseek($fp_src, $offset, SEEK_SET) == 0) {
+				if (fseek($fp_src, $offset) == 0) {
 					$byteslefttowrite = $length;
 					while (($byteslefttowrite > 0) && ($buffer = fread($fp_src, min($byteslefttowrite, getID3::FREAD_BUFFER_SIZE)))) {
 						$byteswritten = fwrite($fp_dest, $buffer, $byteslefttowrite);
 						$byteslefttowrite -= $byteswritten;
 					}
+					fclose($fp_dest);
 					return true;
 				} else {
+					fclose($fp_src);
 					throw new Exception('failed to seek to offset '.$offset.' in '.$filename_source);
 				}
-				fclose($fp_dest);
 			} else {
 				throw new Exception('failed to create file for writing '.$filename_dest);
 			}
-			fclose($fp_src);
 		} else {
 			throw new Exception('failed to open file for reading '.$filename_source);
 		}
-		return false;
 	}
 
+	/**
+	 * @param int $charval
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_int_utf8($charval) {
 		if ($charval < 128) {
 			// 0bbbbbbb
@@ -680,7 +847,14 @@ class getid3_lib
 		return $newcharstring;
 	}
 
-	// ISO-8859-1 => UTF-8
+	/**
+	 * ISO-8859-1 => UTF-8
+	 *
+	 * @param string $string
+	 * @param bool   $bom
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_iso88591_utf8($string, $bom=false) {
 		if (function_exists('utf8_encode')) {
 			return utf8_encode($string);
@@ -691,42 +865,68 @@ class getid3_lib
 			$newcharstring .= "\xEF\xBB\xBF";
 		}
 		for ($i = 0; $i < strlen($string); $i++) {
-			$charval = ord($string{$i});
+			$charval = ord($string[$i]);
 			$newcharstring .= self::iconv_fallback_int_utf8($charval);
 		}
 		return $newcharstring;
 	}
 
-	// ISO-8859-1 => UTF-16BE
+	/**
+	 * ISO-8859-1 => UTF-16BE
+	 *
+	 * @param string $string
+	 * @param bool   $bom
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_iso88591_utf16be($string, $bom=false) {
 		$newcharstring = '';
 		if ($bom) {
 			$newcharstring .= "\xFE\xFF";
 		}
 		for ($i = 0; $i < strlen($string); $i++) {
-			$newcharstring .= "\x00".$string{$i};
+			$newcharstring .= "\x00".$string[$i];
 		}
 		return $newcharstring;
 	}
 
-	// ISO-8859-1 => UTF-16LE
+	/**
+	 * ISO-8859-1 => UTF-16LE
+	 *
+	 * @param string $string
+	 * @param bool   $bom
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_iso88591_utf16le($string, $bom=false) {
 		$newcharstring = '';
 		if ($bom) {
 			$newcharstring .= "\xFF\xFE";
 		}
 		for ($i = 0; $i < strlen($string); $i++) {
-			$newcharstring .= $string{$i}."\x00";
+			$newcharstring .= $string[$i]."\x00";
 		}
 		return $newcharstring;
 	}
 
-	// ISO-8859-1 => UTF-16LE (BOM)
+	/**
+	 * ISO-8859-1 => UTF-16LE (BOM)
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_iso88591_utf16($string) {
 		return self::iconv_fallback_iso88591_utf16le($string, true);
 	}
 
-	// UTF-8 => ISO-8859-1
+	/**
+	 * UTF-8 => ISO-8859-1
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf8_iso88591($string) {
 		if (function_exists('utf8_decode')) {
 			return utf8_decode($string);
@@ -736,27 +936,27 @@ class getid3_lib
 		$offset = 0;
 		$stringlength = strlen($string);
 		while ($offset < $stringlength) {
-			if ((ord($string{$offset}) | 0x07) == 0xF7) {
+			if ((ord($string[$offset]) | 0x07) == 0xF7) {
 				// 11110bbb 10bbbbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x07) << 18) &
-						   ((ord($string{($offset + 1)}) & 0x3F) << 12) &
-						   ((ord($string{($offset + 2)}) & 0x3F) <<  6) &
-							(ord($string{($offset + 3)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x07) << 18) &
+						   ((ord($string[($offset + 1)]) & 0x3F) << 12) &
+						   ((ord($string[($offset + 2)]) & 0x3F) <<  6) &
+							(ord($string[($offset + 3)]) & 0x3F);
 				$offset += 4;
-			} elseif ((ord($string{$offset}) | 0x0F) == 0xEF) {
+			} elseif ((ord($string[$offset]) | 0x0F) == 0xEF) {
 				// 1110bbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x0F) << 12) &
-						   ((ord($string{($offset + 1)}) & 0x3F) <<  6) &
-							(ord($string{($offset + 2)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x0F) << 12) &
+						   ((ord($string[($offset + 1)]) & 0x3F) <<  6) &
+							(ord($string[($offset + 2)]) & 0x3F);
 				$offset += 3;
-			} elseif ((ord($string{$offset}) | 0x1F) == 0xDF) {
+			} elseif ((ord($string[$offset]) | 0x1F) == 0xDF) {
 				// 110bbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x1F) <<  6) &
-							(ord($string{($offset + 1)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x1F) <<  6) &
+							(ord($string[($offset + 1)]) & 0x3F);
 				$offset += 2;
-			} elseif ((ord($string{$offset}) | 0x7F) == 0x7F) {
+			} elseif ((ord($string[$offset]) | 0x7F) == 0x7F) {
 				// 0bbbbbbb
-				$charval = ord($string{$offset});
+				$charval = ord($string[$offset]);
 				$offset += 1;
 			} else {
 				// error? throw some kind of warning here?
@@ -770,7 +970,14 @@ class getid3_lib
 		return $newcharstring;
 	}
 
-	// UTF-8 => UTF-16BE
+	/**
+	 * UTF-8 => UTF-16BE
+	 *
+	 * @param string $string
+	 * @param bool   $bom
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf8_utf16be($string, $bom=false) {
 		$newcharstring = '';
 		if ($bom) {
@@ -779,27 +986,27 @@ class getid3_lib
 		$offset = 0;
 		$stringlength = strlen($string);
 		while ($offset < $stringlength) {
-			if ((ord($string{$offset}) | 0x07) == 0xF7) {
+			if ((ord($string[$offset]) | 0x07) == 0xF7) {
 				// 11110bbb 10bbbbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x07) << 18) &
-						   ((ord($string{($offset + 1)}) & 0x3F) << 12) &
-						   ((ord($string{($offset + 2)}) & 0x3F) <<  6) &
-							(ord($string{($offset + 3)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x07) << 18) &
+						   ((ord($string[($offset + 1)]) & 0x3F) << 12) &
+						   ((ord($string[($offset + 2)]) & 0x3F) <<  6) &
+							(ord($string[($offset + 3)]) & 0x3F);
 				$offset += 4;
-			} elseif ((ord($string{$offset}) | 0x0F) == 0xEF) {
+			} elseif ((ord($string[$offset]) | 0x0F) == 0xEF) {
 				// 1110bbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x0F) << 12) &
-						   ((ord($string{($offset + 1)}) & 0x3F) <<  6) &
-							(ord($string{($offset + 2)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x0F) << 12) &
+						   ((ord($string[($offset + 1)]) & 0x3F) <<  6) &
+							(ord($string[($offset + 2)]) & 0x3F);
 				$offset += 3;
-			} elseif ((ord($string{$offset}) | 0x1F) == 0xDF) {
+			} elseif ((ord($string[$offset]) | 0x1F) == 0xDF) {
 				// 110bbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x1F) <<  6) &
-							(ord($string{($offset + 1)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x1F) <<  6) &
+							(ord($string[($offset + 1)]) & 0x3F);
 				$offset += 2;
-			} elseif ((ord($string{$offset}) | 0x7F) == 0x7F) {
+			} elseif ((ord($string[$offset]) | 0x7F) == 0x7F) {
 				// 0bbbbbbb
-				$charval = ord($string{$offset});
+				$charval = ord($string[$offset]);
 				$offset += 1;
 			} else {
 				// error? throw some kind of warning here?
@@ -813,7 +1020,14 @@ class getid3_lib
 		return $newcharstring;
 	}
 
-	// UTF-8 => UTF-16LE
+	/**
+	 * UTF-8 => UTF-16LE
+	 *
+	 * @param string $string
+	 * @param bool   $bom
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf8_utf16le($string, $bom=false) {
 		$newcharstring = '';
 		if ($bom) {
@@ -822,27 +1036,27 @@ class getid3_lib
 		$offset = 0;
 		$stringlength = strlen($string);
 		while ($offset < $stringlength) {
-			if ((ord($string{$offset}) | 0x07) == 0xF7) {
+			if ((ord($string[$offset]) | 0x07) == 0xF7) {
 				// 11110bbb 10bbbbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x07) << 18) &
-						   ((ord($string{($offset + 1)}) & 0x3F) << 12) &
-						   ((ord($string{($offset + 2)}) & 0x3F) <<  6) &
-							(ord($string{($offset + 3)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x07) << 18) &
+						   ((ord($string[($offset + 1)]) & 0x3F) << 12) &
+						   ((ord($string[($offset + 2)]) & 0x3F) <<  6) &
+							(ord($string[($offset + 3)]) & 0x3F);
 				$offset += 4;
-			} elseif ((ord($string{$offset}) | 0x0F) == 0xEF) {
+			} elseif ((ord($string[$offset]) | 0x0F) == 0xEF) {
 				// 1110bbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x0F) << 12) &
-						   ((ord($string{($offset + 1)}) & 0x3F) <<  6) &
-							(ord($string{($offset + 2)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x0F) << 12) &
+						   ((ord($string[($offset + 1)]) & 0x3F) <<  6) &
+							(ord($string[($offset + 2)]) & 0x3F);
 				$offset += 3;
-			} elseif ((ord($string{$offset}) | 0x1F) == 0xDF) {
+			} elseif ((ord($string[$offset]) | 0x1F) == 0xDF) {
 				// 110bbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x1F) <<  6) &
-							(ord($string{($offset + 1)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x1F) <<  6) &
+							(ord($string[($offset + 1)]) & 0x3F);
 				$offset += 2;
-			} elseif ((ord($string{$offset}) | 0x7F) == 0x7F) {
+			} elseif ((ord($string[$offset]) | 0x7F) == 0x7F) {
 				// 0bbbbbbb
-				$charval = ord($string{$offset});
+				$charval = ord($string[$offset]);
 				$offset += 1;
 			} else {
 				// error? maybe throw some warning here?
@@ -856,12 +1070,24 @@ class getid3_lib
 		return $newcharstring;
 	}
 
-	// UTF-8 => UTF-16LE (BOM)
+	/**
+	 * UTF-8 => UTF-16LE (BOM)
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf8_utf16($string) {
 		return self::iconv_fallback_utf8_utf16le($string, true);
 	}
 
-	// UTF-16BE => UTF-8
+	/**
+	 * UTF-16BE => UTF-8
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf16be_utf8($string) {
 		if (substr($string, 0, 2) == "\xFE\xFF") {
 			// strip BOM
@@ -875,7 +1101,13 @@ class getid3_lib
 		return $newcharstring;
 	}
 
-	// UTF-16LE => UTF-8
+	/**
+	 * UTF-16LE => UTF-8
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf16le_utf8($string) {
 		if (substr($string, 0, 2) == "\xFF\xFE") {
 			// strip BOM
@@ -889,7 +1121,13 @@ class getid3_lib
 		return $newcharstring;
 	}
 
-	// UTF-16BE => ISO-8859-1
+	/**
+	 * UTF-16BE => ISO-8859-1
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf16be_iso88591($string) {
 		if (substr($string, 0, 2) == "\xFE\xFF") {
 			// strip BOM
@@ -903,7 +1141,13 @@ class getid3_lib
 		return $newcharstring;
 	}
 
-	// UTF-16LE => ISO-8859-1
+	/**
+	 * UTF-16LE => ISO-8859-1
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf16le_iso88591($string) {
 		if (substr($string, 0, 2) == "\xFF\xFE") {
 			// strip BOM
@@ -917,7 +1161,13 @@ class getid3_lib
 		return $newcharstring;
 	}
 
-	// UTF-16 (BOM) => ISO-8859-1
+	/**
+	 * UTF-16 (BOM) => ISO-8859-1
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf16_iso88591($string) {
 		$bom = substr($string, 0, 2);
 		if ($bom == "\xFE\xFF") {
@@ -928,7 +1178,13 @@ class getid3_lib
 		return $string;
 	}
 
-	// UTF-16 (BOM) => UTF-8
+	/**
+	 * UTF-16 (BOM) => UTF-8
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function iconv_fallback_utf16_utf8($string) {
 		$bom = substr($string, 0, 2);
 		if ($bom == "\xFE\xFF") {
@@ -939,14 +1195,44 @@ class getid3_lib
 		return $string;
 	}
 
+	/**
+	 * @param string $in_charset
+	 * @param string $out_charset
+	 * @param string $string
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
 	public static function iconv_fallback($in_charset, $out_charset, $string) {
 
 		if ($in_charset == $out_charset) {
 			return $string;
 		}
 
-		// iconv() availble
-		if (function_exists('iconv')) {
+		// mb_convert_encoding() available
+		if (function_exists('mb_convert_encoding')) {
+			if ((strtoupper($in_charset) == 'UTF-16') && (substr($string, 0, 2) != "\xFE\xFF") && (substr($string, 0, 2) != "\xFF\xFE")) {
+				// if BOM missing, mb_convert_encoding will mishandle the conversion, assume UTF-16BE and prepend appropriate BOM
+				$string = "\xFF\xFE".$string;
+			}
+			if ((strtoupper($in_charset) == 'UTF-16') && (strtoupper($out_charset) == 'UTF-8')) {
+				if (($string == "\xFF\xFE") || ($string == "\xFE\xFF")) {
+					// if string consists of only BOM, mb_convert_encoding will return the BOM unmodified
+					return '';
+				}
+			}
+			if ($converted_string = @mb_convert_encoding($string, $out_charset, $in_charset)) {
+				switch ($out_charset) {
+					case 'ISO-8859-1':
+						$converted_string = rtrim($converted_string, "\x00");
+						break;
+				}
+				return $converted_string;
+			}
+			return $string;
+
+		// iconv() available
+		} elseif (function_exists('iconv')) {
 			if ($converted_string = @iconv($in_charset, $out_charset.'//TRANSLIT', $string)) {
 				switch ($out_charset) {
 					case 'ISO-8859-1':
@@ -962,7 +1248,7 @@ class getid3_lib
 		}
 
 
-		// iconv() not available
+		// neither mb_convert_encoding or iconv() is available
 		static $ConversionFunctionList = array();
 		if (empty($ConversionFunctionList)) {
 			$ConversionFunctionList['ISO-8859-1']['UTF-8']    = 'iconv_fallback_iso88591_utf8';
@@ -984,64 +1270,89 @@ class getid3_lib
 			$ConversionFunction = $ConversionFunctionList[strtoupper($in_charset)][strtoupper($out_charset)];
 			return self::$ConversionFunction($string);
 		}
-		throw new Exception('PHP does not have iconv() support - cannot convert from '.$in_charset.' to '.$out_charset);
+		throw new Exception('PHP does not has mb_convert_encoding() or iconv() support - cannot convert from '.$in_charset.' to '.$out_charset);
 	}
 
+	/**
+	 * @param mixed  $data
+	 * @param string $charset
+	 *
+	 * @return mixed
+	 */
+	public static function recursiveMultiByteCharString2HTML($data, $charset='ISO-8859-1') {
+		if (is_string($data)) {
+			return self::MultiByteCharString2HTML($data, $charset);
+		} elseif (is_array($data)) {
+			$return_data = array();
+			foreach ($data as $key => $value) {
+				$return_data[$key] = self::recursiveMultiByteCharString2HTML($value, $charset);
+			}
+			return $return_data;
+		}
+		// integer, float, objects, resources, etc
+		return $data;
+	}
 
+	/**
+	 * @param string|int|float $string
+	 * @param string           $charset
+	 *
+	 * @return string
+	 */
 	public static function MultiByteCharString2HTML($string, $charset='ISO-8859-1') {
 		$string = (string) $string; // in case trying to pass a numeric (float, int) string, would otherwise return an empty string
 		$HTMLstring = '';
 
-		switch ($charset) {
+		switch (strtolower($charset)) {
 			case '1251':
 			case '1252':
 			case '866':
 			case '932':
 			case '936':
 			case '950':
-			case 'BIG5':
-			case 'BIG5-HKSCS':
+			case 'big5':
+			case 'big5-hkscs':
 			case 'cp1251':
 			case 'cp1252':
 			case 'cp866':
-			case 'EUC-JP':
-			case 'EUCJP':
-			case 'GB2312':
+			case 'euc-jp':
+			case 'eucjp':
+			case 'gb2312':
 			case 'ibm866':
-			case 'ISO-8859-1':
-			case 'ISO-8859-15':
-			case 'ISO8859-1':
-			case 'ISO8859-15':
-			case 'KOI8-R':
+			case 'iso-8859-1':
+			case 'iso-8859-15':
+			case 'iso8859-1':
+			case 'iso8859-15':
+			case 'koi8-r':
 			case 'koi8-ru':
 			case 'koi8r':
-			case 'Shift_JIS':
-			case 'SJIS':
+			case 'shift_jis':
+			case 'sjis':
 			case 'win-1251':
-			case 'Windows-1251':
-			case 'Windows-1252':
+			case 'windows-1251':
+			case 'windows-1252':
 				$HTMLstring = htmlentities($string, ENT_COMPAT, $charset);
 				break;
 
-			case 'UTF-8':
+			case 'utf-8':
 				$strlen = strlen($string);
 				for ($i = 0; $i < $strlen; $i++) {
-					$char_ord_val = ord($string{$i});
+					$char_ord_val = ord($string[$i]);
 					$charval = 0;
 					if ($char_ord_val < 0x80) {
 						$charval = $char_ord_val;
 					} elseif ((($char_ord_val & 0xF0) >> 4) == 0x0F  &&  $i+3 < $strlen) {
 						$charval  = (($char_ord_val & 0x07) << 18);
-						$charval += ((ord($string{++$i}) & 0x3F) << 12);
-						$charval += ((ord($string{++$i}) & 0x3F) << 6);
-						$charval +=  (ord($string{++$i}) & 0x3F);
+						$charval += ((ord($string[++$i]) & 0x3F) << 12);
+						$charval += ((ord($string[++$i]) & 0x3F) << 6);
+						$charval +=  (ord($string[++$i]) & 0x3F);
 					} elseif ((($char_ord_val & 0xE0) >> 5) == 0x07  &&  $i+2 < $strlen) {
 						$charval  = (($char_ord_val & 0x0F) << 12);
-						$charval += ((ord($string{++$i}) & 0x3F) << 6);
-						$charval +=  (ord($string{++$i}) & 0x3F);
+						$charval += ((ord($string[++$i]) & 0x3F) << 6);
+						$charval +=  (ord($string[++$i]) & 0x3F);
 					} elseif ((($char_ord_val & 0xC0) >> 6) == 0x03  &&  $i+1 < $strlen) {
 						$charval  = (($char_ord_val & 0x1F) << 6);
-						$charval += (ord($string{++$i}) & 0x3F);
+						$charval += (ord($string[++$i]) & 0x3F);
 					}
 					if (($charval >= 32) && ($charval <= 127)) {
 						$HTMLstring .= htmlentities(chr($charval));
@@ -1051,7 +1362,7 @@ class getid3_lib
 				}
 				break;
 
-			case 'UTF-16LE':
+			case 'utf-16le':
 				for ($i = 0; $i < strlen($string); $i += 2) {
 					$charval = self::LittleEndian2Int(substr($string, $i, 2));
 					if (($charval >= 32) && ($charval <= 127)) {
@@ -1062,7 +1373,7 @@ class getid3_lib
 				}
 				break;
 
-			case 'UTF-16BE':
+			case 'utf-16be':
 				for ($i = 0; $i < strlen($string); $i += 2) {
 					$charval = self::BigEndian2Int(substr($string, $i, 2));
 					if (($charval >= 32) && ($charval <= 127)) {
@@ -1080,8 +1391,11 @@ class getid3_lib
 		return $HTMLstring;
 	}
 
-
-
+	/**
+	 * @param int $namecode
+	 *
+	 * @return string
+	 */
 	public static function RGADnameLookup($namecode) {
 		static $RGADname = array();
 		if (empty($RGADname)) {
@@ -1093,7 +1407,11 @@ class getid3_lib
 		return (isset($RGADname[$namecode]) ? $RGADname[$namecode] : '');
 	}
 
-
+	/**
+	 * @param int $originatorcode
+	 *
+	 * @return string
+	 */
 	public static function RGADoriginatorLookup($originatorcode) {
 		static $RGADoriginator = array();
 		if (empty($RGADoriginator)) {
@@ -1106,16 +1424,27 @@ class getid3_lib
 		return (isset($RGADoriginator[$originatorcode]) ? $RGADoriginator[$originatorcode] : '');
 	}
 
-
+	/**
+	 * @param int $rawadjustment
+	 * @param int $signbit
+	 *
+	 * @return float
+	 */
 	public static function RGADadjustmentLookup($rawadjustment, $signbit) {
-		$adjustment = $rawadjustment / 10;
+		$adjustment = (float) $rawadjustment / 10;
 		if ($signbit == 1) {
 			$adjustment *= -1;
 		}
-		return (float) $adjustment;
+		return $adjustment;
 	}
 
-
+	/**
+	 * @param int $namecode
+	 * @param int $originatorcode
+	 * @param int $replaygain
+	 *
+	 * @return string
+	 */
 	public static function RGADgainString($namecode, $originatorcode, $replaygain) {
 		if ($replaygain < 0) {
 			$signbit = '1';
@@ -1131,62 +1460,89 @@ class getid3_lib
 		return $gainstring;
 	}
 
+	/**
+	 * @param float $amplitude
+	 *
+	 * @return float
+	 */
 	public static function RGADamplitude2dB($amplitude) {
 		return 20 * log10($amplitude);
 	}
 
-
+	/**
+	 * @param string $imgData
+	 * @param array  $imageinfo
+	 *
+	 * @return array|false
+	 */
 	public static function GetDataImageSize($imgData, &$imageinfo=array()) {
+		if (PHP_VERSION_ID >= 50400) {
+			$GetDataImageSize = @getimagesizefromstring($imgData, $imageinfo);
+			if ($GetDataImageSize === false || !isset($GetDataImageSize[0], $GetDataImageSize[1])) {
+				return false;
+			}
+			$GetDataImageSize['height'] = $GetDataImageSize[0];
+			$GetDataImageSize['width'] = $GetDataImageSize[1];
+			return $GetDataImageSize;
+		}
 		static $tempdir = '';
 		if (empty($tempdir)) {
+			if (function_exists('sys_get_temp_dir')) {
+				$tempdir = sys_get_temp_dir(); // https://github.com/JamesHeinrich/getID3/issues/52
+			}
+
 			// yes this is ugly, feel free to suggest a better way
-			require_once(dirname(__FILE__).'/getid3.php');
-			$getid3_temp = new getID3();
-			$tempdir = $getid3_temp->tempdir;
-			unset($getid3_temp);
+			if (include_once(dirname(__FILE__).'/getid3.php')) {
+				$getid3_temp = new getID3();
+				if ($getid3_temp_tempdir = $getid3_temp->tempdir) {
+					$tempdir = $getid3_temp_tempdir;
+				}
+				unset($getid3_temp, $getid3_temp_tempdir);
+			}
 		}
 		$GetDataImageSize = false;
 		if ($tempfilename = tempnam($tempdir, 'gI3')) {
 			if (is_writable($tempfilename) && is_file($tempfilename) && ($tmp = fopen($tempfilename, 'wb'))) {
 				fwrite($tmp, $imgData);
 				fclose($tmp);
-				$GetDataImageSize = @GetImageSize($tempfilename, $imageinfo);
+				$GetDataImageSize = @getimagesize($tempfilename, $imageinfo);
+				if (($GetDataImageSize === false) || !isset($GetDataImageSize[0]) || !isset($GetDataImageSize[1])) {
+					return false;
+				}
+				$GetDataImageSize['height'] = $GetDataImageSize[0];
+				$GetDataImageSize['width']  = $GetDataImageSize[1];
 			}
 			unlink($tempfilename);
 		}
 		return $GetDataImageSize;
 	}
 
+	/**
+	 * @param string $mime_type
+	 *
+	 * @return string
+	 */
 	public static function ImageExtFromMime($mime_type) {
 		// temporary way, works OK for now, but should be reworked in the future
 		return str_replace(array('image/', 'x-', 'jpeg'), array('', '', 'jpg'), $mime_type);
 	}
 
-	public static function ImageTypesLookup($imagetypeid) {
-		static $ImageTypesLookup = array();
-		if (empty($ImageTypesLookup)) {
-			$ImageTypesLookup[1]  = 'gif';
-			$ImageTypesLookup[2]  = 'jpeg';
-			$ImageTypesLookup[3]  = 'png';
-			$ImageTypesLookup[4]  = 'swf';
-			$ImageTypesLookup[5]  = 'psd';
-			$ImageTypesLookup[6]  = 'bmp';
-			$ImageTypesLookup[7]  = 'tiff (little-endian)';
-			$ImageTypesLookup[8]  = 'tiff (big-endian)';
-			$ImageTypesLookup[9]  = 'jpc';
-			$ImageTypesLookup[10] = 'jp2';
-			$ImageTypesLookup[11] = 'jpx';
-			$ImageTypesLookup[12] = 'jb2';
-			$ImageTypesLookup[13] = 'swc';
-			$ImageTypesLookup[14] = 'iff';
-		}
-		return (isset($ImageTypesLookup[$imagetypeid]) ? $ImageTypesLookup[$imagetypeid] : '');
-	}
-
-	public static function CopyTagsToComments(&$ThisFileInfo) {
-
+	/**
+	 * @param array $ThisFileInfo
+	 * @param bool  $option_tags_html default true (just as in the main getID3 class)
+	 *
+	 * @return bool
+	 */
+	public static function CopyTagsToComments(&$ThisFileInfo, $option_tags_html=true) {
 		// Copy all entries from ['tags'] into common ['comments']
 		if (!empty($ThisFileInfo['tags'])) {
+			if (isset($ThisFileInfo['tags']['id3v1'])) {
+				// bubble ID3v1 to the end, if present to aid in detecting bad ID3v1 encodings
+				$ID3v1 = $ThisFileInfo['tags']['id3v1'];
+				unset($ThisFileInfo['tags']['id3v1']);
+				$ThisFileInfo['tags']['id3v1'] = $ID3v1;
+				unset($ID3v1);
+			}
 			foreach ($ThisFileInfo['tags'] as $tagtype => $tagarray) {
 				foreach ($tagarray as $tagname => $tagdata) {
 					foreach ($tagdata as $key => $value) {
@@ -1205,48 +1561,88 @@ class getid3_lib
 										break 2;
 									}
 								}
+								if (function_exists('mb_convert_encoding')) {
+									if (trim($value) == trim(substr(mb_convert_encoding($existingvalue, $ThisFileInfo['id3v1']['encoding'], $ThisFileInfo['encoding']), 0, 30))) {
+										// value stored in ID3v1 appears to be probably the multibyte value transliterated (badly) into ISO-8859-1 in ID3v1.
+										// As an example, Foobar2000 will do this if you tag a file with Chinese or Arabic or Cyrillic or something that doesn't fit into ISO-8859-1 the ID3v1 will consist of mostly "?" characters, one per multibyte unrepresentable character
+										break 2;
+									}
+								}
 
 							} elseif (!is_array($value)) {
 
 								$newvaluelength = strlen(trim($value));
 								foreach ($ThisFileInfo['comments'][$tagname] as $existingkey => $existingvalue) {
 									$oldvaluelength = strlen(trim($existingvalue));
-									if (($newvaluelength > $oldvaluelength) && (substr(trim($value), 0, strlen($existingvalue)) == $existingvalue)) {
+									if ((strlen($existingvalue) > 10) && ($newvaluelength > $oldvaluelength) && (substr(trim($value), 0, strlen($existingvalue)) == $existingvalue)) {
 										$ThisFileInfo['comments'][$tagname][$existingkey] = trim($value);
-										break 2;
+										break;
 									}
 								}
 
 							}
 							if (is_array($value) || empty($ThisFileInfo['comments'][$tagname]) || !in_array(trim($value), $ThisFileInfo['comments'][$tagname])) {
 								$value = (is_string($value) ? trim($value) : $value);
-								$ThisFileInfo['comments'][$tagname][] = $value;
+								if (!is_int($key) && !ctype_digit($key)) {
+									$ThisFileInfo['comments'][$tagname][$key] = $value;
+								} else {
+									if (!isset($ThisFileInfo['comments'][$tagname])) {
+										$ThisFileInfo['comments'][$tagname] = array($value);
+									} else {
+										$ThisFileInfo['comments'][$tagname][] = $value;
+									}
+								}
 							}
 						}
 					}
 				}
 			}
 
-			// Copy to ['comments_html']
-			foreach ($ThisFileInfo['comments'] as $field => $values) {
-				if ($field == 'picture') {
-					// pictures can take up a lot of space, and we don't need multiple copies of them
-					// let there be a single copy in [comments][picture], and not elsewhere
-					continue;
+			// attempt to standardize spelling of returned keys
+			$StandardizeFieldNames = array(
+				'tracknumber' => 'track_number',
+				'track'       => 'track_number',
+			);
+			foreach ($StandardizeFieldNames as $badkey => $goodkey) {
+				if (array_key_exists($badkey, $ThisFileInfo['comments']) && !array_key_exists($goodkey, $ThisFileInfo['comments'])) {
+					$ThisFileInfo['comments'][$goodkey] = $ThisFileInfo['comments'][$badkey];
+					unset($ThisFileInfo['comments'][$badkey]);
 				}
-				foreach ($values as $index => $value) {
-					if (is_array($value)) {
-						$ThisFileInfo['comments_html'][$field][$index] = $value;
-					} else {
-						$ThisFileInfo['comments_html'][$field][$index] = str_replace('&#0;', '', self::MultiByteCharString2HTML($value, $ThisFileInfo['encoding']));
+			}
+
+			if ($option_tags_html) {
+				// Copy ['comments'] to ['comments_html']
+				if (!empty($ThisFileInfo['comments'])) {
+					foreach ($ThisFileInfo['comments'] as $field => $values) {
+						if ($field == 'picture') {
+							// pictures can take up a lot of space, and we don't need multiple copies of them
+							// let there be a single copy in [comments][picture], and not elsewhere
+							continue;
+						}
+						foreach ($values as $index => $value) {
+							if (is_array($value)) {
+								$ThisFileInfo['comments_html'][$field][$index] = $value;
+							} else {
+								$ThisFileInfo['comments_html'][$field][$index] = str_replace('&#0;', '', self::MultiByteCharString2HTML($value, $ThisFileInfo['encoding']));
+							}
+						}
 					}
 				}
 			}
+
 		}
 		return true;
 	}
 
-
+	/**
+	 * @param string $key
+	 * @param int    $begin
+	 * @param int    $end
+	 * @param string $file
+	 * @param string $name
+	 *
+	 * @return string
+	 */
 	public static function EmbeddedLookup($key, $begin, $end, $file, $name) {
 
 		// Cached
@@ -1293,6 +1689,14 @@ class getid3_lib
 		return (isset($cache[$file][$name][$key]) ? $cache[$file][$name][$key] : '');
 	}
 
+	/**
+	 * @param string $filename
+	 * @param string $sourcefile
+	 * @param bool   $DieOnFailure
+	 *
+	 * @return bool
+	 * @throws Exception
+	 */
 	public static function IncludeDependency($filename, $sourcefile, $DieOnFailure=false) {
 		global $GETID3_ERRORARRAY;
 
@@ -1313,8 +1717,85 @@ class getid3_lib
 		return false;
 	}
 
+	/**
+	 * @param string $string
+	 *
+	 * @return string
+	 */
 	public static function trimNullByte($string) {
 		return trim($string, "\x00");
+	}
+
+	/**
+	 * @param string $path
+	 *
+	 * @return float|bool
+	 */
+	public static function getFileSizeSyscall($path) {
+		$filesize = false;
+
+		if (GETID3_OS_ISWINDOWS) {
+			if (class_exists('COM')) { // From PHP 5.3.15 and 5.4.5, COM and DOTNET is no longer built into the php core.you have to add COM support in php.ini:
+				$filesystem = new COM('Scripting.FileSystemObject');
+				$file = $filesystem->GetFile($path);
+				$filesize = $file->Size();
+				unset($filesystem, $file);
+			} else {
+				$commandline = 'for %I in ('.escapeshellarg($path).') do @echo %~zI';
+			}
+		} else {
+			$commandline = 'ls -l '.escapeshellarg($path).' | awk \'{print $5}\'';
+		}
+		if (isset($commandline)) {
+			$output = trim(`$commandline`);
+			if (ctype_digit($output)) {
+				$filesize = (float) $output;
+			}
+		}
+		return $filesize;
+	}
+
+	/**
+	 * @param string $filename
+	 *
+	 * @return string|false
+	 */
+	public static function truepath($filename) {
+		// 2017-11-08: this could use some improvement, patches welcome
+		if (preg_match('#^(\\\\\\\\|//)[a-z0-9]#i', $filename, $matches)) {
+			// PHP's built-in realpath function does not work on UNC Windows shares
+			$goodpath = array();
+			foreach (explode('/', str_replace('\\', '/', $filename)) as $part) {
+				if ($part == '.') {
+					continue;
+				}
+				if ($part == '..') {
+					if (count($goodpath)) {
+						array_pop($goodpath);
+					} else {
+						// cannot step above this level, already at top level
+						return false;
+					}
+				} else {
+					$goodpath[] = $part;
+				}
+			}
+			return implode(DIRECTORY_SEPARATOR, $goodpath);
+		}
+		return realpath($filename);
+	}
+
+	/**
+	 * Workaround for Bug #37268 (https://bugs.php.net/bug.php?id=37268)
+	 *
+	 * @param string $path A path.
+	 * @param string $suffix If the name component ends in suffix this will also be cut off.
+	 *
+	 * @return string
+	 */
+	public static function mb_basename($path, $suffix = null) {
+		$splited = preg_split('#/#', rtrim($path, '/ '));
+		return substr(basename('X'.$splited[count($splited) - 1], $suffix), 1);
 	}
 
 }

--- a/application/libraries/getid3/module.archive.gzip.php
+++ b/application/libraries/getid3/module.archive.gzip.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.archive.gzip.php                                     //
@@ -14,16 +15,28 @@
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // Module originally written by                                //
-//      Mike Mozolin <teddybearØmail*ru>                       //
+//      Mike Mozolin <teddybearÃ˜mail*ru>                       //
 //                                                             //
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
-class getid3_gzip extends getid3_handler {
+class getid3_gzip extends getid3_handler
+{
+	/**
+	 * Optional file list - disable for speed.
+	 *
+	 * Decode gzipped files, if possible, and parse recursively (.tar.gz for example).
+	 *
+	 * @var bool
+	 */
+	public $option_gzip_parse_contents = false;
 
-	// public: Optional file list - disable for speed.
-	public $option_gzip_parse_contents = false; // decode gzipped files, if possible, and parse recursively (.tar.gz for example)
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -35,14 +48,15 @@ class getid3_gzip extends getid3_handler {
 		//|ID1|ID2|CM |FLG|     MTIME     |XFL|OS |
 		//+---+---+---+---+---+---+---+---+---+---+
 
-		if ($info['filesize'] > $info['php_memory_limit']) {
-			$info['error'][] = 'File is too large ('.number_format($info['filesize']).' bytes) to read into memory (limit: '.number_format($info['php_memory_limit'] / 1048576).'MB)';
+		if ($info['php_memory_limit'] && ($info['filesize'] > $info['php_memory_limit'])) {
+			$this->error('File is too large ('.number_format($info['filesize']).' bytes) to read into memory (limit: '.number_format($info['php_memory_limit'] / 1048576).'MB)');
 			return false;
 		}
-		fseek($this->getid3->fp, 0);
-		$buffer = fread($this->getid3->fp, $info['filesize']);
+		$this->fseek(0);
+		$buffer = $this->fread($info['filesize']);
 
 		$arr_members = explode("\x1F\x8B\x08", $buffer);
+		$num_members = 0;
 		while (true) {
 			$is_wrong_members = false;
 			$num_members = intval(count($arr_members));
@@ -55,7 +69,7 @@ class getid3_gzip extends getid3_handler {
 				$attr = unpack($unpack_header, substr($buf, 0, $start_length));
 				if (!$this->get_os_type(ord($attr['os']))) {
 					// Merge member with previous if wrong OS type
-					$arr_members[$i - 1] .= $buf;
+					$arr_members[($i - 1)] .= $buf;
 					$arr_members[$i] = '';
 					$is_wrong_members = true;
 					continue;
@@ -96,7 +110,7 @@ class getid3_gzip extends getid3_handler {
 
 			$thisInfo['os'] = $this->get_os_type($thisInfo['raw']['os']);
 			if (!$thisInfo['os']) {
-				$info['error'][] = 'Read error on gzip file';
+				$this->error('Read error on gzip file');
 				return false;
 			}
 
@@ -140,8 +154,9 @@ class getid3_gzip extends getid3_handler {
 			//|...original file name, zero-terminated...|
 			//+=========================================+
 			// GZIP files may have only one file, with no filename, so assume original filename is current filename without .gz
-			$thisInfo['filename'] = preg_replace('#\.gz$#i', '', $info['filename']);
+			$thisInfo['filename'] = preg_replace('#\\.gz$#i', '', $info['filename']);
 			if ($thisInfo['flags']['filename']) {
+				$thisInfo['filename'] = '';
 				while (true) {
 					if (ord($buff[$fpointer]) == 0) {
 						$fpointer++;
@@ -197,7 +212,7 @@ class getid3_gzip extends getid3_handler {
 					$inflated = gzinflate($cdata);
 
 					// Calculate CRC32 for inflated content
-					$thisInfo['crc32_valid'] = (bool) (sprintf('%u', crc32($inflated)) == $thisInfo['crc32']);
+					$thisInfo['crc32_valid'] = sprintf('%u', crc32($inflated)) == $thisInfo['crc32'];
 
 					// determine format
 					$formattest = substr($inflated, 0, 32774);
@@ -213,7 +228,7 @@ class getid3_gzip extends getid3_handler {
 							if (file_exists(GETID3_INCLUDEPATH.$determined_format['include']) && include_once(GETID3_INCLUDEPATH.$determined_format['include'])) {
 								if (($temp_tar_filename = tempnam(GETID3_TEMP_DIR, 'getID3')) === false) {
 									// can't find anywhere to create a temp file, abort
-									$info['error'][] = 'Unable to create temp file to parse TAR inside GZIP file';
+									$this->error('Unable to create temp file to parse TAR inside GZIP file');
 									break;
 								}
 								if ($fp_temp_tar = fopen($temp_tar_filename, 'w+b')) {
@@ -227,7 +242,7 @@ class getid3_gzip extends getid3_handler {
 									unset($getid3_temp, $getid3_tar);
 									unlink($temp_tar_filename);
 								} else {
-									$info['error'][] = 'Unable to fopen() temp file to parse TAR inside GZIP file';
+									$this->error('Unable to fopen() temp file to parse TAR inside GZIP file');
 									break;
 								}
 							}
@@ -238,13 +253,21 @@ class getid3_gzip extends getid3_handler {
 							// unknown or unhandled format
 							break;
 					}
+				} else {
+					$this->warning('PHP is not compiled with gzinflate() support. Please enable PHP Zlib extension or recompile with the --with-zlib switch');
 				}
 			}
 		}
 		return true;
 	}
 
-	// Converts the OS type
+	/**
+	 * Converts the OS type.
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 */
 	public function get_os_type($key) {
 		static $os_type = array(
 			'0'   => 'FAT filesystem (MS-DOS, OS/2, NT/Win32)',
@@ -266,7 +289,13 @@ class getid3_gzip extends getid3_handler {
 		return (isset($os_type[$key]) ? $os_type[$key] : '');
 	}
 
-	// Converts the eXtra FLags
+	/**
+	 * Converts the eXtra FLags.
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 */
 	public function get_xflag_type($key) {
 		static $xflag_type = array(
 			'0' => 'unknown',

--- a/application/libraries/getid3/module.archive.hpk.php
+++ b/application/libraries/getid3/module.archive.hpk.php
@@ -1,0 +1,92 @@
+<?php
+
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// module.archive.hpk.php                                      //
+// module for analyzing HPK files                              //
+// dependencies: NONE                                          //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+
+class getid3_hpk extends getid3_handler
+{
+	/**
+	 * @return bool
+	 */
+	public function Analyze() {
+		$info = &$this->getid3->info;
+
+		$info['fileformat'] = 'hpk';
+
+		$this->fseek($info['avdataoffset']);
+		$HPKheader = $this->fread(36);
+
+		if (substr($HPKheader, 0, 4) == 'BPUL') {
+
+			$info['hpk']['header']['signature']                    =                              substr($HPKheader,  0, 4);
+			$info['hpk']['header']['data_offset']                  = getid3_lib::LittleEndian2Int(substr($HPKheader,  4, 4));
+			$info['hpk']['header']['fragments_per_file']           = getid3_lib::LittleEndian2Int(substr($HPKheader,  8, 4));
+			//$info['hpk']['header']['unknown1']                     = getid3_lib::LittleEndian2Int(substr($HPKheader, 12, 4));
+			$info['hpk']['header']['fragments_residual_offset']    = getid3_lib::LittleEndian2Int(substr($HPKheader, 16, 4));
+			$info['hpk']['header']['fragments_residual_count']     = getid3_lib::LittleEndian2Int(substr($HPKheader, 20, 4));
+			//$info['hpk']['header']['unknown2']                     = getid3_lib::LittleEndian2Int(substr($HPKheader, 24, 4));
+			$info['hpk']['header']['fragmented_filesystem_offset'] = getid3_lib::LittleEndian2Int(substr($HPKheader, 28, 4));
+			$info['hpk']['header']['fragmented_filesystem_length'] = getid3_lib::LittleEndian2Int(substr($HPKheader, 32, 4));
+
+			$info['hpk']['header']['filesystem_entries'] = $info['hpk']['header']['fragmented_filesystem_length'] / ($info['hpk']['header']['fragments_per_file'] * 8);
+			$this->fseek($info['hpk']['header']['fragmented_filesystem_offset']);
+			for ($i = 0; $i < $info['hpk']['header']['filesystem_entries']; $i++) {
+				$offset = getid3_lib::LittleEndian2Int($this->fread(4));
+				$length = getid3_lib::LittleEndian2Int($this->fread(4));
+				$info['hpk']['filesystem'][$i] = array('offset' => $offset, 'length' => $length);
+			}
+
+$this->error('HPK parsing incomplete (and mostly broken) in this version of getID3() ['.$this->getid3->version().']');
+
+/*
+			$filename = '';
+			$dirs = array();
+			foreach ($info['hpk']['filesystem'] as $key => $filesystemdata) {
+				$this->fseek($filesystemdata['offset']);
+				$first4 = $this->fread(4);
+				if (($first4 == 'LZ4 ') || ($first4 == 'ZLIB')) {
+					// actual data, ignore
+					$info['hpk']['toc'][$key] = array(
+						'filename' => ltrim(implode('/', $dirs).'/'.$filename, '/'),
+						'offset'   => $filesystemdata['offset'],
+						'length'   => $filesystemdata['length'],
+					);
+					$filename = '';
+					$dirs = array();
+				} else {
+					$fragment_index = getid3_lib::LittleEndian2Int($first4);
+					$fragment_type  = getid3_lib::LittleEndian2Int($this->fread(4)); // file = 0, directory = 1
+					$name_length    = getid3_lib::LittleEndian2Int($this->fread(2));
+					if ($fragment_type == 1) {
+						$dirs[]   = $this->fread($name_length);
+					} else {
+						$filename = $this->fread($name_length);
+					}
+				}
+			}
+*/
+
+		} else {
+			$this->error('Expecting "BPUL" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($HPKheader, 0, 4)).'"');
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/application/libraries/getid3/module.archive.rar.php
+++ b/application/libraries/getid3/module.archive.rar.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.archive.rar.php                                      //
@@ -13,12 +14,20 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_rar extends getid3_handler
 {
-
+	/**
+	 * @var bool
+	 */
 	public $option_use_rar_extension = false;
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -35,13 +44,13 @@ class getid3_rar extends getid3_handler
 					rar_close($rp);
 					return true;
 				} else {
-					$info['error'][] = 'failed to rar_open('.$info['filename'].')';
+					$this->error('failed to rar_open('.$info['filename'].')');
 				}
 			} else {
-				$info['error'][] = 'RAR support does not appear to be available in this PHP installation';
+				$this->error('RAR support does not appear to be available in this PHP installation');
 			}
 		} else {
-			$info['error'][] = 'PHP-RAR processing has been disabled (set $getid3_rar->option_use_rar_extension=true to enable)';
+			$this->error('PHP-RAR processing has been disabled (set $getid3_rar->option_use_rar_extension=true to enable)');
 		}
 		return false;
 

--- a/application/libraries/getid3/module.archive.szip.php
+++ b/application/libraries/getid3/module.archive.szip.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.archive.szip.php                                     //
@@ -13,36 +14,43 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_szip extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$SZIPHeader = fread($this->getid3->fp, 6);
+		$this->fseek($info['avdataoffset']);
+		$SZIPHeader = $this->fread(6);
 		if (substr($SZIPHeader, 0, 4) != "SZ\x0A\x04") {
-			$info['error'][] = 'Expecting "53 5A 0A 04" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($SZIPHeader, 0, 4)).'"';
+			$this->error('Expecting "53 5A 0A 04" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($SZIPHeader, 0, 4)).'"');
 			return false;
 		}
 		$info['fileformat']            = 'szip';
 		$info['szip']['major_version'] = getid3_lib::BigEndian2Int(substr($SZIPHeader, 4, 1));
 		$info['szip']['minor_version'] = getid3_lib::BigEndian2Int(substr($SZIPHeader, 5, 1));
+		$this->error('SZIP parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
+		return false;
 
-		while (!feof($this->getid3->fp)) {
-			$NextBlockID = fread($this->getid3->fp, 2);
+		while (!$this->feof()) {
+			$NextBlockID = $this->fread(2);
 			switch ($NextBlockID) {
 				case 'SZ':
 					// Note that szip files can be concatenated, this has the same effect as
 					// concatenating the files. this also means that global header blocks
 					// might be present between directory/data blocks.
-					fseek($this->getid3->fp, 4, SEEK_CUR);
+					$this->fseek(4, SEEK_CUR);
 					break;
 
 				case 'BH':
-					$BHheaderbytes  = getid3_lib::BigEndian2Int(fread($this->getid3->fp, 3));
-					$BHheaderdata   = fread($this->getid3->fp, $BHheaderbytes);
+					$BHheaderbytes  = getid3_lib::BigEndian2Int($this->fread(3));
+					$BHheaderdata   = $this->fread($BHheaderbytes);
 					$BHheaderoffset = 0;
 					while (strpos($BHheaderdata, "\x00", $BHheaderoffset) > 0) {
 						//filename as \0 terminated string  (empty string indicates end)

--- a/application/libraries/getid3/module.archive.xz.php
+++ b/application/libraries/getid3/module.archive.xz.php
@@ -8,8 +8,8 @@
 //  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
-// module.misc.msoffice.php                                    //
-// module for analyzing MS Office (.doc, .xls, etc) files      //
+// module.archive.xz.php                                       //
+// module for analyzing XZ files                               //
 // dependencies: NONE                                          //
 //                                                            ///
 /////////////////////////////////////////////////////////////////
@@ -18,8 +18,9 @@ if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that acce
 	exit;
 }
 
-class getid3_msoffice extends getid3_handler
+class getid3_xz extends getid3_handler
 {
+
 	/**
 	 * @return bool
 	 */
@@ -27,15 +28,16 @@ class getid3_msoffice extends getid3_handler
 		$info = &$this->getid3->info;
 
 		$this->fseek($info['avdataoffset']);
-		$DOCFILEheader = $this->fread(8);
-		$magic = "\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1";
-		if (substr($DOCFILEheader, 0, 8) != $magic) {
-			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at '.$info['avdataoffset'].', found '.getid3_lib::PrintHexBytes(substr($DOCFILEheader, 0, 8)).' instead.');
+		$xzheader = $this->fread(6);
+
+		// https://tukaani.org/xz/xz-file-format-1.0.4.txt
+		$info['xz']['stream_header']['magic'] = substr($xzheader, 0, 6);
+		if ($info['xz']['stream_header']['magic'] != "\xFD".'7zXZ'."\x00") {
+			$this->error('Invalid XZ stream header magic (expecting FD 37 7A 58 5A 00, found '.getid3_lib::PrintHexBytes($info['xz']['stream_header']['magic']).') at offset '.$info['avdataoffset']);
 			return false;
 		}
-		$info['fileformat'] = 'msoffice';
-
-		$this->error('MS Office (.doc, .xls, etc) parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
+		$info['fileformat'] = 'xz';
+		$this->error('XZ parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
 		return false;
 
 	}

--- a/application/libraries/getid3/module.archive.zip.php
+++ b/application/libraries/getid3/module.archive.zip.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.archive.zip.php                                      //
@@ -13,10 +14,15 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_zip extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -29,37 +35,38 @@ class getid3_zip extends getid3_handler
 		$info['zip']['entries_count']     = 0;
 
 		if (!getid3_lib::intValueSupported($info['filesize'])) {
-			$info['error'][] = 'File is larger than '.round(PHP_INT_MAX / 1073741824).'GB, not supported by PHP';
+			$this->error('File is larger than '.round(PHP_INT_MAX / 1073741824).'GB, not supported by PHP');
 			return false;
 		} else {
 			$EOCDsearchData    = '';
 			$EOCDsearchCounter = 0;
 			while ($EOCDsearchCounter++ < 512) {
 
-				fseek($this->getid3->fp, -128 * $EOCDsearchCounter, SEEK_END);
-				$EOCDsearchData = fread($this->getid3->fp, 128).$EOCDsearchData;
+				$this->fseek(-128 * $EOCDsearchCounter, SEEK_END);
+				$EOCDsearchData = $this->fread(128).$EOCDsearchData;
 
 				if (strstr($EOCDsearchData, 'PK'."\x05\x06")) {
 
 					$EOCDposition = strpos($EOCDsearchData, 'PK'."\x05\x06");
-					fseek($this->getid3->fp, (-128 * $EOCDsearchCounter) + $EOCDposition, SEEK_END);
+					$this->fseek((-128 * $EOCDsearchCounter) + $EOCDposition, SEEK_END);
 					$info['zip']['end_central_directory'] = $this->ZIPparseEndOfCentralDirectory();
 
-					fseek($this->getid3->fp, $info['zip']['end_central_directory']['directory_offset'], SEEK_SET);
+					$this->fseek($info['zip']['end_central_directory']['directory_offset']);
 					$info['zip']['entries_count'] = 0;
-					while ($centraldirectoryentry = $this->ZIPparseCentralDirectory($this->getid3->fp)) {
+					while ($centraldirectoryentry = $this->ZIPparseCentralDirectory()) {
 						$info['zip']['central_directory'][] = $centraldirectoryentry;
 						$info['zip']['entries_count']++;
 						$info['zip']['compressed_size']   += $centraldirectoryentry['compressed_size'];
 						$info['zip']['uncompressed_size'] += $centraldirectoryentry['uncompressed_size'];
 
-						if ($centraldirectoryentry['uncompressed_size'] > 0) {
+						//if ($centraldirectoryentry['uncompressed_size'] > 0) { zero-byte files are valid
+						if (!empty($centraldirectoryentry['filename'])) {
 							$info['zip']['files'] = getid3_lib::array_merge_clobber($info['zip']['files'], getid3_lib::CreateDeepArray($centraldirectoryentry['filename'], '/', $centraldirectoryentry['uncompressed_size']));
 						}
 					}
 
 					if ($info['zip']['entries_count'] == 0) {
-						$info['error'][] = 'No Central Directory entries found (truncated file?)';
+						$this->error('No Central Directory entries found (truncated file?)');
 						return false;
 					}
 
@@ -77,36 +84,79 @@ class getid3_zip extends getid3_handler
 						$info['zip']['compression_speed']  = 'store';
 					}
 
-					return true;
+					// secondary check - we (should) already have all the info we NEED from the Central Directory above, but scanning each
+					// Local File Header entry will
+					foreach ($info['zip']['central_directory'] as $central_directory_entry) {
+						$this->fseek($central_directory_entry['entry_offset']);
+						if ($fileentry = $this->ZIPparseLocalFileHeader()) {
+							$info['zip']['entries'][] = $fileentry;
+						} else {
+							$this->warning('Error parsing Local File Header at offset '.$central_directory_entry['entry_offset']);
+						}
+					}
 
+					// check for EPUB files
+					if (!empty($info['zip']['entries'][0]['filename']) &&
+						($info['zip']['entries'][0]['filename'] == 'mimetype') &&
+						($info['zip']['entries'][0]['compression_method'] == 'store') &&
+						($info['zip']['entries'][0]['uncompressed_size'] == 20) &&
+						isset($info['zip']['entries'][0]['data_offset'])) {
+							// http://idpf.org/epub/30/spec/epub30-ocf.html
+							// "3.3 OCF ZIP Container Media Type Identification
+							//  OCF ZIP Containers must include a mimetype file as the first file in the Container, and the contents of this file must be the MIME type string application/epub+zip.
+							//  The contents of the mimetype file must not contain any leading padding or whitespace, must not begin with the Unicode signature (or Byte Order Mark),
+							//  and the case of the MIME type string must be exactly as presented above. The mimetype file additionally must be neither compressed nor encrypted,
+							//  and there must not be an extra field in its ZIP header."
+							$this->fseek($info['zip']['entries'][0]['data_offset']);
+							if ($this->fread(20) == 'application/epub+zip') {
+								$info['fileformat'] = 'zip.epub';
+								$info['mime_type'] = 'application/epub+zip';
+							}
+					}
+
+					// check for Office Open XML files (e.g. .docx, .xlsx)
+					if (!empty($info['zip']['files']['[Content_Types].xml']) &&
+					    !empty($info['zip']['files']['_rels']['.rels'])      &&
+					    !empty($info['zip']['files']['docProps']['app.xml']) &&
+					    !empty($info['zip']['files']['docProps']['core.xml'])) {
+							// http://technet.microsoft.com/en-us/library/cc179224.aspx
+							$info['fileformat'] = 'zip.msoffice';
+							if (!empty($ThisFileInfo['zip']['files']['ppt'])) {
+								$info['mime_type'] = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+							} elseif (!empty($ThisFileInfo['zip']['files']['xl'])) {
+								$info['mime_type'] = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+							} elseif (!empty($ThisFileInfo['zip']['files']['word'])) {
+								$info['mime_type'] = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+							}
+					}
+
+					return true;
 				}
 			}
 		}
 
-		if ($this->getZIPentriesFilepointer()) {
-
-			// central directory couldn't be found and/or parsed
-			// scan through actual file data entries, recover as much as possible from probable trucated file
-			if ($info['zip']['compressed_size'] > ($info['filesize'] - 46 - 22)) {
-				$info['error'][] = 'Warning: Truncated file! - Total compressed file sizes ('.$info['zip']['compressed_size'].' bytes) is greater than filesize minus Central Directory and End Of Central Directory structures ('.($info['filesize'] - 46 - 22).' bytes)';
-			}
-			$info['error'][] = 'Cannot find End Of Central Directory - returned list of files in [zip][entries] array may not be complete';
-			foreach ($info['zip']['entries'] as $key => $valuearray) {
-				$info['zip']['files'][$valuearray['filename']] = $valuearray['uncompressed_size'];
-			}
-			return true;
-
-		} else {
-
+		if (!$this->getZIPentriesFilepointer()) {
 			unset($info['zip']);
 			$info['fileformat'] = '';
-			$info['error'][] = 'Cannot find End Of Central Directory (truncated file?)';
+			$this->error('Cannot find End Of Central Directory (truncated file?)');
 			return false;
-
 		}
+
+		// central directory couldn't be found and/or parsed
+		// scan through actual file data entries, recover as much as possible from probable trucated file
+		if ($info['zip']['compressed_size'] > ($info['filesize'] - 46 - 22)) {
+			$this->error('Warning: Truncated file! - Total compressed file sizes ('.$info['zip']['compressed_size'].' bytes) is greater than filesize minus Central Directory and End Of Central Directory structures ('.($info['filesize'] - 46 - 22).' bytes)');
+		}
+		$this->error('Cannot find End Of Central Directory - returned list of files in [zip][entries] array may not be complete');
+		foreach ($info['zip']['entries'] as $key => $valuearray) {
+			$info['zip']['files'][$valuearray['filename']] = $valuearray['uncompressed_size'];
+		}
+		return true;
 	}
 
-
+	/**
+	 * @return bool
+	 */
 	public function getZIPHeaderFilepointerTopDown() {
 		$info = &$this->getid3->info;
 
@@ -122,26 +172,26 @@ class getid3_zip extends getid3_handler
 			$info['zip']['entries_count']++;
 		}
 		if ($info['zip']['entries_count'] == 0) {
-			$info['error'][] = 'No Local File Header entries found';
+			$this->error('No Local File Header entries found');
 			return false;
 		}
 
 		$info['zip']['entries_count']     = 0;
-		while ($centraldirectoryentry = $this->ZIPparseCentralDirectory($this->getid3->fp)) {
+		while ($centraldirectoryentry = $this->ZIPparseCentralDirectory()) {
 			$info['zip']['central_directory'][] = $centraldirectoryentry;
 			$info['zip']['entries_count']++;
 			$info['zip']['compressed_size']   += $centraldirectoryentry['compressed_size'];
 			$info['zip']['uncompressed_size'] += $centraldirectoryentry['uncompressed_size'];
 		}
 		if ($info['zip']['entries_count'] == 0) {
-			$info['error'][] = 'No Central Directory entries found (truncated file?)';
+			$this->error('No Central Directory entries found (truncated file?)');
 			return false;
 		}
 
 		if ($EOCD = $this->ZIPparseEndOfCentralDirectory()) {
 			$info['zip']['end_central_directory'] = $EOCD;
 		} else {
-			$info['error'][] = 'No End Of Central Directory entry found (truncated file?)';
+			$this->error('No End Of Central Directory entry found (truncated file?)');
 			return false;
 		}
 
@@ -152,7 +202,9 @@ class getid3_zip extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @return bool
+	 */
 	public function getZIPentriesFilepointer() {
 		$info = &$this->getid3->info;
 
@@ -168,23 +220,25 @@ class getid3_zip extends getid3_handler
 			$info['zip']['uncompressed_size'] += $fileentry['uncompressed_size'];
 		}
 		if ($info['zip']['entries_count'] == 0) {
-			$info['error'][] = 'No Local File Header entries found';
+			$this->error('No Local File Header entries found');
 			return false;
 		}
 
 		return true;
 	}
 
-
+	/**
+	 * @return array|false
+	 */
 	public function ZIPparseLocalFileHeader() {
-		$LocalFileHeader['offset'] = ftell($this->getid3->fp);
+		$LocalFileHeader['offset'] = $this->ftell();
 
-		$ZIPlocalFileHeader = fread($this->getid3->fp, 30);
+		$ZIPlocalFileHeader = $this->fread(30);
 
 		$LocalFileHeader['raw']['signature']          = getid3_lib::LittleEndian2Int(substr($ZIPlocalFileHeader,  0, 4));
-		if ($LocalFileHeader['raw']['signature'] != 0x04034B50) {
+		if ($LocalFileHeader['raw']['signature'] != 0x04034B50) { // "PK\x03\x04"
 			// invalid Local File Header Signature
-			fseek($this->getid3->fp, $LocalFileHeader['offset'], SEEK_SET); // seek back to where filepointer originally was so it can be handled properly
+			$this->fseek($LocalFileHeader['offset']); // seek back to where filepointer originally was so it can be handled properly
 			return false;
 		}
 		$LocalFileHeader['raw']['extract_version']    = getid3_lib::LittleEndian2Int(substr($ZIPlocalFileHeader,  4, 2));
@@ -208,7 +262,7 @@ class getid3_zip extends getid3_handler
 
 		$FilenameExtrafieldLength = $LocalFileHeader['raw']['filename_length'] + $LocalFileHeader['raw']['extra_field_length'];
 		if ($FilenameExtrafieldLength > 0) {
-			$ZIPlocalFileHeader .= fread($this->getid3->fp, $FilenameExtrafieldLength);
+			$ZIPlocalFileHeader .= $this->fread($FilenameExtrafieldLength);
 
 			if ($LocalFileHeader['raw']['filename_length'] > 0) {
 				$LocalFileHeader['filename']                = substr($ZIPlocalFileHeader, 30, $LocalFileHeader['raw']['filename_length']);
@@ -218,30 +272,71 @@ class getid3_zip extends getid3_handler
 			}
 		}
 
-		$LocalFileHeader['data_offset'] = ftell($this->getid3->fp);
-		//$LocalFileHeader['compressed_data'] = fread($this->getid3->fp, $LocalFileHeader['raw']['compressed_size']);
-		fseek($this->getid3->fp, $LocalFileHeader['raw']['compressed_size'], SEEK_CUR);
+		if ($LocalFileHeader['compressed_size'] == 0) {
+			// *Could* be a zero-byte file
+			// But could also be a file written on the fly that didn't know compressed filesize beforehand.
+			// Correct compressed filesize should be in the data_descriptor located after this file data, and also in Central Directory (at end of zip file)
+			if (!empty($this->getid3->info['zip']['central_directory'])) {
+				foreach ($this->getid3->info['zip']['central_directory'] as $central_directory_entry) {
+					if ($central_directory_entry['entry_offset'] == $LocalFileHeader['offset']) {
+						if ($central_directory_entry['compressed_size'] > 0) {
+							// overwrite local zero value (but not ['raw']'compressed_size']) so that seeking for data_descriptor (and next file entry) works correctly
+							$LocalFileHeader['compressed_size'] = $central_directory_entry['compressed_size'];
+						}
+						break;
+					}
+				}
+			}
+
+		}
+		$LocalFileHeader['data_offset'] = $this->ftell();
+		$this->fseek($LocalFileHeader['compressed_size'], SEEK_CUR); // this should (but may not) match value in $LocalFileHeader['raw']['compressed_size'] -- $LocalFileHeader['compressed_size'] could have been overwritten above with value from Central Directory
 
 		if ($LocalFileHeader['flags']['data_descriptor_used']) {
-			$DataDescriptor = fread($this->getid3->fp, 12);
-			$LocalFileHeader['data_descriptor']['crc_32']            = getid3_lib::LittleEndian2Int(substr($DataDescriptor,  0, 4));
-			$LocalFileHeader['data_descriptor']['compressed_size']   = getid3_lib::LittleEndian2Int(substr($DataDescriptor,  4, 4));
-			$LocalFileHeader['data_descriptor']['uncompressed_size'] = getid3_lib::LittleEndian2Int(substr($DataDescriptor,  8, 4));
-		}
+			$DataDescriptor = $this->fread(16);
+			$LocalFileHeader['data_descriptor']['signature']         = getid3_lib::LittleEndian2Int(substr($DataDescriptor,  0, 4));
+			if ($LocalFileHeader['data_descriptor']['signature'] != 0x08074B50) { // "PK\x07\x08"
+				$this->getid3->warning('invalid Local File Header Data Descriptor Signature at offset '.($this->ftell() - 16).' - expecting 08 07 4B 50, found '.getid3_lib::PrintHexBytes($LocalFileHeader['data_descriptor']['signature']));
+				$this->fseek($LocalFileHeader['offset']); // seek back to where filepointer originally was so it can be handled properly
+				return false;
+			}
+			$LocalFileHeader['data_descriptor']['crc_32']            = getid3_lib::LittleEndian2Int(substr($DataDescriptor,  4, 4));
+			$LocalFileHeader['data_descriptor']['compressed_size']   = getid3_lib::LittleEndian2Int(substr($DataDescriptor,  8, 4));
+			$LocalFileHeader['data_descriptor']['uncompressed_size'] = getid3_lib::LittleEndian2Int(substr($DataDescriptor, 12, 4));
+			if (!$LocalFileHeader['raw']['compressed_size'] && $LocalFileHeader['data_descriptor']['compressed_size']) {
+				foreach ($this->getid3->info['zip']['central_directory'] as $central_directory_entry) {
+					if ($central_directory_entry['entry_offset'] == $LocalFileHeader['offset']) {
+						if ($LocalFileHeader['data_descriptor']['compressed_size'] == $central_directory_entry['compressed_size']) {
+							// $LocalFileHeader['compressed_size'] already set from Central Directory
+						} else {
+							$this->warning('conflicting compressed_size from data_descriptor ('.$LocalFileHeader['data_descriptor']['compressed_size'].') vs Central Directory ('.$central_directory_entry['compressed_size'].') for file at offset '.$LocalFileHeader['offset']);
+						}
 
+						if ($LocalFileHeader['data_descriptor']['uncompressed_size'] == $central_directory_entry['uncompressed_size']) {
+							$LocalFileHeader['uncompressed_size'] = $LocalFileHeader['data_descriptor']['uncompressed_size'];
+						} else {
+							$this->warning('conflicting uncompressed_size from data_descriptor ('.$LocalFileHeader['data_descriptor']['uncompressed_size'].') vs Central Directory ('.$central_directory_entry['uncompressed_size'].') for file at offset '.$LocalFileHeader['offset']);
+						}
+						break;
+					}
+				}
+			}
+		}
 		return $LocalFileHeader;
 	}
 
-
+	/**
+	 * @return array|false
+	 */
 	public function ZIPparseCentralDirectory() {
-		$CentralDirectory['offset'] = ftell($this->getid3->fp);
+		$CentralDirectory['offset'] = $this->ftell();
 
-		$ZIPcentralDirectory = fread($this->getid3->fp, 46);
+		$ZIPcentralDirectory = $this->fread(46);
 
 		$CentralDirectory['raw']['signature']            = getid3_lib::LittleEndian2Int(substr($ZIPcentralDirectory,  0, 4));
 		if ($CentralDirectory['raw']['signature'] != 0x02014B50) {
 			// invalid Central Directory Signature
-			fseek($this->getid3->fp, $CentralDirectory['offset'], SEEK_SET); // seek back to where filepointer originally was so it can be handled properly
+			$this->fseek($CentralDirectory['offset']); // seek back to where filepointer originally was so it can be handled properly
 			return false;
 		}
 		$CentralDirectory['raw']['create_version']       = getid3_lib::LittleEndian2Int(substr($ZIPcentralDirectory,  4, 2));
@@ -273,7 +368,7 @@ class getid3_zip extends getid3_handler
 
 		$FilenameExtrafieldCommentLength = $CentralDirectory['raw']['filename_length'] + $CentralDirectory['raw']['extra_field_length'] + $CentralDirectory['raw']['file_comment_length'];
 		if ($FilenameExtrafieldCommentLength > 0) {
-			$FilenameExtrafieldComment = fread($this->getid3->fp, $FilenameExtrafieldCommentLength);
+			$FilenameExtrafieldComment = $this->fread($FilenameExtrafieldCommentLength);
 
 			if ($CentralDirectory['raw']['filename_length'] > 0) {
 				$CentralDirectory['filename']                  = substr($FilenameExtrafieldComment, 0, $CentralDirectory['raw']['filename_length']);
@@ -289,15 +384,18 @@ class getid3_zip extends getid3_handler
 		return $CentralDirectory;
 	}
 
+	/**
+	 * @return array|false
+	 */
 	public function ZIPparseEndOfCentralDirectory() {
-		$EndOfCentralDirectory['offset'] = ftell($this->getid3->fp);
+		$EndOfCentralDirectory['offset'] = $this->ftell();
 
-		$ZIPendOfCentralDirectory = fread($this->getid3->fp, 22);
+		$ZIPendOfCentralDirectory = $this->fread(22);
 
 		$EndOfCentralDirectory['signature']                   = getid3_lib::LittleEndian2Int(substr($ZIPendOfCentralDirectory,  0, 4));
 		if ($EndOfCentralDirectory['signature'] != 0x06054B50) {
 			// invalid End Of Central Directory Signature
-			fseek($this->getid3->fp, $EndOfCentralDirectory['offset'], SEEK_SET); // seek back to where filepointer originally was so it can be handled properly
+			$this->fseek($EndOfCentralDirectory['offset']); // seek back to where filepointer originally was so it can be handled properly
 			return false;
 		}
 		$EndOfCentralDirectory['disk_number_current']         = getid3_lib::LittleEndian2Int(substr($ZIPendOfCentralDirectory,  4, 2));
@@ -309,15 +407,37 @@ class getid3_zip extends getid3_handler
 		$EndOfCentralDirectory['comment_length']              = getid3_lib::LittleEndian2Int(substr($ZIPendOfCentralDirectory, 20, 2));
 
 		if ($EndOfCentralDirectory['comment_length'] > 0) {
-			$EndOfCentralDirectory['comment']                 = fread($this->getid3->fp, $EndOfCentralDirectory['comment_length']);
+			$EndOfCentralDirectory['comment']                 = $this->fread($EndOfCentralDirectory['comment_length']);
 		}
 
 		return $EndOfCentralDirectory;
 	}
 
-
+	/**
+	 * @param int $flagbytes
+	 * @param int $compressionmethod
+	 *
+	 * @return array
+	 */
 	public static function ZIPparseGeneralPurposeFlags($flagbytes, $compressionmethod) {
-		$ParsedFlags['encrypted'] = (bool) ($flagbytes & 0x0001);
+		// https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip-printable.html
+		$ParsedFlags = array();
+		$ParsedFlags['encrypted']               = (bool) ($flagbytes & 0x0001);
+		//                                                             0x0002 -- see below
+		//                                                             0x0004 -- see below
+		$ParsedFlags['data_descriptor_used']    = (bool) ($flagbytes & 0x0008);
+		$ParsedFlags['enhanced_deflation']      = (bool) ($flagbytes & 0x0010);
+		$ParsedFlags['compressed_patched_data'] = (bool) ($flagbytes & 0x0020);
+		$ParsedFlags['strong_encryption']       = (bool) ($flagbytes & 0x0040);
+		//                                                             0x0080 - unused
+		//                                                             0x0100 - unused
+		//                                                             0x0200 - unused
+		//                                                             0x0400 - unused
+		$ParsedFlags['language_encoding']       = (bool) ($flagbytes & 0x0800);
+		//                                                             0x1000 - reserved
+		$ParsedFlags['mask_header_values']      = (bool) ($flagbytes & 0x2000);
+		//                                                             0x4000 - reserved
+		//                                                             0x8000 - reserved
 
 		switch ($compressionmethod) {
 			case 6:
@@ -343,12 +463,15 @@ class getid3_zip extends getid3_handler
 				}
 				break;
 		}
-		$ParsedFlags['data_descriptor_used']       = (bool) ($flagbytes & 0x0008);
 
 		return $ParsedFlags;
 	}
 
-
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public static function ZIPversionOSLookup($index) {
 		static $ZIPversionOSLookup = array(
 			0  => 'MS-DOS and OS/2 (FAT / VFAT / FAT32 file systems)',
@@ -368,13 +491,21 @@ class getid3_zip extends getid3_handler
 			14 => 'VFAT',
 			15 => 'Alternate MVS',
 			16 => 'BeOS',
-			17 => 'Tandem'
+			17 => 'Tandem',
+			18 => 'OS/400',
+			19 => 'OS/X (Darwin)',
 		);
 
 		return (isset($ZIPversionOSLookup[$index]) ? $ZIPversionOSLookup[$index] : '[unknown]');
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public static function ZIPcompressionMethodLookup($index) {
+		// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/ZIP.html
 		static $ZIPcompressionMethodLookup = array(
 			0  => 'store',
 			1  => 'shrink',
@@ -386,12 +517,30 @@ class getid3_zip extends getid3_handler
 			7  => 'tokenize',
 			8  => 'deflate',
 			9  => 'deflate64',
-			10 => 'PKWARE Date Compression Library Imploding'
+			10 => 'Imploded (old IBM TERSE)',
+			11 => 'RESERVED[11]',
+			12 => 'BZIP2',
+			13 => 'RESERVED[13]',
+			14 => 'LZMA (EFS)',
+			15 => 'RESERVED[15]',
+			16 => 'RESERVED[16]',
+			17 => 'RESERVED[17]',
+			18 => 'IBM TERSE (new)',
+			19 => 'IBM LZ77 z Architecture (PFS)',
+			96 => 'JPEG recompressed',
+			97 => 'WavPack compressed',
+			98 => 'PPMd version I, Rev 1',
 		);
 
 		return (isset($ZIPcompressionMethodLookup[$index]) ? $ZIPcompressionMethodLookup[$index] : '[unknown]');
 	}
 
+	/**
+	 * @param int $DOSdate
+	 * @param int $DOStime
+	 *
+	 * @return int
+	 */
 	public static function DOStime2UNIXtime($DOSdate, $DOStime) {
 		// wFatDate
 		// Specifies the MS-DOS date. The date is a packed 16-bit value with the following format:

--- a/application/libraries/getid3/module.audio-video.bink.php
+++ b/application/libraries/getid3/module.audio-video.bink.php
@@ -1,10 +1,10 @@
 <?php
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.bink.php                                       //
@@ -13,53 +13,58 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_bink extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-$info['error'][] = 'Bink / Smacker files not properly processed by this version of getID3() ['.$this->getid3->version().']';
+		$this->error('Bink / Smacker files not properly processed by this version of getID3() ['.$this->getid3->version().']');
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$fileTypeID = fread($this->getid3->fp, 3);
+		$this->fseek($info['avdataoffset']);
+		$fileTypeID = $this->fread(3);
 		switch ($fileTypeID) {
 			case 'BIK':
 				return $this->ParseBink();
-				break;
 
 			case 'SMK':
 				return $this->ParseSmacker();
-				break;
 
 			default:
-				$info['error'][] = 'Expecting "BIK" or "SMK" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($fileTypeID).'"';
+				$this->error('Expecting "BIK" or "SMK" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($fileTypeID).'"');
 				return false;
-				break;
 		}
-
-		return true;
-
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function ParseBink() {
 		$info = &$this->getid3->info;
 		$info['fileformat']          = 'bink';
 		$info['video']['dataformat'] = 'bink';
 
-		$fileData = 'BIK'.fread($this->getid3->fp, 13);
+		$fileData = 'BIK'.$this->fread(13);
 
 		$info['bink']['data_size']   = getid3_lib::LittleEndian2Int(substr($fileData, 4, 4));
 		$info['bink']['frame_count'] = getid3_lib::LittleEndian2Int(substr($fileData, 8, 2));
 
 		if (($info['avdataend'] - $info['avdataoffset']) != ($info['bink']['data_size'] + 8)) {
-			$info['error'][] = 'Probably truncated file: expecting '.$info['bink']['data_size'].' bytes, found '.($info['avdataend'] - $info['avdataoffset']);
+			$this->error('Probably truncated file: expecting '.$info['bink']['data_size'].' bytes, found '.($info['avdataend'] - $info['avdataoffset']));
 		}
 
 		return true;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function ParseSmacker() {
 		$info = &$this->getid3->info;
 		$info['fileformat']          = 'smacker';

--- a/application/libraries/getid3/module.audio-video.ivf.php
+++ b/application/libraries/getid3/module.audio-video.ivf.php
@@ -1,0 +1,80 @@
+<?php
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// module.audio.ivf.php                                        //
+// module for analyzing IVF audio-video files                  //
+// dependencies: NONE                                          //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+
+class getid3_ivf extends getid3_handler
+{
+	/**
+	 * @return bool
+	 */
+	public function Analyze() {
+		$info = &$this->getid3->info;
+
+		$info['fileformat']          = 'ivf';
+		$info['video']['dataformat'] = 'ivf';
+
+		$this->fseek($info['avdataoffset']);
+		$IVFheader = $this->fread(32);
+
+		if (substr($IVFheader, 0, 4) == 'DKIF') {
+
+			// https://wiki.multimedia.cx/index.php/IVF
+			$info['ivf']['header']['signature']            =                              substr($IVFheader,  0, 4);
+			$info['ivf']['header']['version']              = getid3_lib::LittleEndian2Int(substr($IVFheader,  4, 2)); // should be 0
+			$info['ivf']['header']['headersize']           = getid3_lib::LittleEndian2Int(substr($IVFheader,  6, 2));
+			$info['ivf']['header']['fourcc']               =                              substr($IVFheader,  8, 4);
+			$info['ivf']['header']['resolution_x']         = getid3_lib::LittleEndian2Int(substr($IVFheader, 12, 2));
+			$info['ivf']['header']['resolution_y']         = getid3_lib::LittleEndian2Int(substr($IVFheader, 14, 2));
+			$info['ivf']['header']['timebase_numerator']   = getid3_lib::LittleEndian2Int(substr($IVFheader, 16, 4));
+			$info['ivf']['header']['timebase_denominator'] = getid3_lib::LittleEndian2Int(substr($IVFheader, 20, 4));
+			$info['ivf']['header']['frame_count']          = getid3_lib::LittleEndian2Int(substr($IVFheader, 24, 4));
+			//$info['ivf']['header']['reserved']             =                              substr($IVFheader, 28, 4);
+
+			$info['ivf']['header']['frame_rate'] = (float) $info['ivf']['header']['timebase_numerator'] / $info['ivf']['header']['timebase_denominator'];
+
+			if ($info['ivf']['header']['version'] > 0) {
+				$this->warning('Expecting IVF header version 0, found version '.$info['ivf']['header']['version'].', results may not be accurate');
+			}
+
+			$info['video']['resolution_x']    =         $info['ivf']['header']['resolution_x'];
+			$info['video']['resolution_y']    =         $info['ivf']['header']['resolution_y'];
+			$info['video']['codec']           =         $info['ivf']['header']['fourcc'];
+
+			$info['ivf']['frame_count'] = 0;
+			while (!$this->feof()) {
+				if ($frameheader = $this->fread(12)) {
+					$framesize = getid3_lib::LittleEndian2Int(substr($frameheader, 0, 4)); // size of frame in bytes (not including the 12-byte header)
+					$timestamp = getid3_lib::LittleEndian2Int(substr($frameheader, 4, 8)); // 64-bit presentation timestamp
+					$this->fseek($framesize, SEEK_CUR);
+					$info['ivf']['frame_count']++;
+				}
+			}
+			if ($info['ivf']['frame_count']) {
+				$info['playtime_seconds']    = $timestamp / 100000;
+				$info['video']['frame_rate'] = (float) $info['ivf']['frame_count'] / $info['playtime_seconds'];
+			}
+
+		} else {
+			$this->error('Expecting "DKIF" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($IVFheader, 0, 4)).'"');
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/application/libraries/getid3/module.audio-video.matroska.php
+++ b/application/libraries/getid3/module.audio-video.matroska.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio-video.matriska.php                             //
@@ -13,8 +14,10 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
-// from: http://www.matroska.org/technical/specs/index.html
 define('EBML_ID_CHAPTERS',                  0x0043A770); // [10][43][A7][70] -- A system to define basic menus and partition data. For more detailed information, look at the Chapters Explanation.
 define('EBML_ID_SEEKHEAD',                  0x014D9B74); // [11][4D][9B][74] -- Contains the position of other level 1 elements.
 define('EBML_ID_TAGS',                      0x0254C367); // [12][54][C3][67] -- Element containing elements specific to Tracks/Chapters. A list of valid tags can be found <http://www.matroska.org/technical/specs/tagging/index.html>.
@@ -72,7 +75,7 @@ define('EBML_ID_FILEREFERRAL',                  0x0675); //         [46][75] -- 
 define('EBML_ID_FILEDESCRIPTION',               0x067E); //         [46][7E] -- A human-friendly name for the attached file.
 define('EBML_ID_FILEUID',                       0x06AE); //         [46][AE] -- Unique ID representing the file, as random as possible.
 define('EBML_ID_CONTENTENCALGO',                0x07E1); //         [47][E1] -- The encryption algorithm used. The value '0' means that the contents have not been encrypted but only signed. Predefined values:
-define('EBML_ID_CONTENTENCKEYID',               0x07E2); //         [47][E2] -- For public key algorithms this is the ID of the public key the the data was encrypted with.
+define('EBML_ID_CONTENTENCKEYID',               0x07E2); //         [47][E2] -- For public key algorithms this is the ID of the public key the data was encrypted with.
 define('EBML_ID_CONTENTSIGNATURE',              0x07E3); //         [47][E3] -- A cryptographic signature of the contents.
 define('EBML_ID_CONTENTSIGKEYID',               0x07E4); //         [47][E4] -- This is the ID of the private key the data was signed with.
 define('EBML_ID_CONTENTSIGALGO',                0x07E5); //         [47][E5] -- The algorithm used for the signature. A value of '0' means that the contents have not been signed but only encrypted. Predefined values:
@@ -207,19 +210,41 @@ define('EBML_ID_CLUSTERREFERENCEBLOCK',           0x7B); //             [FB] -- 
 define('EBML_ID_CLUSTERREFERENCEVIRTUAL',         0x7D); //             [FD] -- Relative position of the data that should be in position of the virtual block.
 
 
+/**
+* @tutorial http://www.matroska.org/technical/specs/index.html
+*
+* @todo Rewrite EBML parser to reduce it's size and honor default element values
+* @todo After rewrite implement stream size calculation, that will provide additional useful info and enable AAC/FLAC audio bitrate detection
+*/
 class getid3_matroska extends getid3_handler
 {
-	// public options
-	public static $hide_clusters      = true;  // if true, do not return information about CLUSTER chunks, since there's a lot of them and they're not usually useful [default: TRUE]
-    public static $parse_whole_file   = false; // true to parse the whole file, not only header [default: FALSE]
+	/**
+	 * If true, do not return information about CLUSTER chunks, since there's a lot of them
+	 * and they're not usually useful [default: TRUE].
+	 *
+	 * @var bool
+	 */
+	public static $hide_clusters    = true;
 
-    // private parser settings/placeholders
-    private $EBMLbuffer        = '';
-    private $EBMLbuffer_offset = 0;
-    private $EBMLbuffer_length = 0;
-    private $current_offset    = 0;
-    private $unuseful_elements = array(EBML_ID_CRC32, EBML_ID_VOID);
+	/**
+	 * True to parse the whole file, not only header [default: FALSE].
+	 *
+	 * @var bool
+	 */
+	public static $parse_whole_file = false;
 
+	/*
+	 * Private parser settings/placeholders.
+	 */
+	private $EBMLbuffer        = '';
+	private $EBMLbuffer_offset = 0;
+	private $EBMLbuffer_length = 0;
+	private $current_offset    = 0;
+	private $unuseful_elements = array(EBML_ID_CRC32, EBML_ID_VOID);
+
+	/**
+	 * @return bool
+	 */
 	public function Analyze()
 	{
 		$info = &$this->getid3->info;
@@ -228,7 +253,7 @@ class getid3_matroska extends getid3_handler
 		try {
 			$this->parseEBML($info);
 		} catch (Exception $e) {
-			$info['error'][] = 'EBML parser: '.$e->getMessage();
+			$this->error('EBML parser: '.$e->getMessage());
 		}
 
 		// calculate playtime
@@ -263,17 +288,21 @@ class getid3_matroska extends getid3_handler
 					case 1: // Video
 						$track_info['resolution_x'] = $trackarray['PixelWidth'];
 						$track_info['resolution_y'] = $trackarray['PixelHeight'];
-						if (isset($trackarray['DisplayWidth']))    { $track_info['display_x']  = $trackarray['DisplayWidth']; }
-						if (isset($trackarray['DisplayHeight']))   { $track_info['display_y']  = $trackarray['DisplayHeight']; }
-						if (isset($trackarray['DefaultDuration'])) { $track_info['frame_rate'] = round(1000000000 / $trackarray['DefaultDuration'], 3); }
-						if (isset($trackarray['CodecName']))       { $track_info['codec']      = $trackarray['CodecName']; }
+						$track_info['display_unit'] = self::displayUnit(isset($trackarray['DisplayUnit']) ? $trackarray['DisplayUnit'] : 0);
+						$track_info['display_x']    = (isset($trackarray['DisplayWidth']) ? $trackarray['DisplayWidth'] : $trackarray['PixelWidth']);
+						$track_info['display_y']    = (isset($trackarray['DisplayHeight']) ? $trackarray['DisplayHeight'] : $trackarray['PixelHeight']);
+
+						if (isset($trackarray['PixelCropBottom'])) { $track_info['crop_bottom'] = $trackarray['PixelCropBottom']; }
+						if (isset($trackarray['PixelCropTop']))    { $track_info['crop_top']    = $trackarray['PixelCropTop']; }
+						if (isset($trackarray['PixelCropLeft']))   { $track_info['crop_left']   = $trackarray['PixelCropLeft']; }
+						if (isset($trackarray['PixelCropRight']))  { $track_info['crop_right']  = $trackarray['PixelCropRight']; }
+						if (isset($trackarray['DefaultDuration'])) { $track_info['frame_rate']  = round(1000000000 / $trackarray['DefaultDuration'], 3); }
+						if (isset($trackarray['CodecName']))       { $track_info['codec']       = $trackarray['CodecName']; }
 
 						switch ($trackarray['CodecID']) {
 							case 'V_MS/VFW/FOURCC':
-								if (!getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio-video.riff.php', __FILE__, false)) {
-									$this->warning('Unable to parse codec private data ['.basename(__FILE__).':'.__LINE__.'] because cannot include "module.audio-video.riff.php"');
-									break;
-								}
+								getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio-video.riff.php', __FILE__, true);
+
 								$parsed = getid3_riff::ParseBITMAPINFOHEADER($trackarray['CodecPrivate']);
 								$track_info['codec'] = getid3_riff::fourccLookup($parsed['fourcc']);
 								$info['matroska']['track_codec_parsed'][$trackarray['TrackNumber']] = $parsed;
@@ -303,7 +332,7 @@ class getid3_matroska extends getid3_handler
 								break;*/
 						}
 
-						$info['video']['streams'][] = $track_info;
+						$info['video']['streams'][$trackarray['TrackUID']] = $track_info;
 						break;
 
 					case 2: // Audio
@@ -316,18 +345,17 @@ class getid3_matroska extends getid3_handler
 						switch ($trackarray['CodecID']) {
 							case 'A_PCM/INT/LIT':
 							case 'A_PCM/INT/BIG':
-								$track_info['bitrate'] = $trackarray['SamplingFrequency'] * $trackarray['Channels'] * $trackarray['BitDepth'];
+								$track_info['bitrate'] = $track_info['sample_rate'] * $track_info['channels'] * $trackarray['BitDepth'];
 								break;
 
 							case 'A_AC3':
+							case 'A_EAC3':
 							case 'A_DTS':
 							case 'A_MPEG/L3':
 							case 'A_MPEG/L2':
 							case 'A_FLAC':
-								if (!getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.'.($track_info['dataformat'] == 'mp2' ? 'mp3' : $track_info['dataformat']).'.php', __FILE__, false)) {
-									$this->warning('Unable to parse audio data ['.basename(__FILE__).':'.__LINE__.'] because cannot include "module.audio.'.$track_info['dataformat'].'.php"');
-									break;
-								}
+								$module_dataformat = ($track_info['dataformat'] == 'mp2' ? 'mp3' : ($track_info['dataformat'] == 'eac3' ? 'ac3' : $track_info['dataformat']));
+								getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.'.$module_dataformat.'.php', __FILE__, true);
 
 								if (!isset($info['matroska']['track_data_offsets'][$trackarray['TrackNumber']])) {
 									$this->warning('Unable to parse audio data ['.basename(__FILE__).':'.__LINE__.'] because $info[matroska][track_data_offsets]['.$trackarray['TrackNumber'].'] not set');
@@ -337,7 +365,7 @@ class getid3_matroska extends getid3_handler
 								// create temp instance
 								$getid3_temp = new getID3();
 								if ($track_info['dataformat'] != 'flac') {
-									$getid3_temp->openfile($this->getid3->filename);
+									$getid3_temp->openfile($this->getid3->filename, $this->getid3->info['filesize'], $this->getid3->fp);
 								}
 								$getid3_temp->info['avdataoffset'] = $info['matroska']['track_data_offsets'][$trackarray['TrackNumber']]['offset'];
 								if ($track_info['dataformat'][0] == 'm' || $track_info['dataformat'] == 'flac') {
@@ -345,7 +373,7 @@ class getid3_matroska extends getid3_handler
 								}
 
 								// analyze
-								$class = 'getid3_'.($track_info['dataformat'] == 'mp2' ? 'mp3' : $track_info['dataformat']);
+								$class = 'getid3_'.$module_dataformat;
 								$header_data_key = $track_info['dataformat'][0] == 'm' ? 'mpeg' : $track_info['dataformat'];
 								$getid3_audio = new $class($getid3_temp, __CLASS__);
 								if ($track_info['dataformat'] == 'flac') {
@@ -357,8 +385,8 @@ class getid3_matroska extends getid3_handler
 								if (!empty($getid3_temp->info[$header_data_key])) {
 									$info['matroska']['track_codec_parsed'][$trackarray['TrackNumber']] = $getid3_temp->info[$header_data_key];
 									if (isset($getid3_temp->info['audio']) && is_array($getid3_temp->info['audio'])) {
-										foreach ($getid3_temp->info['audio'] as $key => $value) {
-											$track_info[$key] = $value;
+										foreach ($getid3_temp->info['audio'] as $sub_key => $value) {
+											$track_info[$sub_key] = $value;
 										}
 									}
 								}
@@ -374,10 +402,6 @@ class getid3_matroska extends getid3_handler
 								}
 								if (!empty($getid3_temp->info['warning'])) {
 									foreach ($getid3_temp->info['warning'] as $newerror) {
-										if ($track_info['dataformat'] == 'mp3' && preg_match('/^Probable truncated file: expecting \d+ bytes of audio data, only found \d+ \(short by \d+ bytes\)$/', $newerror)) {
-											// LAME/Xing header is probably set, but audio data is chunked into Matroska file and near-impossible to verify if audio stream is complete, so ignore useless warning
-											continue;
-										}
 										$this->warning($class.'() says: ['.$newerror.']');
 									}
 								}
@@ -389,7 +413,7 @@ class getid3_matroska extends getid3_handler
 							case 'A_AAC/MPEG2/LC/SBR':
 							case 'A_AAC/MPEG4/LC':
 							case 'A_AAC/MPEG4/LC/SBR':
-							    $this->warning($trackarray['CodecID'].' audio data contains no header, audio/video bitrates can\'t be calculated');
+								$this->warning($trackarray['CodecID'].' audio data contains no header, audio/video bitrates can\'t be calculated');
 								break;
 
 							case 'A_VORBIS':
@@ -404,10 +428,7 @@ class getid3_matroska extends getid3_handler
 								}
 								$vorbis_offset -= 1;
 
-								if (!getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.ogg.php', __FILE__, false)) {
-									$this->warning('Unable to parse audio data ['.basename(__FILE__).':'.__LINE__.'] because cannot include "module.audio.ogg.php"');
-									break;
-								}
+								getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.ogg.php', __FILE__, true);
 
 								// create temp instance
 								$getid3_temp = new getID3();
@@ -419,8 +440,8 @@ class getid3_matroska extends getid3_handler
 								if (!empty($getid3_temp->info['ogg'])) {
 									$info['matroska']['track_codec_parsed'][$trackarray['TrackNumber']] = $getid3_temp->info['ogg'];
 									if (isset($getid3_temp->info['audio']) && is_array($getid3_temp->info['audio'])) {
-										foreach ($getid3_temp->info['audio'] as $key => $value) {
-											$track_info[$key] = $value;
+										foreach ($getid3_temp->info['audio'] as $sub_key => $value) {
+											$track_info[$sub_key] = $value;
 										}
 									}
 								}
@@ -444,15 +465,12 @@ class getid3_matroska extends getid3_handler
 								break;
 
 							case 'A_MS/ACM':
-								if (!getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio-video.riff.php', __FILE__, false)) {
-									$this->warning('Unable to parse audio data ['.basename(__FILE__).':'.__LINE__.'] because cannot include "module.audio-video.riff.php"');
-									break;
-								}
+								getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio-video.riff.php', __FILE__, true);
 
 								$parsed = getid3_riff::parseWAVEFORMATex($trackarray['CodecPrivate']);
-								foreach ($parsed as $key => $value) {
-									if ($key != 'raw') {
-										$track_info[$key] = $value;
+								foreach ($parsed as $sub_key => $value) {
+									if ($sub_key != 'raw') {
+										$track_info[$sub_key] = $value;
 									}
 								}
 								$info['matroska']['track_codec_parsed'][$trackarray['TrackNumber']] = $parsed;
@@ -460,9 +478,10 @@ class getid3_matroska extends getid3_handler
 
 							default:
 								$this->warning('Unhandled audio type "'.(isset($trackarray['CodecID']) ? $trackarray['CodecID'] : '').'"');
+								break;
 						}
 
-						$info['audio']['streams'][] = $track_info;
+						$info['audio']['streams'][$trackarray['TrackUID']] = $track_info;
 						break;
 				}
 			}
@@ -484,7 +503,7 @@ class getid3_matroska extends getid3_handler
 			}
 		}
 
-        // determine mime type
+		// determine mime type
 		if (!empty($info['video']['streams'])) {
 			$info['mime_type'] = ($info['matroska']['doctype'] == 'webm' ? 'video/webm' : 'video/x-matroska');
 		} elseif (!empty($info['audio']['streams'])) {
@@ -493,10 +512,37 @@ class getid3_matroska extends getid3_handler
 			unset($info['mime_type']);
 		}
 
+		// use _STATISTICS_TAGS if available to set audio/video bitrates
+		if (!empty($info['matroska']['tags'])) {
+			$_STATISTICS_byTrackUID = array();
+			foreach ($info['matroska']['tags'] as $key1 => $value1) {
+				if (!empty($value1['Targets']['TagTrackUID'][0]) && !empty($value1['SimpleTag'])) {
+					foreach ($value1['SimpleTag'] as $key2 => $value2) {
+						if (!empty($value2['TagName']) && isset($value2['TagString'])) {
+							$_STATISTICS_byTrackUID[$value1['Targets']['TagTrackUID'][0]][$value2['TagName']] = $value2['TagString'];
+						}
+					}
+				}
+			}
+			foreach (array('audio','video') as $avtype) {
+				if (!empty($info[$avtype]['streams'])) {
+					foreach ($info[$avtype]['streams'] as $trackUID => $trackdata) {
+						if (!isset($trackdata['bitrate']) && !empty($_STATISTICS_byTrackUID[$trackUID]['BPS'])) {
+							$info[$avtype]['streams'][$trackUID]['bitrate'] = (int) $_STATISTICS_byTrackUID[$trackUID]['BPS'];
+							@$info[$avtype]['bitrate'] += $info[$avtype]['streams'][$trackUID]['bitrate'];
+						}
+					}
+				}
+			}
+		}
+
 		return true;
 	}
 
-    private function parseEBML(&$info) {
+	/**
+	 * @param array $info
+	 */
+	private function parseEBML(&$info) {
 		// http://www.matroska.org/technical/specs/index.html#EBMLBasics
 		$this->current_offset = $info['avdataoffset'];
 
@@ -504,7 +550,6 @@ class getid3_matroska extends getid3_handler
 			switch ($top_element['id']) {
 
 				case EBML_ID_EBML:
-					$info['fileformat'] = 'matroska';
 					$info['matroska']['header']['offset'] = $top_element['offset'];
 					$info['matroska']['header']['length'] = $top_element['length'];
 
@@ -523,20 +568,16 @@ class getid3_matroska extends getid3_handler
 							case EBML_ID_DOCTYPE:
 								$element_data['data'] = getid3_lib::trimNullByte($element_data['data']);
 								$info['matroska']['doctype'] = $element_data['data'];
-								break;
-
-							case EBML_ID_CRC32: // not useful, ignore
-								$this->current_offset = $element_data['end'];
-								unset($element_data);
+								$info['fileformat'] = $element_data['data'];
 								break;
 
 							default:
 								$this->unhandledElement('header', __LINE__, $element_data);
+								break;
 						}
-						if (!empty($element_data)) {
-							unset($element_data['offset'], $element_data['end']);
-							$info['matroska']['header']['elements'][] = $element_data;
-						}
+
+						unset($element_data['offset'], $element_data['end']);
+						$info['matroska']['header']['elements'][] = $element_data;
 					}
 					break;
 
@@ -571,15 +612,20 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('seekhead.seek', __LINE__, $sub_seek_entry);												}
+														break;
 											}
-
-											if ($seek_entry['target_id'] != EBML_ID_CLUSTER || !self::$hide_clusters) { // collect clusters only if required
+											if (!isset($seek_entry['target_id'])) {
+												$this->warning('seek_entry[target_id] unexpectedly not set at '.$seek_entry['offset']);
+												break;
+											}
+											if (($seek_entry['target_id'] != EBML_ID_CLUSTER) || !self::$hide_clusters) { // collect clusters only if required
 												$info['matroska']['seek'][] = $seek_entry;
 											}
 											break;
 
 										default:
 											$this->unhandledElement('seekhead', __LINE__, $seek_entry);
+											break;
 									}
 								}
 								break;
@@ -595,8 +641,10 @@ class getid3_matroska extends getid3_handler
 											while ($this->getEBMLelement($subelement, $track_entry['end'], array(EBML_ID_VIDEO, EBML_ID_AUDIO, EBML_ID_CONTENTENCODINGS, EBML_ID_CODECPRIVATE))) {
 												switch ($subelement['id']) {
 
-													case EBML_ID_TRACKNUMBER:
 													case EBML_ID_TRACKUID:
+														$track_entry[$subelement['id_name']] = getid3_lib::PrintHexBytes($subelement['data'], true, false);
+														break;
+													case EBML_ID_TRACKNUMBER:
 													case EBML_ID_TRACKTYPE:
 													case EBML_ID_MINCACHE:
 													case EBML_ID_MAXCACHE:
@@ -662,6 +710,7 @@ class getid3_matroska extends getid3_handler
 
 																default:
 																	$this->unhandledElement('track.video', __LINE__, $sub_subelement);
+																	break;
 															}
 														}
 														break;
@@ -687,6 +736,7 @@ class getid3_matroska extends getid3_handler
 
 																default:
 																	$this->unhandledElement('track.audio', __LINE__, $sub_subelement);
+																	break;
 															}
 														}
 														break;
@@ -722,6 +772,7 @@ class getid3_matroska extends getid3_handler
 
 																						default:
 																							$this->unhandledElement('track.contentencodings.contentencoding.contentcompression', __LINE__, $sub_sub_sub_subelement);
+																							break;
 																					}
 																				}
 																				break;
@@ -745,24 +796,28 @@ class getid3_matroska extends getid3_handler
 
 																						default:
 																							$this->unhandledElement('track.contentencodings.contentencoding.contentcompression', __LINE__, $sub_sub_sub_subelement);
+																							break;
 																					}
 																				}
 																				break;
 
 																			default:
 																				$this->unhandledElement('track.contentencodings.contentencoding', __LINE__, $sub_sub_subelement);
+																				break;
 																		}
 																	}
 																	break;
 
 																default:
 																	$this->unhandledElement('track.contentencodings', __LINE__, $sub_subelement);
+																	break;
 															}
 														}
 														break;
 
 													default:
 														$this->unhandledElement('track', __LINE__, $subelement);
+														break;
 												}
 											}
 
@@ -771,6 +826,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('tracks', __LINE__, $track_entry);
+											break;
 									}
 								}
 								break;
@@ -834,6 +890,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('info.chaptertranslate', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$info_entry[$subelement['id_name']] = $chaptertranslate_entry;
@@ -841,6 +898,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('info', __LINE__, $subelement);
+											break;
 									}
 								}
 								$info['matroska']['info'][] = $info_entry;
@@ -863,7 +921,7 @@ class getid3_matroska extends getid3_handler
 												switch ($sub_subelement['id']) {
 
 													case EBML_ID_CUETRACKPOSITIONS:
-                                                    	$cuetrackpositions_entry = array();
+														$cuetrackpositions_entry = array();
 
 														while ($this->getEBMLelement($sub_sub_subelement, $sub_subelement['end'], true)) {
 															switch ($sub_sub_subelement['id']) {
@@ -877,6 +935,7 @@ class getid3_matroska extends getid3_handler
 
 																default:
 																	$this->unhandledElement('cues.cuepoint.cuetrackpositions', __LINE__, $sub_sub_subelement);
+																	break;
 															}
 														}
 														$cuepoint_entry[$sub_subelement['id_name']][] = $cuetrackpositions_entry;
@@ -888,6 +947,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('cues.cuepoint', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$cues_entry[] = $cuepoint_entry;
@@ -895,13 +955,14 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('cues', __LINE__, $subelement);
+											break;
 									}
 								}
 								$info['matroska']['cues'] = $cues_entry;
 								break;
 
 							case EBML_ID_TAGS: // Element containing elements specific to Tracks/Chapters.
-                            	$tags_entry = array();
+								$tags_entry = array();
 
 								while ($this->getEBMLelement($subelement, $element_data['end'], false)) {
 									switch ($subelement['id']) {
@@ -931,11 +992,12 @@ class getid3_matroska extends getid3_handler
 																case EBML_ID_TAGEDITIONUID:
 																case EBML_ID_TAGCHAPTERUID:
 																case EBML_ID_TAGATTACHMENTUID:
-																	$targets_entry[$sub_sub_subelement['id_name']][] = getid3_lib::BigEndian2Int($sub_sub_subelement['data']);
+																	$targets_entry[$sub_sub_subelement['id_name']][] = getid3_lib::PrintHexBytes($sub_sub_subelement['data'], true, false);
 																	break;
 
 																default:
 																	$this->unhandledElement('tags.tag.targets', __LINE__, $sub_sub_subelement);
+																	break;
 															}
 														}
 														$tag_entry[$sub_subelement['id_name']] = $targets_entry;
@@ -947,6 +1009,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('tags.tag', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$tags_entry[] = $tag_entry;
@@ -954,6 +1017,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('tags', __LINE__, $subelement);
+											break;
 									}
 								}
 								$info['matroska']['tags'] = $tags_entry;
@@ -994,25 +1058,15 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('attachments.attachedfile', __LINE__, $sub_subelement);
+														break;
 												}
 											}
-											//if (!empty($attachedfile_entry['FileData']) && !empty($attachedfile_entry['FileMimeType']) && preg_match('#^image/#i', $attachedfile_entry['FileMimeType'])) {
-											//	if ($this->getid3->option_save_attachments === getID3::ATTACHMENTS_INLINE) {
-											//		$attachedfile_entry['data']       = $attachedfile_entry['FileData'];
-											//		$attachedfile_entry['image_mime'] = $attachedfile_entry['FileMimeType'];
-											//		$info['matroska']['comments']['picture'][] = array('data' => $attachedfile_entry['data'], 'image_mime' => $attachedfile_entry['image_mime'], 'filename' => $attachedfile_entry['FileName']);
-											//		unset($attachedfile_entry['FileData'], $attachedfile_entry['FileMimeType']);
-											//	}
-											//}
-											//if (!empty($attachedfile_entry['image_mime']) && preg_match('#^image/#i', $attachedfile_entry['image_mime'])) {
-											//	// don't add a second copy of attached images, which are grouped under the standard location [comments][picture]
-											//} else {
-												$info['matroska']['attachments'][] = $attachedfile_entry;
-											//}
+											$info['matroska']['attachments'][] = $attachedfile_entry;
 											break;
 
 										default:
 											$this->unhandledElement('attachments', __LINE__, $subelement);
+											break;
 									}
 								}
 								break;
@@ -1072,6 +1126,7 @@ class getid3_matroska extends getid3_handler
 
 																			default:
 																				$this->unhandledElement('chapters.editionentry.chapteratom.chaptertrack', __LINE__, $sub_sub_sub_subelement);
+																				break;
 																		}
 																	}
 																	$chapteratom_entry[$sub_sub_subelement['id_name']][] = $chaptertrack_entry;
@@ -1091,6 +1146,7 @@ class getid3_matroska extends getid3_handler
 
 																			default:
 																				$this->unhandledElement('chapters.editionentry.chapteratom.chapterdisplay', __LINE__, $sub_sub_sub_subelement);
+																				break;
 																		}
 																	}
 																	$chapteratom_entry[$sub_sub_subelement['id_name']][] = $chapterdisplay_entry;
@@ -1098,6 +1154,7 @@ class getid3_matroska extends getid3_handler
 
 																default:
 																	$this->unhandledElement('chapters.editionentry.chapteratom', __LINE__, $sub_sub_subelement);
+																	break;
 															}
 														}
 														$editionentry_entry[$sub_subelement['id_name']][] = $chapteratom_entry;
@@ -1105,6 +1162,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('chapters.editionentry', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$info['matroska']['chapters'][] = $editionentry_entry;
@@ -1112,6 +1170,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('chapters', __LINE__, $subelement);
+											break;
 									}
 								}
 								break;
@@ -1140,6 +1199,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('cluster.silenttracks', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$cluster_entry[$subelement['id_name']][] = $cluster_silent_tracks;
@@ -1170,6 +1230,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('clusters.blockgroup', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$cluster_entry[$subelement['id_name']][] = $cluster_block_group;
@@ -1181,6 +1242,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('cluster', __LINE__, $subelement);
+											break;
 									}
 									$this->current_offset = $subelement['end'];
 								}
@@ -1202,16 +1264,23 @@ class getid3_matroska extends getid3_handler
 
 							default:
 								$this->unhandledElement('segment', __LINE__, $element_data);
+								break;
 						}
 					}
 					break;
 
 				default:
 					$this->unhandledElement('root', __LINE__, $top_element);
+					break;
 			}
 		}
-    }
+	}
 
+	/**
+	 * @param int $min_data
+	 *
+	 * @return bool
+	 */
 	private function EnsureBufferHasEnoughData($min_data=1024) {
 		if (($this->current_offset - $this->EBMLbuffer_offset) >= ($this->EBMLbuffer_length - $min_data)) {
 			$read_bytes = max($min_data, $this->getid3->fread_buffer_size());
@@ -1233,6 +1302,9 @@ class getid3_matroska extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @return int|float|false
+	 */
 	private function readEBMLint() {
 		$actual_offset = $this->current_offset - $this->EBMLbuffer_offset;
 
@@ -1265,6 +1337,12 @@ class getid3_matroska extends getid3_handler
 		return $int_value;
 	}
 
+	/**
+	 * @param int  $length
+	 * @param bool $check_buffer
+	 *
+	 * @return string|false
+	 */
 	private function readEBMLelementData($length, $check_buffer=false) {
 		if ($check_buffer && !$this->EnsureBufferHasEnoughData($length)) {
 			return false;
@@ -1274,6 +1352,13 @@ class getid3_matroska extends getid3_handler
 		return $data;
 	}
 
+	/**
+	 * @param array      $element
+	 * @param int        $parent_end
+	 * @param array|bool $get_data
+	 *
+	 * @return bool
+	 */
 	private function getEBMLelement(&$element, $parent_end, $get_data=false) {
 		if ($this->current_offset >= $parent_end) {
 			return false;
@@ -1310,6 +1395,11 @@ class getid3_matroska extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $type
+	 * @param int    $line
+	 * @param array  $element
+	 */
 	private function unhandledElement($type, $line, $element) {
 		// warn only about unknown and missed elements, not about unuseful
 		if (!in_array($element['id'], $this->unuseful_elements)) {
@@ -1322,6 +1412,11 @@ class getid3_matroska extends getid3_handler
 		}
 	}
 
+	/**
+	 * @param array $SimpleTagArray
+	 *
+	 * @return bool
+	 */
 	private function ExtractCommentsSimpleTag($SimpleTagArray) {
 		if (!empty($SimpleTagArray['SimpleTag'])) {
 			foreach ($SimpleTagArray['SimpleTag'] as $SimpleTagKey => $SimpleTagData) {
@@ -1337,6 +1432,11 @@ class getid3_matroska extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int $parent_end
+	 *
+	 * @return array
+	 */
 	private function HandleEMBLSimpleTag($parent_end) {
 		$simpletag_entry = array();
 
@@ -1360,12 +1460,20 @@ class getid3_matroska extends getid3_handler
 
 				default:
 					$this->unhandledElement('tag.simpletag', __LINE__, $element);
+					break;
 			}
 		}
 
 		return $simpletag_entry;
 	}
 
+	/**
+	 * @param array $element
+	 * @param int   $block_type
+	 * @param array $info
+	 *
+	 * @return array
+	 */
 	private function HandleEMBLClusterBlock($element, $block_type, &$info) {
 		// http://www.matroska.org/technical/specs/index.html#block_structure
 		// http://www.matroska.org/technical/specs/index.html#simpleblock_structure
@@ -1392,7 +1500,7 @@ class getid3_matroska extends getid3_handler
 		}
 		$block_data['flags']['lacing_type'] = self::BlockLacingType($block_data['flags']['lacing']);
 
-        // Lace (when lacing bit is set)
+		// Lace (when lacing bit is set)
 		if ($block_data['flags']['lacing'] > 0) {
 			$block_data['lace_frames'] = getid3_lib::BigEndian2Int($this->readEBMLelementData(1)) + 1; // Number of frames in the lace-1 (uint8)
 			if ($block_data['flags']['lacing'] != 0x02) {
@@ -1429,6 +1537,11 @@ class getid3_matroska extends getid3_handler
 		return $block_data;
 	}
 
+	/**
+	 * @param string $EBMLstring
+	 *
+	 * @return int|float|false
+	 */
 	private static function EBML2Int($EBMLstring) {
 		// http://matroska.org/specs/
 
@@ -1471,12 +1584,22 @@ class getid3_matroska extends getid3_handler
 		return getid3_lib::BigEndian2Int($EBMLstring);
 	}
 
+	/**
+	 * @param int $EBMLdatestamp
+	 *
+	 * @return float
+	 */
 	private static function EBMLdate2unix($EBMLdatestamp) {
 		// Date - signed 8 octets integer in nanoseconds with 0 indicating the precise beginning of the millennium (at 2001-01-01T00:00:00,000000000 UTC)
 		// 978307200 == mktime(0, 0, 0, 1, 1, 2001) == January 1, 2001 12:00:00am UTC
 		return round(($EBMLdatestamp / 1000000000) + 978307200);
 	}
 
+	/**
+	 * @param int $target_type
+	 *
+	 * @return string|int
+	 */
 	public static function TargetTypeValue($target_type) {
 		// http://www.matroska.org/technical/specs/tagging/index.html
 		static $TargetTypeValue = array();
@@ -1492,6 +1615,11 @@ class getid3_matroska extends getid3_handler
 		return (isset($TargetTypeValue[$target_type]) ? $TargetTypeValue[$target_type] : $target_type);
 	}
 
+	/**
+	 * @param int $lacingtype
+	 *
+	 * @return string|int
+	 */
 	public static function BlockLacingType($lacingtype) {
 		// http://matroska.org/technical/specs/index.html#block_structure
 		static $BlockLacingType = array();
@@ -1504,6 +1632,11 @@ class getid3_matroska extends getid3_handler
 		return (isset($BlockLacingType[$lacingtype]) ? $BlockLacingType[$lacingtype] : $lacingtype);
 	}
 
+	/**
+	 * @param string $codecid
+	 *
+	 * @return string
+	 */
 	public static function CodecIDtoCommonName($codecid) {
 		// http://www.matroska.org/technical/specs/codecid/index.html
 		static $CodecIDlist = array();
@@ -1511,6 +1644,7 @@ class getid3_matroska extends getid3_handler
 			$CodecIDlist['A_AAC']            = 'aac';
 			$CodecIDlist['A_AAC/MPEG2/LC']   = 'aac';
 			$CodecIDlist['A_AC3']            = 'ac3';
+			$CodecIDlist['A_EAC3']           = 'eac3';
 			$CodecIDlist['A_DTS']            = 'dts';
 			$CodecIDlist['A_FLAC']           = 'flac';
 			$CodecIDlist['A_MPEG/L1']        = 'mp1';
@@ -1533,12 +1667,17 @@ class getid3_matroska extends getid3_handler
 			$CodecIDlist['V_MPEG4/ISO/AVC']  = 'h264';
 			$CodecIDlist['V_MPEG4/ISO/SP']   = 'mpeg4';
 			$CodecIDlist['V_VP8']            = 'vp8';
-			$CodecIDlist['V_MS/VFW/FOURCC']  = 'riff';
-			$CodecIDlist['A_MS/ACM']         = 'riff';
+			$CodecIDlist['V_MS/VFW/FOURCC']  = 'vcm'; // Microsoft (TM) Video Codec Manager (VCM)
+			$CodecIDlist['A_MS/ACM']         = 'acm'; // Microsoft (TM) Audio Codec Manager (ACM)
 		}
 		return (isset($CodecIDlist[$codecid]) ? $CodecIDlist[$codecid] : $codecid);
 	}
 
+	/**
+	 * @param int $value
+	 *
+	 * @return string
+	 */
 	private static function EBMLidName($value) {
 		static $EBMLidList = array();
 		if (empty($EBMLidList)) {
@@ -1737,8 +1876,30 @@ class getid3_matroska extends getid3_handler
 		return (isset($EBMLidList[$value]) ? $EBMLidList[$value] : dechex($value));
 	}
 
+	/**
+	 * @param int $value
+	 *
+	 * @return string
+	 */
+	public static function displayUnit($value) {
+		// http://www.matroska.org/technical/specs/index.html#DisplayUnit
+		static $units = array(
+			0 => 'pixels',
+			1 => 'centimeters',
+			2 => 'inches',
+			3 => 'Display Aspect Ratio');
+
+		return (isset($units[$value]) ? $units[$value] : 'unknown');
+	}
+
+	/**
+	 * @param array $streams
+	 *
+	 * @return array
+	 */
 	private static function getDefaultStreamInfo($streams)
 	{
+		$stream = array();
 		foreach (array_reverse($streams) as $stream) {
 			if ($stream['default']) {
 				break;

--- a/application/libraries/getid3/module.audio-video.mpeg.php
+++ b/application/libraries/getid3/module.audio-video.mpeg.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio-video.mpeg.php                                 //
@@ -13,220 +14,532 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.mp3.php', __FILE__, true);
-
-define('GETID3_MPEG_VIDEO_PICTURE_START',   "\x00\x00\x01\x00");
-define('GETID3_MPEG_VIDEO_USER_DATA_START', "\x00\x00\x01\xB2");
-define('GETID3_MPEG_VIDEO_SEQUENCE_HEADER', "\x00\x00\x01\xB3");
-define('GETID3_MPEG_VIDEO_SEQUENCE_ERROR',  "\x00\x00\x01\xB4");
-define('GETID3_MPEG_VIDEO_EXTENSION_START', "\x00\x00\x01\xB5");
-define('GETID3_MPEG_VIDEO_SEQUENCE_END',    "\x00\x00\x01\xB7");
-define('GETID3_MPEG_VIDEO_GROUP_START',     "\x00\x00\x01\xB8");
-define('GETID3_MPEG_AUDIO_START',           "\x00\x00\x01\xC0");
-
 
 class getid3_mpeg extends getid3_handler
 {
 
+	const START_CODE_BASE       = "\x00\x00\x01";
+	const VIDEO_PICTURE_START   = "\x00\x00\x01\x00";
+	const VIDEO_USER_DATA_START = "\x00\x00\x01\xB2";
+	const VIDEO_SEQUENCE_HEADER = "\x00\x00\x01\xB3";
+	const VIDEO_SEQUENCE_ERROR  = "\x00\x00\x01\xB4";
+	const VIDEO_EXTENSION_START = "\x00\x00\x01\xB5";
+	const VIDEO_SEQUENCE_END    = "\x00\x00\x01\xB7";
+	const VIDEO_GROUP_START     = "\x00\x00\x01\xB8";
+	const AUDIO_START           = "\x00\x00\x01\xC0";
+
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		if ($info['avdataend'] <= $info['avdataoffset']) {
-			$info['error'][] = '"avdataend" ('.$info['avdataend'].') is unexpectedly less-than-or-equal-to "avdataoffset" ('.$info['avdataoffset'].')';
-			return false;
-		}
 		$info['fileformat'] = 'mpeg';
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$MPEGstreamData       = fread($this->getid3->fp, min(100000, $info['avdataend'] - $info['avdataoffset']));
-		$MPEGstreamDataLength = strlen($MPEGstreamData);
+		$this->fseek($info['avdataoffset']);
 
-		$foundVideo = true;
-		$VideoChunkOffset = 0;
-		while (substr($MPEGstreamData, $VideoChunkOffset++, 4) !== GETID3_MPEG_VIDEO_SEQUENCE_HEADER) {
-			if ($VideoChunkOffset >= $MPEGstreamDataLength) {
-				$foundVideo = false;
+		$MPEGstreamData = $this->fread($this->getid3->option_fread_buffer_size);
+		$MPEGstreamBaseOffset = 0; // how far are we from the beginning of the file data ($info['avdataoffset'])
+		$MPEGstreamDataOffset = 0; // how far are we from the beginning of the buffer data (~32kB)
+
+		$StartCodeValue     = false;
+		$prevStartCodeValue = false;
+
+		$GOPcounter = -1;
+		$FramesByGOP = array();
+		$ParsedAVchannels = array();
+
+		do {
+//echo $MPEGstreamDataOffset.' vs '.(strlen($MPEGstreamData) - 1024).'<Br>';
+			if ($MPEGstreamDataOffset > (strlen($MPEGstreamData) - 16384)) {
+				// buffer running low, get more data
+//echo 'reading more data<br>';
+				$MPEGstreamData .= $this->fread($this->getid3->option_fread_buffer_size);
+				if (strlen($MPEGstreamData) > $this->getid3->option_fread_buffer_size) {
+					$MPEGstreamData = substr($MPEGstreamData, $MPEGstreamDataOffset);
+					$MPEGstreamBaseOffset += $MPEGstreamDataOffset;
+					$MPEGstreamDataOffset  = 0;
+				}
+			}
+			if (($StartCodeOffset = strpos($MPEGstreamData, self::START_CODE_BASE, $MPEGstreamDataOffset)) === false) {
+//echo 'no more start codes found.<br>';
 				break;
-			}
-		}
-		if ($foundVideo) {
-
-			// Start code                       32 bits
-			// horizontal frame size            12 bits
-			// vertical frame size              12 bits
-			// pixel aspect ratio                4 bits
-			// frame rate                        4 bits
-			// bitrate                          18 bits
-			// marker bit                        1 bit
-			// VBV buffer size                  10 bits
-			// constrained parameter flag        1 bit
-			// intra quant. matrix flag          1 bit
-			// intra quant. matrix values      512 bits (present if matrix flag == 1)
-			// non-intra quant. matrix flag      1 bit
-			// non-intra quant. matrix values  512 bits (present if matrix flag == 1)
-
-			$info['video']['dataformat'] = 'mpeg';
-
-			$VideoChunkOffset += (strlen(GETID3_MPEG_VIDEO_SEQUENCE_HEADER) - 1);
-
-			$FrameSizeDWORD = getid3_lib::BigEndian2Int(substr($MPEGstreamData, $VideoChunkOffset, 3));
-			$VideoChunkOffset += 3;
-
-			$AspectRatioFrameRateDWORD = getid3_lib::BigEndian2Int(substr($MPEGstreamData, $VideoChunkOffset, 1));
-			$VideoChunkOffset += 1;
-
-			$assortedinformation = getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $VideoChunkOffset, 4));
-			$VideoChunkOffset += 4;
-
-			$info['mpeg']['video']['raw']['framesize_horizontal'] = ($FrameSizeDWORD & 0xFFF000) >> 12; // 12 bits for horizontal frame size
-			$info['mpeg']['video']['raw']['framesize_vertical']   = ($FrameSizeDWORD & 0x000FFF);       // 12 bits for vertical frame size
-			$info['mpeg']['video']['raw']['pixel_aspect_ratio']   = ($AspectRatioFrameRateDWORD & 0xF0) >> 4;
-			$info['mpeg']['video']['raw']['frame_rate']           = ($AspectRatioFrameRateDWORD & 0x0F);
-
-			$info['mpeg']['video']['framesize_horizontal'] = $info['mpeg']['video']['raw']['framesize_horizontal'];
-			$info['mpeg']['video']['framesize_vertical']   = $info['mpeg']['video']['raw']['framesize_vertical'];
-
-			$info['mpeg']['video']['pixel_aspect_ratio']      = $this->MPEGvideoAspectRatioLookup($info['mpeg']['video']['raw']['pixel_aspect_ratio']);
-			$info['mpeg']['video']['pixel_aspect_ratio_text'] = $this->MPEGvideoAspectRatioTextLookup($info['mpeg']['video']['raw']['pixel_aspect_ratio']);
-			$info['mpeg']['video']['frame_rate']              = $this->MPEGvideoFramerateLookup($info['mpeg']['video']['raw']['frame_rate']);
-
-			$info['mpeg']['video']['raw']['bitrate']                =        getid3_lib::Bin2Dec(substr($assortedinformation,  0, 18));
-			$info['mpeg']['video']['raw']['marker_bit']             = (bool) getid3_lib::Bin2Dec(substr($assortedinformation, 18,  1));
-			$info['mpeg']['video']['raw']['vbv_buffer_size']        =        getid3_lib::Bin2Dec(substr($assortedinformation, 19, 10));
-			$info['mpeg']['video']['raw']['constrained_param_flag'] = (bool) getid3_lib::Bin2Dec(substr($assortedinformation, 29,  1));
-			$info['mpeg']['video']['raw']['intra_quant_flag']       = (bool) getid3_lib::Bin2Dec(substr($assortedinformation, 30,  1));
-			if ($info['mpeg']['video']['raw']['intra_quant_flag']) {
-
-				// read 512 bits
-				$info['mpeg']['video']['raw']['intra_quant']          = getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $VideoChunkOffset, 64));
-				$VideoChunkOffset += 64;
-
-				$info['mpeg']['video']['raw']['non_intra_quant_flag'] = (bool) getid3_lib::Bin2Dec(substr($info['mpeg']['video']['raw']['intra_quant'], 511,  1));
-				$info['mpeg']['video']['raw']['intra_quant']          =        getid3_lib::Bin2Dec(substr($assortedinformation, 31,  1)).substr(getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $VideoChunkOffset, 64)), 0, 511);
-
-				if ($info['mpeg']['video']['raw']['non_intra_quant_flag']) {
-					$info['mpeg']['video']['raw']['non_intra_quant'] = substr($MPEGstreamData, $VideoChunkOffset, 64);
-					$VideoChunkOffset += 64;
-				}
-
 			} else {
-
-				$info['mpeg']['video']['raw']['non_intra_quant_flag'] = (bool) getid3_lib::Bin2Dec(substr($assortedinformation, 31,  1));
-				if ($info['mpeg']['video']['raw']['non_intra_quant_flag']) {
-					$info['mpeg']['video']['raw']['non_intra_quant'] = substr($MPEGstreamData, $VideoChunkOffset, 64);
-					$VideoChunkOffset += 64;
-				}
-
+				$MPEGstreamDataOffset = $StartCodeOffset;
+				$prevStartCodeValue = $StartCodeValue;
+				$StartCodeValue = ord(substr($MPEGstreamData, $StartCodeOffset + 3, 1));
+//echo 'Found "'.strtoupper(dechex($StartCodeValue)).'" at offset '.($MPEGstreamBaseOffset + $StartCodeOffset).' ($MPEGstreamDataOffset = '.$MPEGstreamDataOffset.')<br>';
 			}
+			$MPEGstreamDataOffset += 4;
+			switch ($StartCodeValue) {
 
-			if ($info['mpeg']['video']['raw']['bitrate'] == 0x3FFFF) { // 18 set bits
+				case 0x00: // picture_start_code
+					if (!empty($info['mpeg']['video']['bitrate_mode']) && ($info['mpeg']['video']['bitrate_mode'] == 'vbr')) {
+						$bitstream = getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $StartCodeOffset + 4, 4));
+						$bitstreamoffset = 0;
 
-				$info['warning'][] = 'This version of getID3() ['.$this->getid3->version().'] cannot determine average bitrate of VBR MPEG video files';
-				$info['mpeg']['video']['bitrate_mode'] = 'vbr';
+						$PictureHeader = array();
 
-			} else {
+						$PictureHeader['temporal_reference']  = self::readBitsFromStream($bitstream, $bitstreamoffset, 10); // 10-bit unsigned integer associated with each input picture. It is incremented by one, modulo 1024, for each input frame. When a frame is coded as two fields the temporal reference in the picture header of both fields is the same. Following a group start header the temporal reference of the earliest picture (in display order) shall be reset to zero.
+						$PictureHeader['picture_coding_type'] = self::readBitsFromStream($bitstream, $bitstreamoffset,  3); //  3 bits for picture_coding_type
+						$PictureHeader['vbv_delay']           = self::readBitsFromStream($bitstream, $bitstreamoffset, 16); // 16 bits for vbv_delay
+						//... etc
 
-				$info['mpeg']['video']['bitrate']      = $info['mpeg']['video']['raw']['bitrate'] * 400;
-				$info['mpeg']['video']['bitrate_mode'] = 'cbr';
-				$info['video']['bitrate']              = $info['mpeg']['video']['bitrate'];
+						$FramesByGOP[$GOPcounter][] = $PictureHeader;
+					}
+					break;
 
-			}
+				case 0xB3: // sequence_header_code
+					// Note: purposely doing the less-pretty (and probably a bit slower) method of using string of bits rather than bitwise operations.
+					// Mostly because PHP 32-bit doesn't handle unsigned integers well for bitwise operation.
+					// Also the MPEG stream is designed as a bitstream and often doesn't align nicely with byte boundaries.
+					$info['video']['codec'] = 'MPEG-1'; // will be updated if extension_start_code found
 
-			$info['video']['resolution_x']       = $info['mpeg']['video']['framesize_horizontal'];
-			$info['video']['resolution_y']       = $info['mpeg']['video']['framesize_vertical'];
-			$info['video']['frame_rate']         = $info['mpeg']['video']['frame_rate'];
-			$info['video']['bitrate_mode']       = $info['mpeg']['video']['bitrate_mode'];
-			$info['video']['pixel_aspect_ratio'] = $info['mpeg']['video']['pixel_aspect_ratio'];
-			$info['video']['lossless']           = false;
-			$info['video']['bits_per_sample']    = 24;
+					$bitstream = getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $StartCodeOffset + 4, 8));
+					$bitstreamoffset = 0;
 
-		} else {
+					$info['mpeg']['video']['raw']['horizontal_size_value']       = self::readBitsFromStream($bitstream, $bitstreamoffset, 12); // 12 bits for horizontal frame size. Note: horizontal_size_extension, if present, will add 2 most-significant bits to this value
+					$info['mpeg']['video']['raw']['vertical_size_value']         = self::readBitsFromStream($bitstream, $bitstreamoffset, 12); // 12 bits for vertical frame size.   Note: vertical_size_extension,   if present, will add 2 most-significant bits to this value
+					$info['mpeg']['video']['raw']['aspect_ratio_information']    = self::readBitsFromStream($bitstream, $bitstreamoffset,  4); //  4 bits for aspect_ratio_information
+					$info['mpeg']['video']['raw']['frame_rate_code']             = self::readBitsFromStream($bitstream, $bitstreamoffset,  4); //  4 bits for Frame Rate id code
+					$info['mpeg']['video']['raw']['bitrate']                     = self::readBitsFromStream($bitstream, $bitstreamoffset, 18); // 18 bits for bit_rate_value (18 set bits = VBR, otherwise bitrate = this value * 400)
+					$marker_bit                                                  = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // The term "marker_bit" indicates a one bit field in which the value zero is forbidden. These marker bits are introduced at several points in the syntax to avoid start code emulation.
+					$info['mpeg']['video']['raw']['vbv_buffer_size']             = self::readBitsFromStream($bitstream, $bitstreamoffset, 10); // 10 bits vbv_buffer_size_value
+					$info['mpeg']['video']['raw']['constrained_param_flag']      = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: constrained_param_flag
+					$info['mpeg']['video']['raw']['load_intra_quantiser_matrix'] = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: load_intra_quantiser_matrix
 
-			$info['error'][] = 'Could not find start of video block in the first 100,000 bytes (or before end of file) - this might not be an MPEG-video file?';
+					if ($info['mpeg']['video']['raw']['load_intra_quantiser_matrix']) {
+						$bitstream .= getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $StartCodeOffset + 12, 64));
+						for ($i = 0; $i < 64; $i++) {
+							$info['mpeg']['video']['raw']['intra_quantiser_matrix'][$i] = self::readBitsFromStream($bitstream, $bitstreamoffset,  8);
+						}
+					}
+					$info['mpeg']['video']['raw']['load_non_intra_quantiser_matrix'] = self::readBitsFromStream($bitstream, $bitstreamoffset,  1);
 
-		}
+					if ($info['mpeg']['video']['raw']['load_non_intra_quantiser_matrix']) {
+						$bitstream .= getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $StartCodeOffset + 12 + ($info['mpeg']['video']['raw']['load_intra_quantiser_matrix'] ? 64 : 0), 64));
+						for ($i = 0; $i < 64; $i++) {
+							$info['mpeg']['video']['raw']['non_intra_quantiser_matrix'][$i] = self::readBitsFromStream($bitstream, $bitstreamoffset,  8);
+						}
+					}
 
-		//0x000001B3 begins the sequence_header of every MPEG video stream.
-		//But in MPEG-2, this header must immediately be followed by an
-		//extension_start_code (0x000001B5) with a sequence_extension ID (1).
-		//(This extension contains all the additional MPEG-2 stuff.)
-		//MPEG-1 doesn't have this extension, so that's a sure way to tell the
-		//difference between MPEG-1 and MPEG-2 video streams.
+					$info['mpeg']['video']['pixel_aspect_ratio']      =     self::videoAspectRatioLookup($info['mpeg']['video']['raw']['aspect_ratio_information']); // may be overridden later if file turns out to be MPEG-2
+					$info['mpeg']['video']['pixel_aspect_ratio_text'] = self::videoAspectRatioTextLookup($info['mpeg']['video']['raw']['aspect_ratio_information']); // may be overridden later if file turns out to be MPEG-2
+					$info['mpeg']['video']['frame_rate']              =       self::videoFramerateLookup($info['mpeg']['video']['raw']['frame_rate_code']);
+					if ($info['mpeg']['video']['raw']['bitrate'] == 0x3FFFF) { // 18 set bits = VBR
+						//$this->warning('This version of getID3() ['.$this->getid3->version().'] cannot determine average bitrate of VBR MPEG video files');
+						$info['mpeg']['video']['bitrate_mode'] = 'vbr';
+					} else {
+						$info['mpeg']['video']['bitrate']      = $info['mpeg']['video']['raw']['bitrate'] * 400;
+						$info['mpeg']['video']['bitrate_mode'] = 'cbr';
+						$info['video']['bitrate']              = $info['mpeg']['video']['bitrate'];
+					}
+					$info['video']['resolution_x']       = $info['mpeg']['video']['raw']['horizontal_size_value'];
+					$info['video']['resolution_y']       = $info['mpeg']['video']['raw']['vertical_size_value'];
+					$info['video']['frame_rate']         = $info['mpeg']['video']['frame_rate'];
+					$info['video']['bitrate_mode']       = $info['mpeg']['video']['bitrate_mode'];
+					$info['video']['pixel_aspect_ratio'] = $info['mpeg']['video']['pixel_aspect_ratio'];
+					$info['video']['lossless']           = false;
+					$info['video']['bits_per_sample']    = 24;
+					break;
 
-		if (substr($MPEGstreamData, $VideoChunkOffset, 4) == GETID3_MPEG_VIDEO_EXTENSION_START) {
-			$info['video']['codec'] = 'MPEG-2';
-		} else {
-			$info['video']['codec'] = 'MPEG-1';
-		}
+				case 0xB5: // extension_start_code
+					$info['video']['codec'] = 'MPEG-2';
+
+					$bitstream = getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $StartCodeOffset + 4, 8)); // 48 bits for Sequence Extension ID; 61 bits for Sequence Display Extension ID; 59 bits for Sequence Scalable Extension ID
+					$bitstreamoffset = 0;
+
+					$info['mpeg']['video']['raw']['extension_start_code_identifier'] = self::readBitsFromStream($bitstream, $bitstreamoffset,  4); //  4 bits for extension_start_code_identifier
+//echo $info['mpeg']['video']['raw']['extension_start_code_identifier'].'<br>';
+					switch ($info['mpeg']['video']['raw']['extension_start_code_identifier']) {
+						case  1: // 0001 Sequence Extension ID
+							$info['mpeg']['video']['raw']['profile_and_level_indication']    = self::readBitsFromStream($bitstream, $bitstreamoffset,  8); //  8 bits for profile_and_level_indication
+							$info['mpeg']['video']['raw']['progressive_sequence']            = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: progressive_sequence
+							$info['mpeg']['video']['raw']['chroma_format']                   = self::readBitsFromStream($bitstream, $bitstreamoffset,  2); //  2 bits for chroma_format
+							$info['mpeg']['video']['raw']['horizontal_size_extension']       = self::readBitsFromStream($bitstream, $bitstreamoffset,  2); //  2 bits for horizontal_size_extension
+							$info['mpeg']['video']['raw']['vertical_size_extension']         = self::readBitsFromStream($bitstream, $bitstreamoffset,  2); //  2 bits for vertical_size_extension
+							$info['mpeg']['video']['raw']['bit_rate_extension']              = self::readBitsFromStream($bitstream, $bitstreamoffset, 12); // 12 bits for bit_rate_extension
+							$marker_bit                                                      = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // The term "marker_bit" indicates a one bit field in which the value zero is forbidden. These marker bits are introduced at several points in the syntax to avoid start code emulation.
+							$info['mpeg']['video']['raw']['vbv_buffer_size_extension']       = self::readBitsFromStream($bitstream, $bitstreamoffset,  8); //  8 bits for vbv_buffer_size_extension
+							$info['mpeg']['video']['raw']['low_delay']                       = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: low_delay
+							$info['mpeg']['video']['raw']['frame_rate_extension_n']          = self::readBitsFromStream($bitstream, $bitstreamoffset,  2); //  2 bits for frame_rate_extension_n
+							$info['mpeg']['video']['raw']['frame_rate_extension_d']          = self::readBitsFromStream($bitstream, $bitstreamoffset,  5); //  5 bits for frame_rate_extension_d
+
+							$info['video']['resolution_x']          = ($info['mpeg']['video']['raw']['horizontal_size_extension'] << 12) | $info['mpeg']['video']['raw']['horizontal_size_value'];
+							$info['video']['resolution_y']          = ($info['mpeg']['video']['raw']['vertical_size_extension']   << 12) | $info['mpeg']['video']['raw']['vertical_size_value'];
+							$info['video']['interlaced']            = !$info['mpeg']['video']['raw']['progressive_sequence'];
+							$info['mpeg']['video']['interlaced']    = !$info['mpeg']['video']['raw']['progressive_sequence'];
+							$info['mpeg']['video']['chroma_format'] = self::chromaFormatTextLookup($info['mpeg']['video']['raw']['chroma_format']);
+
+							if (isset($info['mpeg']['video']['raw']['aspect_ratio_information'])) {
+								// MPEG-2 defines the aspect ratio flag differently from MPEG-1, but the MPEG-2 extension start code may occur after we've already looked up the aspect ratio assuming it was MPEG-1, so re-lookup assuming MPEG-2
+								// This must be done after the extended size is known, so the display aspect ratios can be converted to pixel aspect ratios.
+								$info['mpeg']['video']['pixel_aspect_ratio']      =     self::videoAspectRatioLookup($info['mpeg']['video']['raw']['aspect_ratio_information'], 2, $info['video']['resolution_x'], $info['video']['resolution_y']);
+								$info['mpeg']['video']['pixel_aspect_ratio_text'] = self::videoAspectRatioTextLookup($info['mpeg']['video']['raw']['aspect_ratio_information'], 2);
+								$info['video']['pixel_aspect_ratio'] = $info['mpeg']['video']['pixel_aspect_ratio'];
+								$info['video']['pixel_aspect_ratio_text'] = $info['mpeg']['video']['pixel_aspect_ratio_text'];
+							}
+
+							break;
+
+						case  2: // 0010 Sequence Display Extension ID
+							$info['mpeg']['video']['raw']['video_format']                    = self::readBitsFromStream($bitstream, $bitstreamoffset,  3); //  3 bits for video_format
+							$info['mpeg']['video']['raw']['colour_description']              = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: colour_description
+							if ($info['mpeg']['video']['raw']['colour_description']) {
+								$info['mpeg']['video']['raw']['colour_primaries']            = self::readBitsFromStream($bitstream, $bitstreamoffset,  8); //  8 bits for colour_primaries
+								$info['mpeg']['video']['raw']['transfer_characteristics']    = self::readBitsFromStream($bitstream, $bitstreamoffset,  8); //  8 bits for transfer_characteristics
+								$info['mpeg']['video']['raw']['matrix_coefficients']         = self::readBitsFromStream($bitstream, $bitstreamoffset,  8); //  8 bits for matrix_coefficients
+							}
+							$info['mpeg']['video']['raw']['display_horizontal_size']         = self::readBitsFromStream($bitstream, $bitstreamoffset, 14); // 14 bits for display_horizontal_size
+							$marker_bit                                                      = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // The term "marker_bit" indicates a one bit field in which the value zero is forbidden. These marker bits are introduced at several points in the syntax to avoid start code emulation.
+							$info['mpeg']['video']['raw']['display_vertical_size']           = self::readBitsFromStream($bitstream, $bitstreamoffset, 14); // 14 bits for display_vertical_size
+
+							$info['mpeg']['video']['video_format'] = self::videoFormatTextLookup($info['mpeg']['video']['raw']['video_format']);
+							break;
+
+						case  3: // 0011 Quant Matrix Extension ID
+							break;
+
+						case  5: // 0101 Sequence Scalable Extension ID
+							$info['mpeg']['video']['raw']['scalable_mode']                              = self::readBitsFromStream($bitstream, $bitstreamoffset,  2); //  2 bits for scalable_mode
+							$info['mpeg']['video']['raw']['layer_id']                                   = self::readBitsFromStream($bitstream, $bitstreamoffset,  4); //  4 bits for layer_id
+							if ($info['mpeg']['video']['raw']['scalable_mode'] == 1) { // "spatial scalability"
+								$info['mpeg']['video']['raw']['lower_layer_prediction_horizontal_size'] = self::readBitsFromStream($bitstream, $bitstreamoffset, 14); // 14 bits for lower_layer_prediction_horizontal_size
+								$marker_bit                                                             = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // The term "marker_bit" indicates a one bit field in which the value zero is forbidden. These marker bits are introduced at several points in the syntax to avoid start code emulation.
+								$info['mpeg']['video']['raw']['lower_layer_prediction_vertical_size']   = self::readBitsFromStream($bitstream, $bitstreamoffset, 14); // 14 bits for lower_layer_prediction_vertical_size
+								$info['mpeg']['video']['raw']['horizontal_subsampling_factor_m']        = self::readBitsFromStream($bitstream, $bitstreamoffset,  5); //  5 bits for horizontal_subsampling_factor_m
+								$info['mpeg']['video']['raw']['horizontal_subsampling_factor_n']        = self::readBitsFromStream($bitstream, $bitstreamoffset,  5); //  5 bits for horizontal_subsampling_factor_n
+								$info['mpeg']['video']['raw']['vertical_subsampling_factor_m']          = self::readBitsFromStream($bitstream, $bitstreamoffset,  5); //  5 bits for vertical_subsampling_factor_m
+								$info['mpeg']['video']['raw']['vertical_subsampling_factor_n']          = self::readBitsFromStream($bitstream, $bitstreamoffset,  5); //  5 bits for vertical_subsampling_factor_n
+							} elseif ($info['mpeg']['video']['raw']['scalable_mode'] == 3) { // "temporal scalability"
+								$info['mpeg']['video']['raw']['picture_mux_enable']                     = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: picture_mux_enable
+								if ($info['mpeg']['video']['raw']['picture_mux_enable']) {
+									$info['mpeg']['video']['raw']['mux_to_progressive_sequence']        = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: mux_to_progressive_sequence
+								}
+								$info['mpeg']['video']['raw']['picture_mux_order']                      = self::readBitsFromStream($bitstream, $bitstreamoffset,  3); //  3 bits for picture_mux_order
+								$info['mpeg']['video']['raw']['picture_mux_factor']                     = self::readBitsFromStream($bitstream, $bitstreamoffset,  3); //  3 bits for picture_mux_factor
+							}
+
+							$info['mpeg']['video']['scalable_mode'] = self::scalableModeTextLookup($info['mpeg']['video']['raw']['scalable_mode']);
+							break;
+
+						case  7: // 0111 Picture Display Extension ID
+							break;
+
+						case  8: // 1000 Picture Coding Extension ID
+							$info['mpeg']['video']['raw']['f_code_00']                       = self::readBitsFromStream($bitstream, $bitstreamoffset,  4); // 4 bits for f_code[0][0] (forward horizontal)
+							$info['mpeg']['video']['raw']['f_code_01']                       = self::readBitsFromStream($bitstream, $bitstreamoffset,  4); // 4 bits for f_code[0][1] (forward vertical)
+							$info['mpeg']['video']['raw']['f_code_10']                       = self::readBitsFromStream($bitstream, $bitstreamoffset,  4); // 4 bits for f_code[1][0] (backward horizontal)
+							$info['mpeg']['video']['raw']['f_code_11']                       = self::readBitsFromStream($bitstream, $bitstreamoffset,  4); // 4 bits for f_code[1][1] (backward vertical)
+							$info['mpeg']['video']['raw']['intra_dc_precision']              = self::readBitsFromStream($bitstream, $bitstreamoffset,  2); // 2 bits for intra_dc_precision
+							$info['mpeg']['video']['raw']['picture_structure']               = self::readBitsFromStream($bitstream, $bitstreamoffset,  2); // 2 bits for picture_structure
+							$info['mpeg']['video']['raw']['top_field_first']                 = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: top_field_first
+							$info['mpeg']['video']['raw']['frame_pred_frame_dct']            = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: frame_pred_frame_dct
+							$info['mpeg']['video']['raw']['concealment_motion_vectors']      = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: concealment_motion_vectors
+							$info['mpeg']['video']['raw']['q_scale_type']                    = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: q_scale_type
+							$info['mpeg']['video']['raw']['intra_vlc_format']                = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: intra_vlc_format
+							$info['mpeg']['video']['raw']['alternate_scan']                  = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: alternate_scan
+							$info['mpeg']['video']['raw']['repeat_first_field']              = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: repeat_first_field
+							$info['mpeg']['video']['raw']['chroma_420_type']                 = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: chroma_420_type
+							$info['mpeg']['video']['raw']['progressive_frame']               = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: progressive_frame
+							$info['mpeg']['video']['raw']['composite_display_flag']          = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: composite_display_flag
+							if ($info['mpeg']['video']['raw']['composite_display_flag']) {
+								$info['mpeg']['video']['raw']['v_axis']                      = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: v_axis
+								$info['mpeg']['video']['raw']['field_sequence']              = self::readBitsFromStream($bitstream, $bitstreamoffset,  3); // 3 bits for field_sequence
+								$info['mpeg']['video']['raw']['sub_carrier']                 = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // 1 bit flag: sub_carrier
+								$info['mpeg']['video']['raw']['burst_amplitude']             = self::readBitsFromStream($bitstream, $bitstreamoffset,  7); // 7 bits for burst_amplitude
+								$info['mpeg']['video']['raw']['sub_carrier_phase']           = self::readBitsFromStream($bitstream, $bitstreamoffset,  8); // 8 bits for sub_carrier_phase
+							}
+
+							$info['mpeg']['video']['intra_dc_precision_bits'] = $info['mpeg']['video']['raw']['intra_dc_precision'] + 8;
+							$info['mpeg']['video']['picture_structure'] = self::pictureStructureTextLookup($info['mpeg']['video']['raw']['picture_structure']);
+							break;
+
+						case  9: // 1001 Picture Spatial Scalable Extension ID
+							break;
+						case 10: // 1010 Picture Temporal Scalable Extension ID
+							break;
+
+						default:
+							$this->warning('Unexpected $info[mpeg][video][raw][extension_start_code_identifier] value of '.$info['mpeg']['video']['raw']['extension_start_code_identifier']);
+							break;
+					}
+					break;
 
 
-		$AudioChunkOffset = 0;
-		while (true) {
-			while (substr($MPEGstreamData, $AudioChunkOffset++, 4) !== GETID3_MPEG_AUDIO_START) {
-				if ($AudioChunkOffset >= $MPEGstreamDataLength) {
-					break 2;
-				}
-			}
+				case 0xB8: // group_of_pictures_header
+					$GOPcounter++;
+					if (!empty($info['mpeg']['video']['bitrate_mode']) && ($info['mpeg']['video']['bitrate_mode'] == 'vbr')) {
+						$bitstream = getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $StartCodeOffset + 4, 4)); // 27 bits needed for group_of_pictures_header
+						$bitstreamoffset = 0;
 
-			$getid3_temp = new getID3();
-			$getid3_temp->openfile($this->getid3->filename);
-			$getid3_temp->info = $info;
-			$getid3_mp3 = new getid3_mp3($getid3_temp);
-			for ($i = 0; $i <= 7; $i++) {
-				// some files have the MPEG-audio header 8 bytes after the end of the $00 $00 $01 $C0 signature, some have it up to 13 bytes (or more?) after
-				// I have no idea why or what the difference is, so this is a stupid hack.
-				// If anybody has any better idea of what's going on, please let me know - info@getid3.org
-				fseek($getid3_temp->fp, ftell($this->getid3->fp), SEEK_SET);
-				$getid3_temp->info = $info; // only overwrite real data if valid header found
-				if ($getid3_mp3->decodeMPEGaudioHeader(($AudioChunkOffset + 3) + 8 + $i, $getid3_temp->info, false)) {
-					$info = $getid3_temp->info;
-					$info['audio']['bitrate_mode']    = 'cbr';
-					$info['audio']['lossless']        = false;
+						$GOPheader = array();
+
+						$GOPheader['byte_offset'] = $MPEGstreamBaseOffset + $StartCodeOffset;
+						$GOPheader['drop_frame_flag']    = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: drop_frame_flag
+						$GOPheader['time_code_hours']    = self::readBitsFromStream($bitstream, $bitstreamoffset,  5); //  5 bits for time_code_hours
+						$GOPheader['time_code_minutes']  = self::readBitsFromStream($bitstream, $bitstreamoffset,  6); //  6 bits for time_code_minutes
+						$marker_bit                      = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); // The term "marker_bit" indicates a one bit field in which the value zero is forbidden. These marker bits are introduced at several points in the syntax to avoid start code emulation.
+						$GOPheader['time_code_seconds']  = self::readBitsFromStream($bitstream, $bitstreamoffset,  6); //  6 bits for time_code_seconds
+						$GOPheader['time_code_pictures'] = self::readBitsFromStream($bitstream, $bitstreamoffset,  6); //  6 bits for time_code_pictures
+						$GOPheader['closed_gop']         = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: closed_gop
+						$GOPheader['broken_link']        = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: broken_link
+
+						$time_code_separator = ($GOPheader['drop_frame_flag'] ? ';' : ':'); // While non-drop time code is displayed with colons separating the digit pairs "HH:MM:SS:FF" drop frame is usually represented with a semi-colon (;) or period (.) as the divider between all the digit pairs "HH;MM;SS;FF", "HH.MM.SS.FF"
+						$GOPheader['time_code'] = sprintf('%02d'.$time_code_separator.'%02d'.$time_code_separator.'%02d'.$time_code_separator.'%02d', $GOPheader['time_code_hours'], $GOPheader['time_code_minutes'], $GOPheader['time_code_seconds'], $GOPheader['time_code_pictures']);
+
+						$info['mpeg']['group_of_pictures'][] = $GOPheader;
+					}
+					break;
+
+				case 0xC0: // audio stream
+				case 0xC1: // audio stream
+				case 0xC2: // audio stream
+				case 0xC3: // audio stream
+				case 0xC4: // audio stream
+				case 0xC5: // audio stream
+				case 0xC6: // audio stream
+				case 0xC7: // audio stream
+				case 0xC8: // audio stream
+				case 0xC9: // audio stream
+				case 0xCA: // audio stream
+				case 0xCB: // audio stream
+				case 0xCC: // audio stream
+				case 0xCD: // audio stream
+				case 0xCE: // audio stream
+				case 0xCF: // audio stream
+				case 0xD0: // audio stream
+				case 0xD1: // audio stream
+				case 0xD2: // audio stream
+				case 0xD3: // audio stream
+				case 0xD4: // audio stream
+				case 0xD5: // audio stream
+				case 0xD6: // audio stream
+				case 0xD7: // audio stream
+				case 0xD8: // audio stream
+				case 0xD9: // audio stream
+				case 0xDA: // audio stream
+				case 0xDB: // audio stream
+				case 0xDC: // audio stream
+				case 0xDD: // audio stream
+				case 0xDE: // audio stream
+				case 0xDF: // audio stream
+				//case 0xE0: // video stream
+				//case 0xE1: // video stream
+				//case 0xE2: // video stream
+				//case 0xE3: // video stream
+				//case 0xE4: // video stream
+				//case 0xE5: // video stream
+				//case 0xE6: // video stream
+				//case 0xE7: // video stream
+				//case 0xE8: // video stream
+				//case 0xE9: // video stream
+				//case 0xEA: // video stream
+				//case 0xEB: // video stream
+				//case 0xEC: // video stream
+				//case 0xED: // video stream
+				//case 0xEE: // video stream
+				//case 0xEF: // video stream
+					if (isset($ParsedAVchannels[$StartCodeValue])) {
+						break;
+					}
+					$ParsedAVchannels[$StartCodeValue] = $StartCodeValue;
+					// http://en.wikipedia.org/wiki/Packetized_elementary_stream
+					// http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
+/*
+					$PackedElementaryStream = array();
+					if ($StartCodeValue >= 0xE0) {
+						$PackedElementaryStream['stream_type'] = 'video';
+						$PackedElementaryStream['stream_id']   = $StartCodeValue - 0xE0;
+					} else {
+						$PackedElementaryStream['stream_type'] = 'audio';
+						$PackedElementaryStream['stream_id']   = $StartCodeValue - 0xC0;
+					}
+					$PackedElementaryStream['packet_length'] = getid3_lib::BigEndian2Int(substr($MPEGstreamData, $StartCodeOffset + 4, 2));
+
+					$bitstream = getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $StartCodeOffset + 6, 3)); // more may be needed below
+					$bitstreamoffset = 0;
+
+					$PackedElementaryStream['marker_bits']               = self::readBitsFromStream($bitstream, $bitstreamoffset,  2); //  2 bits for marker_bits -- should be "10" = 2
+echo 'marker_bits = '.$PackedElementaryStream['marker_bits'].'<br>';
+					$PackedElementaryStream['scrambling_control']        = self::readBitsFromStream($bitstream, $bitstreamoffset,  2); //  2 bits for scrambling_control -- 00 implies not scrambled
+					$PackedElementaryStream['priority']                  = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: priority
+					$PackedElementaryStream['data_alignment_indicator']  = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: data_alignment_indicator -- 1 indicates that the PES packet header is immediately followed by the video start code or audio syncword
+					$PackedElementaryStream['copyright']                 = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: copyright -- 1 implies copyrighted
+					$PackedElementaryStream['original_or_copy']          = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: original_or_copy -- 1 implies original
+					$PackedElementaryStream['pts_flag']                  = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: pts_flag -- Presentation Time Stamp
+					$PackedElementaryStream['dts_flag']                  = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: dts_flag -- Decode Time Stamp
+					$PackedElementaryStream['escr_flag']                 = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: escr_flag -- Elementary Stream Clock Reference
+					$PackedElementaryStream['es_rate_flag']              = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: es_rate_flag -- Elementary Stream [data] Rate
+					$PackedElementaryStream['dsm_trick_mode_flag']       = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: dsm_trick_mode_flag -- DSM trick mode - not used by DVD
+					$PackedElementaryStream['additional_copy_info_flag'] = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: additional_copy_info_flag
+					$PackedElementaryStream['crc_flag']                  = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: crc_flag
+					$PackedElementaryStream['extension_flag']            = self::readBitsFromStream($bitstream, $bitstreamoffset,  1); //  1 bit flag: extension_flag
+					$PackedElementaryStream['pes_remain_header_length']  = self::readBitsFromStream($bitstream, $bitstreamoffset,  8); //  1 bit flag: priority
+
+					$additional_header_bytes = 0;
+					$additional_header_bytes += ($PackedElementaryStream['pts_flag']                  ? 5 : 0);
+					$additional_header_bytes += ($PackedElementaryStream['dts_flag']                  ? 5 : 0);
+					$additional_header_bytes += ($PackedElementaryStream['escr_flag']                 ? 6 : 0);
+					$additional_header_bytes += ($PackedElementaryStream['es_rate_flag']              ? 3 : 0);
+					$additional_header_bytes += ($PackedElementaryStream['additional_copy_info_flag'] ? 1 : 0);
+					$additional_header_bytes += ($PackedElementaryStream['crc_flag']                  ? 2 : 0);
+					$additional_header_bytes += ($PackedElementaryStream['extension_flag']            ? 1 : 0);
+$PackedElementaryStream['additional_header_bytes'] = $additional_header_bytes;
+					$bitstream .= getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $StartCodeOffset + 9, $additional_header_bytes));
+
+					$info['mpeg']['packed_elementary_streams'][$PackedElementaryStream['stream_type']][$PackedElementaryStream['stream_id']][] = $PackedElementaryStream;
+*/
+					$getid3_temp = new getID3();
+					$getid3_temp->openfile($this->getid3->filename, $this->getid3->info['filesize'], $this->getid3->fp);
+					$getid3_temp->info = $info;
+					$getid3_mp3 = new getid3_mp3($getid3_temp);
+					for ($i = 0; $i <= 7; $i++) {
+						// some files have the MPEG-audio header 8 bytes after the end of the $00 $00 $01 $C0 signature, some have it up to 13 bytes (or more?) after
+						// I have no idea why or what the difference is, so this is a stupid hack.
+						// If anybody has any better idea of what's going on, please let me know - info@getid3.org
+						$getid3_temp->info = $info; // only overwrite real data if valid header found
+//echo 'audio at? '.($MPEGstreamBaseOffset + $StartCodeOffset + 4 + 8 + $i).'<br>';
+						if ($getid3_mp3->decodeMPEGaudioHeader($MPEGstreamBaseOffset + $StartCodeOffset + 4 + 8 + $i, $getid3_temp->info, false)) {
+//echo 'yes!<br>';
+							$info = $getid3_temp->info;
+							$info['audio']['bitrate_mode'] = 'cbr';
+							$info['audio']['lossless']     = false;
+							break;
+						}
+					}
 					unset($getid3_temp, $getid3_mp3);
-					break 2;
-				}
+					break;
+
+				case 0xBC: // Program Stream Map
+				case 0xBD: // Private stream 1 (non MPEG audio, subpictures)
+				case 0xBE: // Padding stream
+				case 0xBF: // Private stream 2 (navigation data)
+				case 0xF0: // ECM stream
+				case 0xF1: // EMM stream
+				case 0xF2: // DSM-CC stream
+				case 0xF3: // ISO/IEC_13522_stream
+				case 0xF4: // ITU-I Rec. H.222.1 type A
+				case 0xF5: // ITU-I Rec. H.222.1 type B
+				case 0xF6: // ITU-I Rec. H.222.1 type C
+				case 0xF7: // ITU-I Rec. H.222.1 type D
+				case 0xF8: // ITU-I Rec. H.222.1 type E
+				case 0xF9: // ancilliary stream
+				case 0xFA: // ISO/IEC 14496-1 SL-packtized stream
+				case 0xFB: // ISO/IEC 14496-1 FlexMux stream
+				case 0xFC: // metadata stream
+				case 0xFD: // extended stream ID
+				case 0xFE: // reserved data stream
+				case 0xFF: // program stream directory
+					// ignore
+					break;
+
+				default:
+					// ignore
+					break;
 			}
-			unset($getid3_temp, $getid3_mp3);
+		} while (true);
+
+
+
+//		// Temporary hack to account for interleaving overhead:
+//		if (!empty($info['video']['bitrate']) && !empty($info['audio']['bitrate'])) {
+//			$info['playtime_seconds'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / ($info['video']['bitrate'] + $info['audio']['bitrate']);
+//
+//			// Interleaved MPEG audio/video files have a certain amount of overhead that varies
+//			// by both video and audio bitrates, and not in any sensible, linear/logarithmic pattern
+//			// Use interpolated lookup tables to approximately guess how much is overhead, because
+//			// playtime is calculated as filesize / total-bitrate
+//			$info['playtime_seconds'] *= self::systemNonOverheadPercentage($info['video']['bitrate'], $info['audio']['bitrate']);
+//
+//			//switch ($info['video']['bitrate']) {
+//			//	case('5000000'):
+//			//		$multiplier = 0.93292642112380355828048824319889;
+//			//		break;
+//			//	case('5500000'):
+//			//		$multiplier = 0.93582895375200989965359777343219;
+//			//		break;
+//			//	case('6000000'):
+//			//		$multiplier = 0.93796247714820932532911373859139;
+//			//		break;
+//			//	case('7000000'):
+//			//		$multiplier = 0.9413264083635103463010117778776;
+//			//		break;
+//			//	default:
+//			//		$multiplier = 1;
+//			//		break;
+//			//}
+//			//$info['playtime_seconds'] *= $multiplier;
+//			//$this->warning('Interleaved MPEG audio/video playtime may be inaccurate. With current hack should be within a few seconds of accurate. Report to info@getid3.org if off by more than 10 seconds.');
+//			if ($info['video']['bitrate'] < 50000) {
+//				$this->warning('Interleaved MPEG audio/video playtime may be slightly inaccurate for video bitrates below 100kbps. Except in extreme low-bitrate situations, error should be less than 1%. Report to info@getid3.org if greater than this.');
+//			}
+//		}
+//
+/*
+$time_prev = 0;
+$byte_prev = 0;
+$vbr_bitrates = array();
+foreach ($info['mpeg']['group_of_pictures'] as $gopkey => $gopdata) {
+	$time_this = ($gopdata['time_code_hours'] * 3600) + ($gopdata['time_code_minutes'] * 60) + $gopdata['time_code_seconds'] + ($gopdata['time_code_seconds'] / 30);
+	$byte_this = $gopdata['byte_offset'];
+	if ($gopkey > 0) {
+		if ($time_this > $time_prev) {
+			$bytedelta = $byte_this - $byte_prev;
+			$timedelta = $time_this - $time_prev;
+			$this_bitrate = ($bytedelta * 8) / $timedelta;
+echo $gopkey.': ('.number_format($time_prev, 2).'-'.number_format($time_this, 2).') '.number_format($bytedelta).' bytes over '.number_format($timedelta, 3).' seconds = '.number_format($this_bitrate / 1000, 2).'kbps<br>';
+			$time_prev = $time_this;
+			$byte_prev = $byte_this;
+			$vbr_bitrates[] = $this_bitrate;
 		}
-
-		// Temporary hack to account for interleaving overhead:
-		if (!empty($info['video']['bitrate']) && !empty($info['audio']['bitrate'])) {
-			$info['playtime_seconds'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / ($info['video']['bitrate'] + $info['audio']['bitrate']);
-
-			// Interleaved MPEG audio/video files have a certain amount of overhead that varies
-			// by both video and audio bitrates, and not in any sensible, linear/logarithmic patter
-			// Use interpolated lookup tables to approximately guess how much is overhead, because
-			// playtime is calculated as filesize / total-bitrate
-			$info['playtime_seconds'] *= $this->MPEGsystemNonOverheadPercentage($info['video']['bitrate'], $info['audio']['bitrate']);
-
-			//switch ($info['video']['bitrate']) {
-			//	case('5000000'):
-			//		$multiplier = 0.93292642112380355828048824319889;
-			//		break;
-			//	case('5500000'):
-			//		$multiplier = 0.93582895375200989965359777343219;
-			//		break;
-			//	case('6000000'):
-			//		$multiplier = 0.93796247714820932532911373859139;
-			//		break;
-			//	case('7000000'):
-			//		$multiplier = 0.9413264083635103463010117778776;
-			//		break;
-			//	default:
-			//		$multiplier = 1;
-			//		break;
-			//}
-			//$info['playtime_seconds'] *= $multiplier;
-			//$info['warning'][] = 'Interleaved MPEG audio/video playtime may be inaccurate. With current hack should be within a few seconds of accurate. Report to info@getid3.org if off by more than 10 seconds.';
-			if ($info['video']['bitrate'] < 50000) {
-				$info['warning'][] = 'Interleaved MPEG audio/video playtime may be slightly inaccurate for video bitrates below 100kbps. Except in extreme low-bitrate situations, error should be less than 1%. Report to info@getid3.org if greater than this.';
+	}
+}
+echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($vbr_bitrates), 1).'<br>';
+*/
+//echo '<pre>'.print_r($FramesByGOP, true).'</pre>';
+		if (!empty($info['mpeg']['video']['bitrate_mode']) && ($info['mpeg']['video']['bitrate_mode'] == 'vbr')) {
+			$last_GOP_id = max(array_keys($FramesByGOP));
+			$frames_in_last_GOP = count($FramesByGOP[$last_GOP_id]);
+			$gopdata = &$info['mpeg']['group_of_pictures'][$last_GOP_id];
+			$info['playtime_seconds'] = ($gopdata['time_code_hours'] * 3600) + ($gopdata['time_code_minutes'] * 60) + $gopdata['time_code_seconds'] + (($gopdata['time_code_pictures'] + $frames_in_last_GOP + 1) / $info['mpeg']['video']['frame_rate']);
+			if (!isset($info['video']['bitrate'])) {
+				$overall_bitrate = ($info['avdataend'] - $info['avdataoffset']) * 8 / $info['playtime_seconds'];
+				$info['video']['bitrate'] = $overall_bitrate - (isset($info['audio']['bitrate']) ? $info['audio']['bitrate'] : 0);
 			}
+			unset($info['mpeg']['group_of_pictures']);
 		}
 
 		return true;
 	}
 
+	/**
+	 * @param string $bitstream
+	 * @param int    $bitstreamoffset
+	 * @param int    $bits_to_read
+	 * @param bool $return_singlebit_as_boolean
+	 *
+	 * @return bool|int
+	 */
+	private function readBitsFromStream(&$bitstream, &$bitstreamoffset, $bits_to_read, $return_singlebit_as_boolean=true) {
+		$return = bindec(substr($bitstream, $bitstreamoffset, $bits_to_read));
+		$bitstreamoffset += $bits_to_read;
+		if (($bits_to_read == 1) && $return_singlebit_as_boolean) {
+			$return = (bool) $return;
+		}
+		return $return;
+	}
 
-	public function MPEGsystemNonOverheadPercentage($VideoBitrate, $AudioBitrate) {
+	/**
+	 * @param int $VideoBitrate
+	 * @param int $AudioBitrate
+	 *
+	 * @return float|int
+	 */
+	public static function systemNonOverheadPercentage($VideoBitrate, $AudioBitrate) {
 		$OverheadPercentage = 0;
 
 		$AudioBitrate = max(min($AudioBitrate / 1000,   384), 32); // limit to range of 32kbps - 384kbps (should be only legal bitrates, but maybe VBR?)
@@ -277,20 +590,93 @@ class getid3_mpeg extends getid3_handler
 		return $OverheadPercentage;
 	}
 
-
-	public function MPEGvideoFramerateLookup($rawframerate) {
-		$MPEGvideoFramerateLookup = array(0, 23.976, 24, 25, 29.97, 30, 50, 59.94, 60);
-		return (isset($MPEGvideoFramerateLookup[$rawframerate]) ? (float) $MPEGvideoFramerateLookup[$rawframerate] : (float) 0);
+	/**
+	 * @param int $rawframerate
+	 *
+	 * @return float
+	 */
+	public static function videoFramerateLookup($rawframerate) {
+		$lookup = array(0, 23.976, 24, 25, 29.97, 30, 50, 59.94, 60);
+		return (float) (isset($lookup[$rawframerate]) ? $lookup[$rawframerate] : 0);
 	}
 
-	public function MPEGvideoAspectRatioLookup($rawaspectratio) {
-		$MPEGvideoAspectRatioLookup = array(0, 1, 0.6735, 0.7031, 0.7615, 0.8055, 0.8437, 0.8935, 0.9157, 0.9815, 1.0255, 1.0695, 1.0950, 1.1575, 1.2015, 0);
-		return (isset($MPEGvideoAspectRatioLookup[$rawaspectratio]) ? (float) $MPEGvideoAspectRatioLookup[$rawaspectratio] : (float) 0);
+	/**
+	 * @param int $rawaspectratio
+	 * @param int $mpeg_version
+	 * @param int $width
+	 * @param int $height
+	 *
+	 * @return float
+	 */
+	public static function videoAspectRatioLookup($rawaspectratio, $mpeg_version=1, $width=0, $height=0) {
+		$lookup = array(
+			1 => array(0, 1, 0.6735, 0.7031, 0.7615, 0.8055, 0.8437, 0.8935, 0.9157, 0.9815, 1.0255, 1.0695, 1.0950, 1.1575, 1.2015, 0),
+			2 => array(0, 1, 1.3333, 1.7778, 2.2100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+		);
+		$ratio = (float) (isset($lookup[$mpeg_version][$rawaspectratio]) ? $lookup[$mpeg_version][$rawaspectratio] : 0);
+		if ($mpeg_version == 2 && $ratio != 1) {
+			// Calculate pixel aspect ratio from MPEG-2 display aspect ratio
+			$ratio = $ratio * $height / $width;
+		}
+		return $ratio;
 	}
 
-	public function MPEGvideoAspectRatioTextLookup($rawaspectratio) {
-		$MPEGvideoAspectRatioTextLookup = array('forbidden', 'square pixels', '0.6735', '16:9, 625 line, PAL', '0.7615', '0.8055', '16:9, 525 line, NTSC', '0.8935', '4:3, 625 line, PAL, CCIR601', '0.9815', '1.0255', '1.0695', '4:3, 525 line, NTSC, CCIR601', '1.1575', '1.2015', 'reserved');
-		return (isset($MPEGvideoAspectRatioTextLookup[$rawaspectratio]) ? $MPEGvideoAspectRatioTextLookup[$rawaspectratio] : '');
+	/**
+	 * @param int $rawaspectratio
+	 * @param int $mpeg_version
+	 *
+	 * @return string
+	 */
+	public static function videoAspectRatioTextLookup($rawaspectratio, $mpeg_version=1) {
+		$lookup = array(
+			1 => array('forbidden', 'square pixels', '0.6735', '16:9, 625 line, PAL', '0.7615', '0.8055', '16:9, 525 line, NTSC', '0.8935', '4:3, 625 line, PAL, CCIR601', '0.9815', '1.0255', '1.0695', '4:3, 525 line, NTSC, CCIR601', '1.1575', '1.2015', 'reserved'),
+			2 => array('forbidden', 'square pixels', '4:3', '16:9', '2.21:1', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved'), // http://dvd.sourceforge.net/dvdinfo/mpeghdrs.html
+		);
+		return (isset($lookup[$mpeg_version][$rawaspectratio]) ? $lookup[$mpeg_version][$rawaspectratio] : '');
+	}
+
+	/**
+	 * @param int $video_format
+	 *
+	 * @return string
+	 */
+	public static function videoFormatTextLookup($video_format) {
+		// ISO/IEC 13818-2, section 6.3.6, Table 6-6. Meaning of video_format
+		$lookup = array('component', 'PAL', 'NTSC', 'SECAM', 'MAC', 'Unspecified video format', 'reserved(6)', 'reserved(7)');
+		return (isset($lookup[$video_format]) ? $lookup[$video_format] : '');
+	}
+
+	/**
+	 * @param int $scalable_mode
+	 *
+	 * @return string
+	 */
+	public static function scalableModeTextLookup($scalable_mode) {
+		// ISO/IEC 13818-2, section 6.3.8, Table 6-10. Definition of scalable_mode
+		$lookup = array('data partitioning', 'spatial scalability', 'SNR scalability', 'temporal scalability');
+		return (isset($lookup[$scalable_mode]) ? $lookup[$scalable_mode] : '');
+	}
+
+	/**
+	 * @param int $picture_structure
+	 *
+	 * @return string
+	 */
+	public static function pictureStructureTextLookup($picture_structure) {
+		// ISO/IEC 13818-2, section 6.3.11, Table 6-14 Meaning of picture_structure
+		$lookup = array('reserved', 'Top Field', 'Bottom Field', 'Frame picture');
+		return (isset($lookup[$picture_structure]) ? $lookup[$picture_structure] : '');
+	}
+
+	/**
+	 * @param int $chroma_format
+	 *
+	 * @return string
+	 */
+	public static function chromaFormatTextLookup($chroma_format) {
+		// ISO/IEC 13818-2, section 6.3.11, Table 6-14 Meaning of picture_structure
+		$lookup = array('reserved', '4:2:0', '4:2:2', '4:4:4');
+		return (isset($lookup[$chroma_format]) ? $lookup[$chroma_format] : '');
 	}
 
 }

--- a/application/libraries/getid3/module.audio-video.nsv.php
+++ b/application/libraries/getid3/module.audio-video.nsv.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.nsv.php                                        //
@@ -13,15 +14,20 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_nsv extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$NSVheader = fread($this->getid3->fp, 4);
+		$this->fseek($info['avdataoffset']);
+		$NSVheader = $this->fread(4);
 
 		switch ($NSVheader) {
 			case 'NSVs':
@@ -46,29 +52,33 @@ class getid3_nsv extends getid3_handler
 				break;
 
 			default:
-				$info['error'][] = 'Expecting "NSVs" or "NSVf" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($NSVheader).'"';
+				$this->error('Expecting "NSVs" or "NSVf" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($NSVheader).'"');
 				return false;
-				break;
 		}
 
 		if (!isset($info['nsv']['NSVf'])) {
-			$info['warning'][] = 'NSVf header not present - cannot calculate playtime or bitrate';
+			$this->warning('NSVf header not present - cannot calculate playtime or bitrate');
 		}
 
 		return true;
 	}
 
+	/**
+	 * @param int $fileoffset
+	 *
+	 * @return bool
+	 */
 	public function getNSVsHeaderFilepointer($fileoffset) {
 		$info = &$this->getid3->info;
-		fseek($this->getid3->fp, $fileoffset, SEEK_SET);
-		$NSVsheader = fread($this->getid3->fp, 28);
+		$this->fseek($fileoffset);
+		$NSVsheader = $this->fread(28);
 		$offset = 0;
 
 		$info['nsv']['NSVs']['identifier']      =                  substr($NSVsheader, $offset, 4);
 		$offset += 4;
 
 		if ($info['nsv']['NSVs']['identifier'] != 'NSVs') {
-			$info['error'][] = 'expected "NSVs" at offset ('.$fileoffset.'), found "'.$info['nsv']['NSVs']['identifier'].'" instead';
+			$this->error('expected "NSVs" at offset ('.$fileoffset.'), found "'.$info['nsv']['NSVs']['identifier'].'" instead');
 			unset($info['nsv']['NSVs']);
 			return false;
 		}
@@ -131,17 +141,23 @@ class getid3_nsv extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int  $fileoffset
+	 * @param bool $getTOCoffsets
+	 *
+	 * @return bool
+	 */
 	public function getNSVfHeaderFilepointer($fileoffset, $getTOCoffsets=false) {
 		$info = &$this->getid3->info;
-		fseek($this->getid3->fp, $fileoffset, SEEK_SET);
-		$NSVfheader = fread($this->getid3->fp, 28);
+		$this->fseek($fileoffset);
+		$NSVfheader = $this->fread(28);
 		$offset = 0;
 
 		$info['nsv']['NSVf']['identifier']    =                  substr($NSVfheader, $offset, 4);
 		$offset += 4;
 
 		if ($info['nsv']['NSVf']['identifier'] != 'NSVf') {
-			$info['error'][] = 'expected "NSVf" at offset ('.$fileoffset.'), found "'.$info['nsv']['NSVf']['identifier'].'" instead';
+			$this->error('expected "NSVf" at offset ('.$fileoffset.'), found "'.$info['nsv']['NSVf']['identifier'].'" instead');
 			unset($info['nsv']['NSVf']);
 			return false;
 		}
@@ -154,7 +170,7 @@ class getid3_nsv extends getid3_handler
 		$offset += 4;
 
 		if ($info['nsv']['NSVf']['file_size'] > $info['avdataend']) {
-			$info['warning'][] = 'truncated file - NSVf header indicates '.$info['nsv']['NSVf']['file_size'].' bytes, file actually '.$info['avdataend'].' bytes';
+			$this->warning('truncated file - NSVf header indicates '.$info['nsv']['NSVf']['file_size'].' bytes, file actually '.$info['avdataend'].' bytes');
 		}
 
 		$info['nsv']['NSVf']['playtime_ms']   = getid3_lib::LittleEndian2Int(substr($NSVfheader, $offset, 4));
@@ -167,11 +183,11 @@ class getid3_nsv extends getid3_handler
 		$offset += 4;
 
 		if ($info['nsv']['NSVf']['playtime_ms'] == 0) {
-			$info['error'][] = 'Corrupt NSV file: NSVf.playtime_ms == zero';
+			$this->error('Corrupt NSV file: NSVf.playtime_ms == zero');
 			return false;
 		}
 
-		$NSVfheader .= fread($this->getid3->fp, $info['nsv']['NSVf']['meta_size'] + (4 * $info['nsv']['NSVf']['TOC_entries_1']) + (4 * $info['nsv']['NSVf']['TOC_entries_2']));
+		$NSVfheader .= $this->fread($info['nsv']['NSVf']['meta_size'] + (4 * $info['nsv']['NSVf']['TOC_entries_1']) + (4 * $info['nsv']['NSVf']['TOC_entries_2']));
 		$NSVfheaderlength = strlen($NSVfheader);
 		$info['nsv']['NSVf']['metadata']      =                  substr($NSVfheader, $offset, $info['nsv']['NSVf']['meta_size']);
 		$offset += $info['nsv']['NSVf']['meta_size'];
@@ -204,18 +220,22 @@ class getid3_nsv extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @param int $framerateindex
+	 *
+	 * @return float|false
+	 */
 	public static function NSVframerateLookup($framerateindex) {
 		if ($framerateindex <= 127) {
 			return (float) $framerateindex;
 		}
 		static $NSVframerateLookup = array();
 		if (empty($NSVframerateLookup)) {
-			$NSVframerateLookup[129] = (float) 29.970;
-			$NSVframerateLookup[131] = (float) 23.976;
-			$NSVframerateLookup[133] = (float) 14.985;
-			$NSVframerateLookup[197] = (float) 59.940;
-			$NSVframerateLookup[199] = (float) 47.952;
+			$NSVframerateLookup[129] = 29.970;
+			$NSVframerateLookup[131] = 23.976;
+			$NSVframerateLookup[133] = 14.985;
+			$NSVframerateLookup[197] = 59.940;
+			$NSVframerateLookup[199] = 47.952;
 		}
 		return (isset($NSVframerateLookup[$framerateindex]) ? $NSVframerateLookup[$framerateindex] : false);
 	}

--- a/application/libraries/getid3/module.audio-video.quicktime.php
+++ b/application/libraries/getid3/module.audio-video.quicktime.php
@@ -1,19 +1,25 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio-video.quicktime.php                            //
 // module for analyzing Quicktime and MP3-in-MP4 files         //
 // dependencies: module.audio.mp3.php                          //
+// dependencies: module.tag.id3v2.php                          //
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.mp3.php', __FILE__, true);
+getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.id3v2.php', __FILE__, true); // needed for ISO 639-2 language code lookup
 
 class getid3_quicktime extends getid3_handler
 {
@@ -21,6 +27,9 @@ class getid3_quicktime extends getid3_handler
 	public $ReturnAtomData        = true;
 	public $ParseAllPossibleAtoms = false;
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -28,61 +37,1459 @@ class getid3_quicktime extends getid3_handler
 		$info['quicktime']['hinting']    = false;
 		$info['quicktime']['controller'] = 'standard'; // may be overridden if 'ctyp' atom is present
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+		$this->fseek($info['avdataoffset']);
 
 		$offset      = 0;
 		$atomcounter = 0;
-
+		$atom_data_read_buffer_size = $info['php_memory_limit'] ? round($info['php_memory_limit'] / 4) : $this->getid3->option_fread_buffer_size * 1024; // set read buffer to 25% of PHP memory limit (if one is specified), otherwise use option_fread_buffer_size [default: 32MB]
 		while ($offset < $info['avdataend']) {
 			if (!getid3_lib::intValueSupported($offset)) {
-				$info['error'][] = 'Unable to parse atom at offset '.$offset.' because beyond '.round(PHP_INT_MAX / 1073741824).'GB limit of PHP filesystem functions';
+				$this->error('Unable to parse atom at offset '.$offset.' because beyond '.round(PHP_INT_MAX / 1073741824).'GB limit of PHP filesystem functions');
 				break;
 			}
-			fseek($this->getid3->fp, $offset, SEEK_SET);
-			$AtomHeader = fread($this->getid3->fp, 8);
+			$this->fseek($offset);
+			$AtomHeader = $this->fread(8);
 
 			$atomsize = getid3_lib::BigEndian2Int(substr($AtomHeader, 0, 4));
 			$atomname = substr($AtomHeader, 4, 4);
 
-			// 64-bit MOV patch by jlegateØktnc*com
+			// 64-bit MOV patch by jlegateÃ˜ktnc*com
 			if ($atomsize == 1) {
-				$atomsize = getid3_lib::BigEndian2Int(fread($this->getid3->fp, 8));
+				$atomsize = getid3_lib::BigEndian2Int($this->fread(8));
 			}
-
-			$info['quicktime'][$atomname]['name']   = $atomname;
-			$info['quicktime'][$atomname]['size']   = $atomsize;
-			$info['quicktime'][$atomname]['offset'] = $offset;
 
 			if (($offset + $atomsize) > $info['avdataend']) {
-				$info['error'][] = 'Atom at offset '.$offset.' claims to go beyond end-of-file (length: '.$atomsize.' bytes)';
+				$info['quicktime'][$atomname]['name']   = $atomname;
+				$info['quicktime'][$atomname]['size']   = $atomsize;
+				$info['quicktime'][$atomname]['offset'] = $offset;
+				$this->error('Atom at offset '.$offset.' claims to go beyond end-of-file (length: '.$atomsize.' bytes)');
 				return false;
 			}
-
 			if ($atomsize == 0) {
 				// Furthermore, for historical reasons the list of atoms is optionally
 				// terminated by a 32-bit integer set to 0. If you are writing a program
 				// to read user data atoms, you should allow for the terminating 0.
+				$info['quicktime'][$atomname]['name']   = $atomname;
+				$info['quicktime'][$atomname]['size']   = $atomsize;
+				$info['quicktime'][$atomname]['offset'] = $offset;
 				break;
 			}
+
+			$atomHierarchy = array();
+			$parsedAtomData = $this->QuicktimeParseAtom($atomname, $atomsize, $this->fread(min($atomsize, $atom_data_read_buffer_size)), $offset, $atomHierarchy, $this->ParseAllPossibleAtoms);
+			$parsedAtomData['name']   = $atomname;
+			$parsedAtomData['size']   = $atomsize;
+			$parsedAtomData['offset'] = $offset;
+			if (in_array($atomname, array('uuid'))) {
+				@$info['quicktime'][$atomname][] = $parsedAtomData;
+			} else {
+				$info['quicktime'][$atomname] = $parsedAtomData;
+			}
+
+			$offset += $atomsize;
+			$atomcounter++;
+		}
+
+		if (!empty($info['avdataend_tmp'])) {
+			// this value is assigned to a temp value and then erased because
+			// otherwise any atoms beyond the 'mdat' atom would not get parsed
+			$info['avdataend'] = $info['avdataend_tmp'];
+			unset($info['avdataend_tmp']);
+		}
+
+		if (!empty($info['quicktime']['comments']['chapters']) && is_array($info['quicktime']['comments']['chapters']) && (count($info['quicktime']['comments']['chapters']) > 0)) {
+			$durations = $this->quicktime_time_to_sample_table($info);
+			for ($i = 0; $i < count($info['quicktime']['comments']['chapters']); $i++) {
+				$bookmark = array();
+				$bookmark['title'] = $info['quicktime']['comments']['chapters'][$i];
+				if (isset($durations[$i])) {
+					$bookmark['duration_sample'] = $durations[$i]['sample_duration'];
+					if ($i > 0) {
+						$bookmark['start_sample'] = $info['quicktime']['bookmarks'][($i - 1)]['start_sample'] + $info['quicktime']['bookmarks'][($i - 1)]['duration_sample'];
+					} else {
+						$bookmark['start_sample'] = 0;
+					}
+					if ($time_scale = $this->quicktime_bookmark_time_scale($info)) {
+						$bookmark['duration_seconds'] = $bookmark['duration_sample'] / $time_scale;
+						$bookmark['start_seconds']    = $bookmark['start_sample']    / $time_scale;
+					}
+				}
+				$info['quicktime']['bookmarks'][] = $bookmark;
+			}
+		}
+
+		if (isset($info['quicktime']['temp_meta_key_names'])) {
+			unset($info['quicktime']['temp_meta_key_names']);
+		}
+
+		if (!empty($info['quicktime']['comments']['location.ISO6709'])) {
+			// https://en.wikipedia.org/wiki/ISO_6709
+			foreach ($info['quicktime']['comments']['location.ISO6709'] as $ISO6709string) {
+				$ISO6709parsed = array('latitude'=>false, 'longitude'=>false, 'altitude'=>false);
+				if (preg_match('#^([\\+\\-])([0-9]{2}|[0-9]{4}|[0-9]{6})(\\.[0-9]+)?([\\+\\-])([0-9]{3}|[0-9]{5}|[0-9]{7})(\\.[0-9]+)?(([\\+\\-])([0-9]{3}|[0-9]{5}|[0-9]{7})(\\.[0-9]+)?)?/$#', $ISO6709string, $matches)) {
+					@list($dummy, $lat_sign, $lat_deg, $lat_deg_dec, $lon_sign, $lon_deg, $lon_deg_dec, $dummy, $alt_sign, $alt_deg, $alt_deg_dec) = $matches;
+
+					if (strlen($lat_deg) == 2) {        // [+-]DD.D
+						$ISO6709parsed['latitude'] = (($lat_sign == '-') ? -1 : 1) * floatval(ltrim($lat_deg, '0').$lat_deg_dec);
+					} elseif (strlen($lat_deg) == 4) {  // [+-]DDMM.M
+						$ISO6709parsed['latitude'] = (($lat_sign == '-') ? -1 : 1) * floatval(ltrim(substr($lat_deg, 0, 2), '0')) + floatval(ltrim(substr($lat_deg, 2, 2), '0').$lat_deg_dec / 60);
+					} elseif (strlen($lat_deg) == 6) {  // [+-]DDMMSS.S
+						$ISO6709parsed['latitude'] = (($lat_sign == '-') ? -1 : 1) * floatval(ltrim(substr($lat_deg, 0, 2), '0')) + floatval(ltrim(substr($lat_deg, 2, 2), '0') / 60) + floatval(ltrim(substr($lat_deg, 4, 2), '0').$lat_deg_dec / 3600);
+					}
+
+					if (strlen($lon_deg) == 3) {        // [+-]DDD.D
+						$ISO6709parsed['longitude'] = (($lon_sign == '-') ? -1 : 1) * floatval(ltrim($lon_deg, '0').$lon_deg_dec);
+					} elseif (strlen($lon_deg) == 5) {  // [+-]DDDMM.M
+						$ISO6709parsed['longitude'] = (($lon_sign == '-') ? -1 : 1) * floatval(ltrim(substr($lon_deg, 0, 2), '0')) + floatval(ltrim(substr($lon_deg, 2, 2), '0').$lon_deg_dec / 60);
+					} elseif (strlen($lon_deg) == 7) {  // [+-]DDDMMSS.S
+						$ISO6709parsed['longitude'] = (($lon_sign == '-') ? -1 : 1) * floatval(ltrim(substr($lon_deg, 0, 2), '0')) + floatval(ltrim(substr($lon_deg, 2, 2), '0') / 60) + floatval(ltrim(substr($lon_deg, 4, 2), '0').$lon_deg_dec / 3600);
+					}
+
+					if (strlen($alt_deg) == 3) {        // [+-]DDD.D
+						$ISO6709parsed['altitude'] = (($alt_sign == '-') ? -1 : 1) * floatval(ltrim($alt_deg, '0').$alt_deg_dec);
+					} elseif (strlen($alt_deg) == 5) {  // [+-]DDDMM.M
+						$ISO6709parsed['altitude'] = (($alt_sign == '-') ? -1 : 1) * floatval(ltrim(substr($alt_deg, 0, 2), '0')) + floatval(ltrim(substr($alt_deg, 2, 2), '0').$alt_deg_dec / 60);
+					} elseif (strlen($alt_deg) == 7) {  // [+-]DDDMMSS.S
+						$ISO6709parsed['altitude'] = (($alt_sign == '-') ? -1 : 1) * floatval(ltrim(substr($alt_deg, 0, 2), '0')) + floatval(ltrim(substr($alt_deg, 2, 2), '0') / 60) + floatval(ltrim(substr($alt_deg, 4, 2), '0').$alt_deg_dec / 3600);
+					}
+
+					foreach (array('latitude', 'longitude', 'altitude') as $key) {
+						if ($ISO6709parsed[$key] !== false) {
+							$value = (($lat_sign == '-') ? -1 : 1) * floatval($ISO6709parsed[$key]);
+							if (!isset($info['quicktime']['comments']['gps_'.$key]) || !in_array($value, $info['quicktime']['comments']['gps_'.$key])) {
+								@$info['quicktime']['comments']['gps_'.$key][] = (($lat_sign == '-') ? -1 : 1) * floatval($ISO6709parsed[$key]);
+							}
+						}
+					}
+				}
+				if ($ISO6709parsed['latitude'] === false) {
+					$this->warning('location.ISO6709 string not parsed correctly: "'.$ISO6709string.'", please submit as a bug');
+				}
+				break;
+			}
+		}
+
+		if (!isset($info['bitrate']) && isset($info['playtime_seconds'])) {
+			$info['bitrate'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
+		}
+		if (isset($info['bitrate']) && !isset($info['audio']['bitrate']) && !isset($info['quicktime']['video'])) {
+			$info['audio']['bitrate'] = $info['bitrate'];
+		}
+		if (!empty($info['bitrate']) && !empty($info['audio']['bitrate']) && empty($info['video']['bitrate']) && !empty($info['video']['frame_rate']) && !empty($info['video']['resolution_x']) && ($info['bitrate'] > $info['audio']['bitrate'])) {
+			$info['video']['bitrate'] = $info['bitrate'] - $info['audio']['bitrate'];
+		}
+		if (!empty($info['playtime_seconds']) && !isset($info['video']['frame_rate']) && !empty($info['quicktime']['stts_framecount'])) {
+			foreach ($info['quicktime']['stts_framecount'] as $key => $samples_count) {
+				$samples_per_second = $samples_count / $info['playtime_seconds'];
+				if ($samples_per_second > 240) {
+					// has to be audio samples
+				} else {
+					$info['video']['frame_rate'] = $samples_per_second;
+					break;
+				}
+			}
+		}
+		if ($info['audio']['dataformat'] == 'mp4') {
+			$info['fileformat'] = 'mp4';
+			if (empty($info['video']['resolution_x'])) {
+				$info['mime_type']  = 'audio/mp4';
+				unset($info['video']['dataformat']);
+			} else {
+				$info['mime_type']  = 'video/mp4';
+			}
+		}
+
+		if (!$this->ReturnAtomData) {
+			unset($info['quicktime']['moov']);
+		}
+
+		if (empty($info['audio']['dataformat']) && !empty($info['quicktime']['audio'])) {
+			$info['audio']['dataformat'] = 'quicktime';
+		}
+		if (empty($info['video']['dataformat']) && !empty($info['quicktime']['video'])) {
+			$info['video']['dataformat'] = 'quicktime';
+		}
+		if (isset($info['video']) && ($info['mime_type'] == 'audio/mp4') && empty($info['video']['resolution_x']) && empty($info['video']['resolution_y']))  {
+			unset($info['video']);
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param string $atomname
+	 * @param int    $atomsize
+	 * @param string $atom_data
+	 * @param int    $baseoffset
+	 * @param array  $atomHierarchy
+	 * @param bool   $ParseAllPossibleAtoms
+	 *
+	 * @return array|false
+	 */
+	public function QuicktimeParseAtom($atomname, $atomsize, $atom_data, $baseoffset, &$atomHierarchy, $ParseAllPossibleAtoms) {
+		// http://developer.apple.com/techpubs/quicktime/qtdevdocs/APIREF/INDEX/atomalphaindex.htm
+		// https://code.google.com/p/mp4v2/wiki/iTunesMetadata
+
+		$info = &$this->getid3->info;
+
+		$atom_parent = end($atomHierarchy); // not array_pop($atomHierarchy); see https://www.getid3.org/phpBB3/viewtopic.php?t=1717
+		array_push($atomHierarchy, $atomname);
+		$atom_structure              = array();
+		$atom_structure['hierarchy'] = implode(' ', $atomHierarchy);
+		$atom_structure['name']      = $atomname;
+		$atom_structure['size']      = $atomsize;
+		$atom_structure['offset']    = $baseoffset;
+		if (substr($atomname, 0, 3) == "\x00\x00\x00") {
+			// https://github.com/JamesHeinrich/getID3/issues/139
+			$atomname = getid3_lib::BigEndian2Int($atomname);
+			$atom_structure['name'] = $atomname;
+			$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
+		} else {
 			switch ($atomname) {
+				case 'moov': // MOVie container atom
+				case 'trak': // TRAcK container atom
+				case 'clip': // CLIPping container atom
+				case 'matt': // track MATTe container atom
+				case 'edts': // EDiTS container atom
+				case 'tref': // Track REFerence container atom
+				case 'mdia': // MeDIA container atom
+				case 'minf': // Media INFormation container atom
+				case 'dinf': // Data INFormation container atom
+				case 'nmhd': // Null Media HeaDer container atom
+				case 'udta': // User DaTA container atom
+				case 'cmov': // Compressed MOVie container atom
+				case 'rmra': // Reference Movie Record Atom
+				case 'rmda': // Reference Movie Descriptor Atom
+				case 'gmhd': // Generic Media info HeaDer atom (seen on QTVR)
+					$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
+					break;
+
+				case 'ilst': // Item LiST container atom
+					if ($atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms)) {
+						// some "ilst" atoms contain data atoms that have a numeric name, and the data is far more accessible if the returned array is compacted
+						$allnumericnames = true;
+						foreach ($atom_structure['subatoms'] as $subatomarray) {
+							if (!is_integer($subatomarray['name']) || (count($subatomarray['subatoms']) != 1)) {
+								$allnumericnames = false;
+								break;
+							}
+						}
+						if ($allnumericnames) {
+							$newData = array();
+							foreach ($atom_structure['subatoms'] as $subatomarray) {
+								foreach ($subatomarray['subatoms'] as $newData_subatomarray) {
+									unset($newData_subatomarray['hierarchy'], $newData_subatomarray['name']);
+									$newData[$subatomarray['name']] = $newData_subatomarray;
+									break;
+								}
+							}
+							$atom_structure['data'] = $newData;
+							unset($atom_structure['subatoms']);
+						}
+					}
+					break;
+
+				case 'stbl': // Sample TaBLe container atom
+					$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
+					$isVideo = false;
+					$framerate  = 0;
+					$framecount = 0;
+					foreach ($atom_structure['subatoms'] as $key => $value_array) {
+						if (isset($value_array['sample_description_table'])) {
+							foreach ($value_array['sample_description_table'] as $key2 => $value_array2) {
+								if (isset($value_array2['data_format'])) {
+									switch ($value_array2['data_format']) {
+										case 'avc1':
+										case 'mp4v':
+											// video data
+											$isVideo = true;
+											break;
+										case 'mp4a':
+											// audio data
+											break;
+									}
+								}
+							}
+						} elseif (isset($value_array['time_to_sample_table'])) {
+							foreach ($value_array['time_to_sample_table'] as $key2 => $value_array2) {
+								if (isset($value_array2['sample_count']) && isset($value_array2['sample_duration']) && ($value_array2['sample_duration'] > 0)) {
+									$framerate  = round($info['quicktime']['time_scale'] / $value_array2['sample_duration'], 3);
+									$framecount = $value_array2['sample_count'];
+								}
+							}
+						}
+					}
+					if ($isVideo && $framerate) {
+						$info['quicktime']['video']['frame_rate'] = $framerate;
+						$info['video']['frame_rate'] = $info['quicktime']['video']['frame_rate'];
+					}
+					if ($isVideo && $framecount) {
+						$info['quicktime']['video']['frame_count'] = $framecount;
+					}
+					break;
+
+
+				case "\xA9".'alb': // ALBum
+				case "\xA9".'ART': //
+				case "\xA9".'art': // ARTist
+				case "\xA9".'aut': //
+				case "\xA9".'cmt': // CoMmenT
+				case "\xA9".'com': // COMposer
+				case "\xA9".'cpy': //
+				case "\xA9".'day': // content created year
+				case "\xA9".'dir': //
+				case "\xA9".'ed1': //
+				case "\xA9".'ed2': //
+				case "\xA9".'ed3': //
+				case "\xA9".'ed4': //
+				case "\xA9".'ed5': //
+				case "\xA9".'ed6': //
+				case "\xA9".'ed7': //
+				case "\xA9".'ed8': //
+				case "\xA9".'ed9': //
+				case "\xA9".'enc': //
+				case "\xA9".'fmt': //
+				case "\xA9".'gen': // GENre
+				case "\xA9".'grp': // GRouPing
+				case "\xA9".'hst': //
+				case "\xA9".'inf': //
+				case "\xA9".'lyr': // LYRics
+				case "\xA9".'mak': //
+				case "\xA9".'mod': //
+				case "\xA9".'nam': // full NAMe
+				case "\xA9".'ope': //
+				case "\xA9".'PRD': //
+				case "\xA9".'prf': //
+				case "\xA9".'req': //
+				case "\xA9".'src': //
+				case "\xA9".'swr': //
+				case "\xA9".'too': // encoder
+				case "\xA9".'trk': // TRacK
+				case "\xA9".'url': //
+				case "\xA9".'wrn': //
+				case "\xA9".'wrt': // WRiTer
+				case '----': // itunes specific
+				case 'aART': // Album ARTist
+				case 'akID': // iTunes store account type
+				case 'apID': // Purchase Account
+				case 'atID': //
+				case 'catg': // CaTeGory
+				case 'cmID': //
+				case 'cnID': //
+				case 'covr': // COVeR artwork
+				case 'cpil': // ComPILation
+				case 'cprt': // CoPyRighT
+				case 'desc': // DESCription
+				case 'disk': // DISK number
+				case 'egid': // Episode Global ID
+				case 'geID': //
+				case 'gnre': // GeNRE
+				case 'hdvd': // HD ViDeo
+				case 'keyw': // KEYWord
+				case 'ldes': // Long DEScription
+				case 'pcst': // PodCaST
+				case 'pgap': // GAPless Playback
+				case 'plID': //
+				case 'purd': // PURchase Date
+				case 'purl': // Podcast URL
+				case 'rati': //
+				case 'rndu': //
+				case 'rpdu': //
+				case 'rtng': // RaTiNG
+				case 'sfID': // iTunes store country
+				case 'soaa': // SOrt Album Artist
+				case 'soal': // SOrt ALbum
+				case 'soar': // SOrt ARtist
+				case 'soco': // SOrt COmposer
+				case 'sonm': // SOrt NaMe
+				case 'sosn': // SOrt Show Name
+				case 'stik': //
+				case 'tmpo': // TeMPO (BPM)
+				case 'trkn': // TRacK Number
+				case 'tven': // tvEpisodeID
+				case 'tves': // TV EpiSode
+				case 'tvnn': // TV Network Name
+				case 'tvsh': // TV SHow Name
+				case 'tvsn': // TV SeasoN
+					if ($atom_parent == 'udta') {
+						// User data atom handler
+						$atom_structure['data_length'] = getid3_lib::BigEndian2Int(substr($atom_data, 0, 2));
+						$atom_structure['language_id'] = getid3_lib::BigEndian2Int(substr($atom_data, 2, 2));
+						$atom_structure['data']        =                           substr($atom_data, 4);
+
+						$atom_structure['language']    = $this->QuicktimeLanguageLookup($atom_structure['language_id']);
+						if (empty($info['comments']['language']) || (!in_array($atom_structure['language'], $info['comments']['language']))) {
+							$info['comments']['language'][] = $atom_structure['language'];
+						}
+					} else {
+						// Apple item list box atom handler
+						$atomoffset = 0;
+						if (substr($atom_data, 2, 2) == "\x10\xB5") {
+							// not sure what it means, but observed on iPhone4 data.
+							// Each $atom_data has 2 bytes of datasize, plus 0x10B5, then data
+							while ($atomoffset < strlen($atom_data)) {
+								$boxsmallsize = getid3_lib::BigEndian2Int(substr($atom_data, $atomoffset,     2));
+								$boxsmalltype =                           substr($atom_data, $atomoffset + 2, 2);
+								$boxsmalldata =                           substr($atom_data, $atomoffset + 4, $boxsmallsize);
+								if ($boxsmallsize <= 1) {
+									$this->warning('Invalid QuickTime atom smallbox size "'.$boxsmallsize.'" in atom "'.preg_replace('#[^a-zA-Z0-9 _\\-]#', '?', $atomname).'" at offset: '.($atom_structure['offset'] + $atomoffset));
+									$atom_structure['data'] = null;
+									$atomoffset = strlen($atom_data);
+									break;
+								}
+								switch ($boxsmalltype) {
+									case "\x10\xB5":
+										$atom_structure['data'] = $boxsmalldata;
+										break;
+									default:
+										$this->warning('Unknown QuickTime smallbox type: "'.preg_replace('#[^a-zA-Z0-9 _\\-]#', '?', $boxsmalltype).'" ('.trim(getid3_lib::PrintHexBytes($boxsmalltype)).') at offset '.$baseoffset);
+										$atom_structure['data'] = $atom_data;
+										break;
+								}
+								$atomoffset += (4 + $boxsmallsize);
+							}
+						} else {
+							while ($atomoffset < strlen($atom_data)) {
+								$boxsize = getid3_lib::BigEndian2Int(substr($atom_data, $atomoffset, 4));
+								$boxtype =                           substr($atom_data, $atomoffset + 4, 4);
+								$boxdata =                           substr($atom_data, $atomoffset + 8, $boxsize - 8);
+								if ($boxsize <= 1) {
+									$this->warning('Invalid QuickTime atom box size "'.$boxsize.'" in atom "'.preg_replace('#[^a-zA-Z0-9 _\\-]#', '?', $atomname).'" at offset: '.($atom_structure['offset'] + $atomoffset));
+									$atom_structure['data'] = null;
+									$atomoffset = strlen($atom_data);
+									break;
+								}
+								$atomoffset += $boxsize;
+
+								switch ($boxtype) {
+									case 'mean':
+									case 'name':
+										$atom_structure[$boxtype] = substr($boxdata, 4);
+										break;
+
+									case 'data':
+										$atom_structure['version']   = getid3_lib::BigEndian2Int(substr($boxdata,  0, 1));
+										$atom_structure['flags_raw'] = getid3_lib::BigEndian2Int(substr($boxdata,  1, 3));
+										switch ($atom_structure['flags_raw']) {
+											case  0: // data flag
+											case 21: // tmpo/cpil flag
+												switch ($atomname) {
+													case 'cpil':
+													case 'hdvd':
+													case 'pcst':
+													case 'pgap':
+														// 8-bit integer (boolean)
+														$atom_structure['data'] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 1));
+														break;
+
+													case 'tmpo':
+														// 16-bit integer
+														$atom_structure['data'] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 2));
+														break;
+
+													case 'disk':
+													case 'trkn':
+														// binary
+														$num       = getid3_lib::BigEndian2Int(substr($boxdata, 10, 2));
+														$num_total = getid3_lib::BigEndian2Int(substr($boxdata, 12, 2));
+														$atom_structure['data']  = empty($num) ? '' : $num;
+														$atom_structure['data'] .= empty($num_total) ? '' : '/'.$num_total;
+														break;
+
+													case 'gnre':
+														// enum
+														$GenreID = getid3_lib::BigEndian2Int(substr($boxdata, 8, 4));
+														$atom_structure['data']    = getid3_id3v1::LookupGenreName($GenreID - 1);
+														break;
+
+													case 'rtng':
+														// 8-bit integer
+														$atom_structure[$atomname] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 1));
+														$atom_structure['data']    = $this->QuicktimeContentRatingLookup($atom_structure[$atomname]);
+														break;
+
+													case 'stik':
+														// 8-bit integer (enum)
+														$atom_structure[$atomname] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 1));
+														$atom_structure['data']    = $this->QuicktimeSTIKLookup($atom_structure[$atomname]);
+														break;
+
+													case 'sfID':
+														// 32-bit integer
+														$atom_structure[$atomname] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 4));
+														$atom_structure['data']    = $this->QuicktimeStoreFrontCodeLookup($atom_structure[$atomname]);
+														break;
+
+													case 'egid':
+													case 'purl':
+														$atom_structure['data'] = substr($boxdata, 8);
+														break;
+
+													case 'plID':
+														// 64-bit integer
+														$atom_structure['data'] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 8));
+														break;
+
+													case 'covr':
+														$atom_structure['data'] = substr($boxdata, 8);
+														// not a foolproof check, but better than nothing
+														if (preg_match('#^\\xFF\\xD8\\xFF#', $atom_structure['data'])) {
+															$atom_structure['image_mime'] = 'image/jpeg';
+														} elseif (preg_match('#^\\x89\\x50\\x4E\\x47\\x0D\\x0A\\x1A\\x0A#', $atom_structure['data'])) {
+															$atom_structure['image_mime'] = 'image/png';
+														} elseif (preg_match('#^GIF#', $atom_structure['data'])) {
+															$atom_structure['image_mime'] = 'image/gif';
+														}
+														$info['quicktime']['comments']['picture'][] = array('image_mime'=>$atom_structure['image_mime'], 'data'=>$atom_structure['data'], 'description'=>'cover');
+														break;
+
+													case 'atID':
+													case 'cnID':
+													case 'geID':
+													case 'tves':
+													case 'tvsn':
+													default:
+														// 32-bit integer
+														$atom_structure['data'] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 4));
+												}
+												break;
+
+											case  1: // text flag
+											case 13: // image flag
+											default:
+												$atom_structure['data'] = substr($boxdata, 8);
+												if ($atomname == 'covr') {
+													// not a foolproof check, but better than nothing
+													if (preg_match('#^\\xFF\\xD8\\xFF#', $atom_structure['data'])) {
+														$atom_structure['image_mime'] = 'image/jpeg';
+													} elseif (preg_match('#^\\x89\\x50\\x4E\\x47\\x0D\\x0A\\x1A\\x0A#', $atom_structure['data'])) {
+														$atom_structure['image_mime'] = 'image/png';
+													} elseif (preg_match('#^GIF#', $atom_structure['data'])) {
+														$atom_structure['image_mime'] = 'image/gif';
+													}
+													$info['quicktime']['comments']['picture'][] = array('image_mime'=>$atom_structure['image_mime'], 'data'=>$atom_structure['data'], 'description'=>'cover');
+												}
+												break;
+
+										}
+										break;
+
+									default:
+										$this->warning('Unknown QuickTime box type: "'.preg_replace('#[^a-zA-Z0-9 _\\-]#', '?', $boxtype).'" ('.trim(getid3_lib::PrintHexBytes($boxtype)).') at offset '.$baseoffset);
+										$atom_structure['data'] = $atom_data;
+
+								}
+							}
+						}
+					}
+					$this->CopyToAppropriateCommentsSection($atomname, $atom_structure['data'], $atom_structure['name']);
+					break;
+
+
+				case 'play': // auto-PLAY atom
+					$atom_structure['autoplay'] = (bool) getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+
+					$info['quicktime']['autoplay'] = $atom_structure['autoplay'];
+					break;
+
+
+				case 'WLOC': // Window LOCation atom
+					$atom_structure['location_x']  = getid3_lib::BigEndian2Int(substr($atom_data,  0, 2));
+					$atom_structure['location_y']  = getid3_lib::BigEndian2Int(substr($atom_data,  2, 2));
+					break;
+
+
+				case 'LOOP': // LOOPing atom
+				case 'SelO': // play SELection Only atom
+				case 'AllF': // play ALL Frames atom
+					$atom_structure['data'] = getid3_lib::BigEndian2Int($atom_data);
+					break;
+
+
+				case 'name': //
+				case 'MCPS': // Media Cleaner PRo
+				case '@PRM': // adobe PReMiere version
+				case '@PRQ': // adobe PRemiere Quicktime version
+					$atom_structure['data'] = $atom_data;
+					break;
+
+
+				case 'cmvd': // Compressed MooV Data atom
+					// Code by ubergeekÃ˜ubergeek*tv based on information from
+					// http://developer.apple.com/quicktime/icefloe/dispatch012.html
+					$atom_structure['unCompressedSize'] = getid3_lib::BigEndian2Int(substr($atom_data, 0, 4));
+
+					$CompressedFileData = substr($atom_data, 4);
+					if ($UncompressedHeader = @gzuncompress($CompressedFileData)) {
+						$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($UncompressedHeader, 0, $atomHierarchy, $ParseAllPossibleAtoms);
+					} else {
+						$this->warning('Error decompressing compressed MOV atom at offset '.$atom_structure['offset']);
+					}
+					break;
+
+
+				case 'dcom': // Data COMpression atom
+					$atom_structure['compression_id']   = $atom_data;
+					$atom_structure['compression_text'] = $this->QuicktimeDCOMLookup($atom_data);
+					break;
+
+
+				case 'rdrf': // Reference movie Data ReFerence atom
+					$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3));
+					$atom_structure['flags']['internal_data'] = (bool) ($atom_structure['flags_raw'] & 0x000001);
+
+					$atom_structure['reference_type_name']    =                           substr($atom_data,  4, 4);
+					$atom_structure['reference_length']       = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
+					switch ($atom_structure['reference_type_name']) {
+						case 'url ':
+							$atom_structure['url']            =       $this->NoNullString(substr($atom_data, 12));
+							break;
+
+						case 'alis':
+							$atom_structure['file_alias']     =                           substr($atom_data, 12);
+							break;
+
+						case 'rsrc':
+							$atom_structure['resource_alias'] =                           substr($atom_data, 12);
+							break;
+
+						default:
+							$atom_structure['data']           =                           substr($atom_data, 12);
+							break;
+					}
+					break;
+
+
+				case 'rmqu': // Reference Movie QUality atom
+					$atom_structure['movie_quality'] = getid3_lib::BigEndian2Int($atom_data);
+					break;
+
+
+				case 'rmcs': // Reference Movie Cpu Speed atom
+					$atom_structure['version']          = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']        = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['cpu_speed_rating'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
+					break;
+
+
+				case 'rmvc': // Reference Movie Version Check atom
+					$atom_structure['version']            = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']          = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['gestalt_selector']   =                           substr($atom_data,  4, 4);
+					$atom_structure['gestalt_value_mask'] = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
+					$atom_structure['gestalt_value']      = getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
+					$atom_structure['gestalt_check_type'] = getid3_lib::BigEndian2Int(substr($atom_data, 14, 2));
+					break;
+
+
+				case 'rmcd': // Reference Movie Component check atom
+					$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['component_type']         =                           substr($atom_data,  4, 4);
+					$atom_structure['component_subtype']      =                           substr($atom_data,  8, 4);
+					$atom_structure['component_manufacturer'] =                           substr($atom_data, 12, 4);
+					$atom_structure['component_flags_raw']    = getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
+					$atom_structure['component_flags_mask']   = getid3_lib::BigEndian2Int(substr($atom_data, 20, 4));
+					$atom_structure['component_min_version']  = getid3_lib::BigEndian2Int(substr($atom_data, 24, 4));
+					break;
+
+
+				case 'rmdr': // Reference Movie Data Rate atom
+					$atom_structure['version']       = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']     = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['data_rate']     = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+
+					$atom_structure['data_rate_bps'] = $atom_structure['data_rate'] * 10;
+					break;
+
+
+				case 'rmla': // Reference Movie Language Atom
+					$atom_structure['version']     = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']   = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['language_id'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
+
+					$atom_structure['language']    = $this->QuicktimeLanguageLookup($atom_structure['language_id']);
+					if (empty($info['comments']['language']) || (!in_array($atom_structure['language'], $info['comments']['language']))) {
+						$info['comments']['language'][] = $atom_structure['language'];
+					}
+					break;
+
+
+				case 'ptv ': // Print To Video - defines a movie's full screen mode
+					// http://developer.apple.com/documentation/QuickTime/APIREF/SOURCESIV/at_ptv-_pg.htm
+					$atom_structure['display_size_raw']  = getid3_lib::BigEndian2Int(substr($atom_data, 0, 2));
+					$atom_structure['reserved_1']        = getid3_lib::BigEndian2Int(substr($atom_data, 2, 2)); // hardcoded: 0x0000
+					$atom_structure['reserved_2']        = getid3_lib::BigEndian2Int(substr($atom_data, 4, 2)); // hardcoded: 0x0000
+					$atom_structure['slide_show_flag']   = getid3_lib::BigEndian2Int(substr($atom_data, 6, 1));
+					$atom_structure['play_on_open_flag'] = getid3_lib::BigEndian2Int(substr($atom_data, 7, 1));
+
+					$atom_structure['flags']['play_on_open'] = (bool) $atom_structure['play_on_open_flag'];
+					$atom_structure['flags']['slide_show']   = (bool) $atom_structure['slide_show_flag'];
+
+					$ptv_lookup[0] = 'normal';
+					$ptv_lookup[1] = 'double';
+					$ptv_lookup[2] = 'half';
+					$ptv_lookup[3] = 'full';
+					$ptv_lookup[4] = 'current';
+					if (isset($ptv_lookup[$atom_structure['display_size_raw']])) {
+						$atom_structure['display_size'] = $ptv_lookup[$atom_structure['display_size_raw']];
+					} else {
+						$this->warning('unknown "ptv " display constant ('.$atom_structure['display_size_raw'].')');
+					}
+					break;
+
+
+				case 'stsd': // Sample Table Sample Description atom
+					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+
+					// see: https://github.com/JamesHeinrich/getID3/issues/111
+					// Some corrupt files have been known to have high bits set in the number_entries field
+					// This field shouldn't really need to be 32-bits, values stores are likely in the range 1-100000
+					// Workaround: mask off the upper byte and throw a warning if it's nonzero
+					if ($atom_structure['number_entries'] > 0x000FFFFF) {
+						if ($atom_structure['number_entries'] > 0x00FFFFFF) {
+							$this->warning('"stsd" atom contains improbably large number_entries (0x'.getid3_lib::PrintHexBytes(substr($atom_data, 4, 4), true, false).' = '.$atom_structure['number_entries'].'), probably in error. Ignoring upper byte and interpreting this as 0x'.getid3_lib::PrintHexBytes(substr($atom_data, 5, 3), true, false).' = '.($atom_structure['number_entries'] & 0x00FFFFFF));
+							$atom_structure['number_entries'] = ($atom_structure['number_entries'] & 0x00FFFFFF);
+						} else {
+							$this->warning('"stsd" atom contains improbably large number_entries (0x'.getid3_lib::PrintHexBytes(substr($atom_data, 4, 4), true, false).' = '.$atom_structure['number_entries'].'), probably in error. Please report this to info@getid3.org referencing bug report #111');
+						}
+					}
+
+					$stsdEntriesDataOffset = 8;
+					for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
+						$atom_structure['sample_description_table'][$i]['size']             = getid3_lib::BigEndian2Int(substr($atom_data, $stsdEntriesDataOffset, 4));
+						$stsdEntriesDataOffset += 4;
+						$atom_structure['sample_description_table'][$i]['data_format']      =                           substr($atom_data, $stsdEntriesDataOffset, 4);
+						$stsdEntriesDataOffset += 4;
+						$atom_structure['sample_description_table'][$i]['reserved']         = getid3_lib::BigEndian2Int(substr($atom_data, $stsdEntriesDataOffset, 6));
+						$stsdEntriesDataOffset += 6;
+						$atom_structure['sample_description_table'][$i]['reference_index']  = getid3_lib::BigEndian2Int(substr($atom_data, $stsdEntriesDataOffset, 2));
+						$stsdEntriesDataOffset += 2;
+						$atom_structure['sample_description_table'][$i]['data']             =                           substr($atom_data, $stsdEntriesDataOffset, ($atom_structure['sample_description_table'][$i]['size'] - 4 - 4 - 6 - 2));
+						$stsdEntriesDataOffset += ($atom_structure['sample_description_table'][$i]['size'] - 4 - 4 - 6 - 2);
+
+						if (substr($atom_structure['sample_description_table'][$i]['data'],  1, 54) == 'application/octet-stream;type=com.parrot.videometadata') {
+							// special handling for apparently-malformed (TextMetaDataSampleEntry?) data for some version of Parrot drones
+							$atom_structure['sample_description_table'][$i]['parrot_frame_metadata']['mime_type']        =       substr($atom_structure['sample_description_table'][$i]['data'],  1, 55);
+							$atom_structure['sample_description_table'][$i]['parrot_frame_metadata']['metadata_version'] = (int) substr($atom_structure['sample_description_table'][$i]['data'], 55,  1);
+							unset($atom_structure['sample_description_table'][$i]['data']);
+$this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in this version of getID3() ['.$this->getid3->version().']');
+							continue;
+						}
+
+						$atom_structure['sample_description_table'][$i]['encoder_version']  = getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'],  0, 2));
+						$atom_structure['sample_description_table'][$i]['encoder_revision'] = getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'],  2, 2));
+						$atom_structure['sample_description_table'][$i]['encoder_vendor']   =                           substr($atom_structure['sample_description_table'][$i]['data'],  4, 4);
+
+						switch ($atom_structure['sample_description_table'][$i]['encoder_vendor']) {
+
+							case "\x00\x00\x00\x00":
+								// audio tracks
+								$atom_structure['sample_description_table'][$i]['audio_channels']       =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'],  8,  2));
+								$atom_structure['sample_description_table'][$i]['audio_bit_depth']      =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 10,  2));
+								$atom_structure['sample_description_table'][$i]['audio_compression_id'] =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 12,  2));
+								$atom_structure['sample_description_table'][$i]['audio_packet_size']    =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 14,  2));
+								$atom_structure['sample_description_table'][$i]['audio_sample_rate']    = getid3_lib::FixedPoint16_16(substr($atom_structure['sample_description_table'][$i]['data'], 16,  4));
+
+								// video tracks
+								// http://developer.apple.com/library/mac/#documentation/QuickTime/QTFF/QTFFChap3/qtff3.html
+								$atom_structure['sample_description_table'][$i]['temporal_quality'] =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'],  8,  4));
+								$atom_structure['sample_description_table'][$i]['spatial_quality']  =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 12,  4));
+								$atom_structure['sample_description_table'][$i]['width']            =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 16,  2));
+								$atom_structure['sample_description_table'][$i]['height']           =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 18,  2));
+								$atom_structure['sample_description_table'][$i]['resolution_x']     = getid3_lib::FixedPoint16_16(substr($atom_structure['sample_description_table'][$i]['data'], 24,  4));
+								$atom_structure['sample_description_table'][$i]['resolution_y']     = getid3_lib::FixedPoint16_16(substr($atom_structure['sample_description_table'][$i]['data'], 28,  4));
+								$atom_structure['sample_description_table'][$i]['data_size']        =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 32,  4));
+								$atom_structure['sample_description_table'][$i]['frame_count']      =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 36,  2));
+								$atom_structure['sample_description_table'][$i]['compressor_name']  =                             substr($atom_structure['sample_description_table'][$i]['data'], 38,  4);
+								$atom_structure['sample_description_table'][$i]['pixel_depth']      =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 42,  2));
+								$atom_structure['sample_description_table'][$i]['color_table_id']   =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 44,  2));
+
+								switch ($atom_structure['sample_description_table'][$i]['data_format']) {
+									case '2vuY':
+									case 'avc1':
+									case 'cvid':
+									case 'dvc ':
+									case 'dvcp':
+									case 'gif ':
+									case 'h263':
+									case 'jpeg':
+									case 'kpcd':
+									case 'mjpa':
+									case 'mjpb':
+									case 'mp4v':
+									case 'png ':
+									case 'raw ':
+									case 'rle ':
+									case 'rpza':
+									case 'smc ':
+									case 'SVQ1':
+									case 'SVQ3':
+									case 'tiff':
+									case 'v210':
+									case 'v216':
+									case 'v308':
+									case 'v408':
+									case 'v410':
+									case 'yuv2':
+										$info['fileformat'] = 'mp4';
+										$info['video']['fourcc'] = $atom_structure['sample_description_table'][$i]['data_format'];
+										if ($this->QuicktimeVideoCodecLookup($info['video']['fourcc'])) {
+											$info['video']['fourcc_lookup'] = $this->QuicktimeVideoCodecLookup($info['video']['fourcc']);
+										}
+
+										// https://www.getid3.org/phpBB3/viewtopic.php?t=1550
+										//if ((!empty($atom_structure['sample_description_table'][$i]['width']) && !empty($atom_structure['sample_description_table'][$i]['width'])) && (empty($info['video']['resolution_x']) || empty($info['video']['resolution_y']) || (number_format($info['video']['resolution_x'], 6) != number_format(round($info['video']['resolution_x']), 6)) || (number_format($info['video']['resolution_y'], 6) != number_format(round($info['video']['resolution_y']), 6)))) { // ugly check for floating point numbers
+										if (!empty($atom_structure['sample_description_table'][$i]['width']) && !empty($atom_structure['sample_description_table'][$i]['height'])) {
+											// assume that values stored here are more important than values stored in [tkhd] atom
+											$info['video']['resolution_x'] = $atom_structure['sample_description_table'][$i]['width'];
+											$info['video']['resolution_y'] = $atom_structure['sample_description_table'][$i]['height'];
+											$info['quicktime']['video']['resolution_x'] = $info['video']['resolution_x'];
+											$info['quicktime']['video']['resolution_y'] = $info['video']['resolution_y'];
+										}
+										break;
+
+									case 'qtvr':
+										$info['video']['dataformat'] = 'quicktimevr';
+										break;
+
+									case 'mp4a':
+									default:
+										$info['quicktime']['audio']['codec']       = $this->QuicktimeAudioCodecLookup($atom_structure['sample_description_table'][$i]['data_format']);
+										$info['quicktime']['audio']['sample_rate'] = $atom_structure['sample_description_table'][$i]['audio_sample_rate'];
+										$info['quicktime']['audio']['channels']    = $atom_structure['sample_description_table'][$i]['audio_channels'];
+										$info['quicktime']['audio']['bit_depth']   = $atom_structure['sample_description_table'][$i]['audio_bit_depth'];
+										$info['audio']['codec']                    = $info['quicktime']['audio']['codec'];
+										$info['audio']['sample_rate']              = $info['quicktime']['audio']['sample_rate'];
+										$info['audio']['channels']                 = $info['quicktime']['audio']['channels'];
+										$info['audio']['bits_per_sample']          = $info['quicktime']['audio']['bit_depth'];
+										switch ($atom_structure['sample_description_table'][$i]['data_format']) {
+											case 'raw ': // PCM
+											case 'alac': // Apple Lossless Audio Codec
+											case 'sowt': // signed/two's complement (Little Endian)
+											case 'twos': // signed/two's complement (Big Endian)
+											case 'in24': // 24-bit Integer
+											case 'in32': // 32-bit Integer
+											case 'fl32': // 32-bit Floating Point
+											case 'fl64': // 64-bit Floating Point
+												$info['audio']['lossless'] = $info['quicktime']['audio']['lossless'] = true;
+												$info['audio']['bitrate']  = $info['quicktime']['audio']['bitrate']  = $info['audio']['channels'] * $info['audio']['bits_per_sample'] * $info['audio']['sample_rate'];
+												break;
+											default:
+												$info['audio']['lossless'] = false;
+												break;
+										}
+										break;
+								}
+								break;
+
+							default:
+								switch ($atom_structure['sample_description_table'][$i]['data_format']) {
+									case 'mp4s':
+										$info['fileformat'] = 'mp4';
+										break;
+
+									default:
+										// video atom
+										$atom_structure['sample_description_table'][$i]['video_temporal_quality']  =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'],  8,  4));
+										$atom_structure['sample_description_table'][$i]['video_spatial_quality']   =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 12,  4));
+										$atom_structure['sample_description_table'][$i]['video_frame_width']       =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 16,  2));
+										$atom_structure['sample_description_table'][$i]['video_frame_height']      =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 18,  2));
+										$atom_structure['sample_description_table'][$i]['video_resolution_x']      = getid3_lib::FixedPoint16_16(substr($atom_structure['sample_description_table'][$i]['data'], 20,  4));
+										$atom_structure['sample_description_table'][$i]['video_resolution_y']      = getid3_lib::FixedPoint16_16(substr($atom_structure['sample_description_table'][$i]['data'], 24,  4));
+										$atom_structure['sample_description_table'][$i]['video_data_size']         =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 28,  4));
+										$atom_structure['sample_description_table'][$i]['video_frame_count']       =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 32,  2));
+										$atom_structure['sample_description_table'][$i]['video_encoder_name_len']  =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 34,  1));
+										$atom_structure['sample_description_table'][$i]['video_encoder_name']      =                             substr($atom_structure['sample_description_table'][$i]['data'], 35, $atom_structure['sample_description_table'][$i]['video_encoder_name_len']);
+										$atom_structure['sample_description_table'][$i]['video_pixel_color_depth'] =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 66,  2));
+										$atom_structure['sample_description_table'][$i]['video_color_table_id']    =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 68,  2));
+
+										$atom_structure['sample_description_table'][$i]['video_pixel_color_type']  = (($atom_structure['sample_description_table'][$i]['video_pixel_color_depth'] > 32) ? 'grayscale' : 'color');
+										$atom_structure['sample_description_table'][$i]['video_pixel_color_name']  = $this->QuicktimeColorNameLookup($atom_structure['sample_description_table'][$i]['video_pixel_color_depth']);
+
+										if ($atom_structure['sample_description_table'][$i]['video_pixel_color_name'] != 'invalid') {
+											$info['quicktime']['video']['codec_fourcc']        = $atom_structure['sample_description_table'][$i]['data_format'];
+											$info['quicktime']['video']['codec_fourcc_lookup'] = $this->QuicktimeVideoCodecLookup($atom_structure['sample_description_table'][$i]['data_format']);
+											$info['quicktime']['video']['codec']               = (($atom_structure['sample_description_table'][$i]['video_encoder_name_len'] > 0) ? $atom_structure['sample_description_table'][$i]['video_encoder_name'] : $atom_structure['sample_description_table'][$i]['data_format']);
+											$info['quicktime']['video']['color_depth']         = $atom_structure['sample_description_table'][$i]['video_pixel_color_depth'];
+											$info['quicktime']['video']['color_depth_name']    = $atom_structure['sample_description_table'][$i]['video_pixel_color_name'];
+
+											$info['video']['codec']           = $info['quicktime']['video']['codec'];
+											$info['video']['bits_per_sample'] = $info['quicktime']['video']['color_depth'];
+										}
+										$info['video']['lossless']           = false;
+										$info['video']['pixel_aspect_ratio'] = (float) 1;
+										break;
+								}
+								break;
+						}
+						switch (strtolower($atom_structure['sample_description_table'][$i]['data_format'])) {
+							case 'mp4a':
+								$info['audio']['dataformat']         = 'mp4';
+								$info['quicktime']['audio']['codec'] = 'mp4';
+								break;
+
+							case '3ivx':
+							case '3iv1':
+							case '3iv2':
+								$info['video']['dataformat'] = '3ivx';
+								break;
+
+							case 'xvid':
+								$info['video']['dataformat'] = 'xvid';
+								break;
+
+							case 'mp4v':
+								$info['video']['dataformat'] = 'mpeg4';
+								break;
+
+							case 'divx':
+							case 'div1':
+							case 'div2':
+							case 'div3':
+							case 'div4':
+							case 'div5':
+							case 'div6':
+								$info['video']['dataformat'] = 'divx';
+								break;
+
+							default:
+								// do nothing
+								break;
+						}
+						unset($atom_structure['sample_description_table'][$i]['data']);
+					}
+					break;
+
+
+				case 'stts': // Sample Table Time-to-Sample atom
+					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+					$sttsEntriesDataOffset = 8;
+					//$FrameRateCalculatorArray = array();
+					$frames_count = 0;
+
+					$max_stts_entries_to_scan = ($info['php_memory_limit'] ? min(floor($this->getid3->memory_limit / 10000), $atom_structure['number_entries']) : $atom_structure['number_entries']);
+					if ($max_stts_entries_to_scan < $atom_structure['number_entries']) {
+						$this->warning('QuickTime atom "stts" has '.$atom_structure['number_entries'].' but only scanning the first '.$max_stts_entries_to_scan.' entries due to limited PHP memory available ('.floor($this->getid3->memory_limit / 1048576).'MB).');
+					}
+					for ($i = 0; $i < $max_stts_entries_to_scan; $i++) {
+						$atom_structure['time_to_sample_table'][$i]['sample_count']    = getid3_lib::BigEndian2Int(substr($atom_data, $sttsEntriesDataOffset, 4));
+						$sttsEntriesDataOffset += 4;
+						$atom_structure['time_to_sample_table'][$i]['sample_duration'] = getid3_lib::BigEndian2Int(substr($atom_data, $sttsEntriesDataOffset, 4));
+						$sttsEntriesDataOffset += 4;
+
+						$frames_count += $atom_structure['time_to_sample_table'][$i]['sample_count'];
+
+						// THIS SECTION REPLACED WITH CODE IN "stbl" ATOM
+						//if (!empty($info['quicktime']['time_scale']) && ($atom_structure['time_to_sample_table'][$i]['sample_duration'] > 0)) {
+						//	$stts_new_framerate = $info['quicktime']['time_scale'] / $atom_structure['time_to_sample_table'][$i]['sample_duration'];
+						//	if ($stts_new_framerate <= 60) {
+						//		// some atoms have durations of "1" giving a very large framerate, which probably is not right
+						//		$info['video']['frame_rate'] = max($info['video']['frame_rate'], $stts_new_framerate);
+						//	}
+						//}
+						//
+						//$FrameRateCalculatorArray[($info['quicktime']['time_scale'] / $atom_structure['time_to_sample_table'][$i]['sample_duration'])] += $atom_structure['time_to_sample_table'][$i]['sample_count'];
+					}
+					$info['quicktime']['stts_framecount'][] = $frames_count;
+					//$sttsFramesTotal  = 0;
+					//$sttsSecondsTotal = 0;
+					//foreach ($FrameRateCalculatorArray as $frames_per_second => $frame_count) {
+					//	if (($frames_per_second > 60) || ($frames_per_second < 1)) {
+					//		// not video FPS information, probably audio information
+					//		$sttsFramesTotal  = 0;
+					//		$sttsSecondsTotal = 0;
+					//		break;
+					//	}
+					//	$sttsFramesTotal  += $frame_count;
+					//	$sttsSecondsTotal += $frame_count / $frames_per_second;
+					//}
+					//if (($sttsFramesTotal > 0) && ($sttsSecondsTotal > 0)) {
+					//	if (($sttsFramesTotal / $sttsSecondsTotal) > $info['video']['frame_rate']) {
+					//		$info['video']['frame_rate'] = $sttsFramesTotal / $sttsSecondsTotal;
+					//	}
+					//}
+					break;
+
+
+				case 'stss': // Sample Table Sync Sample (key frames) atom
+					if ($ParseAllPossibleAtoms) {
+						$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+						$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+						$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+						$stssEntriesDataOffset = 8;
+						for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
+							$atom_structure['time_to_sample_table'][$i] = getid3_lib::BigEndian2Int(substr($atom_data, $stssEntriesDataOffset, 4));
+							$stssEntriesDataOffset += 4;
+						}
+					}
+					break;
+
+
+				case 'stsc': // Sample Table Sample-to-Chunk atom
+					if ($ParseAllPossibleAtoms) {
+						$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+						$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+						$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+						$stscEntriesDataOffset = 8;
+						for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
+							$atom_structure['sample_to_chunk_table'][$i]['first_chunk']        = getid3_lib::BigEndian2Int(substr($atom_data, $stscEntriesDataOffset, 4));
+							$stscEntriesDataOffset += 4;
+							$atom_structure['sample_to_chunk_table'][$i]['samples_per_chunk']  = getid3_lib::BigEndian2Int(substr($atom_data, $stscEntriesDataOffset, 4));
+							$stscEntriesDataOffset += 4;
+							$atom_structure['sample_to_chunk_table'][$i]['sample_description'] = getid3_lib::BigEndian2Int(substr($atom_data, $stscEntriesDataOffset, 4));
+							$stscEntriesDataOffset += 4;
+						}
+					}
+					break;
+
+
+				case 'stsz': // Sample Table SiZe atom
+					if ($ParseAllPossibleAtoms) {
+						$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+						$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+						$atom_structure['sample_size']    = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+						$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
+						$stszEntriesDataOffset = 12;
+						if ($atom_structure['sample_size'] == 0) {
+							for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
+								$atom_structure['sample_size_table'][$i] = getid3_lib::BigEndian2Int(substr($atom_data, $stszEntriesDataOffset, 4));
+								$stszEntriesDataOffset += 4;
+							}
+						}
+					}
+					break;
+
+
+				case 'stco': // Sample Table Chunk Offset atom
+//					if (true) {
+					if ($ParseAllPossibleAtoms) {
+						$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+						$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+						$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+						$stcoEntriesDataOffset = 8;
+						for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
+							$atom_structure['chunk_offset_table'][$i] = getid3_lib::BigEndian2Int(substr($atom_data, $stcoEntriesDataOffset, 4));
+							$stcoEntriesDataOffset += 4;
+						}
+					}
+					break;
+
+
+				case 'co64': // Chunk Offset 64-bit (version of "stco" that supports > 2GB files)
+					if ($ParseAllPossibleAtoms) {
+						$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+						$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+						$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+						$stcoEntriesDataOffset = 8;
+						for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
+							$atom_structure['chunk_offset_table'][$i] = getid3_lib::BigEndian2Int(substr($atom_data, $stcoEntriesDataOffset, 8));
+							$stcoEntriesDataOffset += 8;
+						}
+					}
+					break;
+
+
+				case 'dref': // Data REFerence atom
+					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+					$drefDataOffset = 8;
+					for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
+						$atom_structure['data_references'][$i]['size']                    = getid3_lib::BigEndian2Int(substr($atom_data, $drefDataOffset, 4));
+						$drefDataOffset += 4;
+						$atom_structure['data_references'][$i]['type']                    =                           substr($atom_data, $drefDataOffset, 4);
+						$drefDataOffset += 4;
+						$atom_structure['data_references'][$i]['version']                 = getid3_lib::BigEndian2Int(substr($atom_data,  $drefDataOffset, 1));
+						$drefDataOffset += 1;
+						$atom_structure['data_references'][$i]['flags_raw']               = getid3_lib::BigEndian2Int(substr($atom_data,  $drefDataOffset, 3)); // hardcoded: 0x0000
+						$drefDataOffset += 3;
+						$atom_structure['data_references'][$i]['data']                    =                           substr($atom_data, $drefDataOffset, ($atom_structure['data_references'][$i]['size'] - 4 - 4 - 1 - 3));
+						$drefDataOffset += ($atom_structure['data_references'][$i]['size'] - 4 - 4 - 1 - 3);
+
+						$atom_structure['data_references'][$i]['flags']['self_reference'] = (bool) ($atom_structure['data_references'][$i]['flags_raw'] & 0x001);
+					}
+					break;
+
+
+				case 'gmin': // base Media INformation atom
+					$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['graphics_mode']          = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
+					$atom_structure['opcolor_red']            = getid3_lib::BigEndian2Int(substr($atom_data,  6, 2));
+					$atom_structure['opcolor_green']          = getid3_lib::BigEndian2Int(substr($atom_data,  8, 2));
+					$atom_structure['opcolor_blue']           = getid3_lib::BigEndian2Int(substr($atom_data, 10, 2));
+					$atom_structure['balance']                = getid3_lib::BigEndian2Int(substr($atom_data, 12, 2));
+					$atom_structure['reserved']               = getid3_lib::BigEndian2Int(substr($atom_data, 14, 2));
+					break;
+
+
+				case 'smhd': // Sound Media information HeaDer atom
+					$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['balance']                = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
+					$atom_structure['reserved']               = getid3_lib::BigEndian2Int(substr($atom_data,  6, 2));
+					break;
+
+
+				case 'vmhd': // Video Media information HeaDer atom
+					$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3));
+					$atom_structure['graphics_mode']          = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
+					$atom_structure['opcolor_red']            = getid3_lib::BigEndian2Int(substr($atom_data,  6, 2));
+					$atom_structure['opcolor_green']          = getid3_lib::BigEndian2Int(substr($atom_data,  8, 2));
+					$atom_structure['opcolor_blue']           = getid3_lib::BigEndian2Int(substr($atom_data, 10, 2));
+
+					$atom_structure['flags']['no_lean_ahead'] = (bool) ($atom_structure['flags_raw'] & 0x001);
+					break;
+
+
+				case 'hdlr': // HanDLeR reference atom
+					$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['component_type']         =                           substr($atom_data,  4, 4);
+					$atom_structure['component_subtype']      =                           substr($atom_data,  8, 4);
+					$atom_structure['component_manufacturer'] =                           substr($atom_data, 12, 4);
+					$atom_structure['component_flags_raw']    = getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
+					$atom_structure['component_flags_mask']   = getid3_lib::BigEndian2Int(substr($atom_data, 20, 4));
+					$atom_structure['component_name']         = $this->MaybePascal2String(substr($atom_data, 24));
+
+					if (($atom_structure['component_subtype'] == 'STpn') && ($atom_structure['component_manufacturer'] == 'zzzz')) {
+						$info['video']['dataformat'] = 'quicktimevr';
+					}
+					break;
+
+
+				case 'mdhd': // MeDia HeaDer atom
+					$atom_structure['version']               = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']             = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['creation_time']         = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+					$atom_structure['modify_time']           = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
+					$atom_structure['time_scale']            = getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
+					$atom_structure['duration']              = getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
+					$atom_structure['language_id']           = getid3_lib::BigEndian2Int(substr($atom_data, 20, 2));
+					$atom_structure['quality']               = getid3_lib::BigEndian2Int(substr($atom_data, 22, 2));
+
+					if ($atom_structure['time_scale'] == 0) {
+						$this->error('Corrupt Quicktime file: mdhd.time_scale == zero');
+						return false;
+					}
+					$info['quicktime']['time_scale'] = ((isset($info['quicktime']['time_scale']) && ($info['quicktime']['time_scale'] < 1000)) ? max($info['quicktime']['time_scale'], $atom_structure['time_scale']) : $atom_structure['time_scale']);
+
+					$atom_structure['creation_time_unix']    = getid3_lib::DateMac2Unix($atom_structure['creation_time']);
+					$atom_structure['modify_time_unix']      = getid3_lib::DateMac2Unix($atom_structure['modify_time']);
+					$atom_structure['playtime_seconds']      = $atom_structure['duration'] / $atom_structure['time_scale'];
+					$atom_structure['language']              = $this->QuicktimeLanguageLookup($atom_structure['language_id']);
+					if (empty($info['comments']['language']) || (!in_array($atom_structure['language'], $info['comments']['language']))) {
+						$info['comments']['language'][] = $atom_structure['language'];
+					}
+					$info['quicktime']['timestamps_unix']['create'][$atom_structure['hierarchy']] = $atom_structure['creation_time_unix'];
+					$info['quicktime']['timestamps_unix']['modify'][$atom_structure['hierarchy']] = $atom_structure['modify_time_unix'];
+					break;
+
+
+				case 'pnot': // Preview atom
+					$atom_structure['modification_date']      = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4)); // "standard Macintosh format"
+					$atom_structure['version_number']         = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2)); // hardcoded: 0x00
+					$atom_structure['atom_type']              =                           substr($atom_data,  6, 4);        // usually: 'PICT'
+					$atom_structure['atom_index']             = getid3_lib::BigEndian2Int(substr($atom_data, 10, 2)); // usually: 0x01
+
+					$atom_structure['modification_date_unix'] = getid3_lib::DateMac2Unix($atom_structure['modification_date']);
+					$info['quicktime']['timestamps_unix']['modify'][$atom_structure['hierarchy']] = $atom_structure['modification_date_unix'];
+					break;
+
+
+				case 'crgn': // Clipping ReGioN atom
+					$atom_structure['region_size']   = getid3_lib::BigEndian2Int(substr($atom_data,  0, 2)); // The Region size, Region boundary box,
+					$atom_structure['boundary_box']  = getid3_lib::BigEndian2Int(substr($atom_data,  2, 8)); // and Clipping region data fields
+					$atom_structure['clipping_data'] =                           substr($atom_data, 10);           // constitute a QuickDraw region.
+					break;
+
+
+				case 'load': // track LOAD settings atom
+					$atom_structure['preload_start_time'] = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4));
+					$atom_structure['preload_duration']   = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+					$atom_structure['preload_flags_raw']  = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
+					$atom_structure['default_hints_raw']  = getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
+
+					$atom_structure['default_hints']['double_buffer'] = (bool) ($atom_structure['default_hints_raw'] & 0x0020);
+					$atom_structure['default_hints']['high_quality']  = (bool) ($atom_structure['default_hints_raw'] & 0x0100);
+					break;
+
+
+				case 'tmcd': // TiMe CoDe atom
+				case 'chap': // CHAPter list atom
+				case 'sync': // SYNChronization atom
+				case 'scpt': // tranSCriPT atom
+				case 'ssrc': // non-primary SouRCe atom
+					for ($i = 0; $i < strlen($atom_data); $i += 4) {
+						@$atom_structure['track_id'][] = getid3_lib::BigEndian2Int(substr($atom_data, $i, 4));
+					}
+					break;
+
+
+				case 'elst': // Edit LiST atom
+					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+					for ($i = 0; $i < $atom_structure['number_entries']; $i++ ) {
+						$atom_structure['edit_list'][$i]['track_duration'] =   getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($i * 12) + 0, 4));
+						$atom_structure['edit_list'][$i]['media_time']     =   getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($i * 12) + 4, 4));
+						$atom_structure['edit_list'][$i]['media_rate']     = getid3_lib::FixedPoint16_16(substr($atom_data, 8 + ($i * 12) + 8, 4));
+					}
+					break;
+
+
+				case 'kmat': // compressed MATte atom
+					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
+					$atom_structure['matte_data_raw'] =               substr($atom_data,  4);
+					break;
+
+
+				case 'ctab': // Color TABle atom
+					$atom_structure['color_table_seed']   = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4)); // hardcoded: 0x00000000
+					$atom_structure['color_table_flags']  = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2)); // hardcoded: 0x8000
+					$atom_structure['color_table_size']   = getid3_lib::BigEndian2Int(substr($atom_data,  6, 2)) + 1;
+					for ($colortableentry = 0; $colortableentry < $atom_structure['color_table_size']; $colortableentry++) {
+						$atom_structure['color_table'][$colortableentry]['alpha'] = getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($colortableentry * 8) + 0, 2));
+						$atom_structure['color_table'][$colortableentry]['red']   = getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($colortableentry * 8) + 2, 2));
+						$atom_structure['color_table'][$colortableentry]['green'] = getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($colortableentry * 8) + 4, 2));
+						$atom_structure['color_table'][$colortableentry]['blue']  = getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($colortableentry * 8) + 6, 2));
+					}
+					break;
+
+
+				case 'mvhd': // MoVie HeaDer atom
+					$atom_structure['version']            =   getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']          =   getid3_lib::BigEndian2Int(substr($atom_data,  1, 3));
+					$atom_structure['creation_time']      =   getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+					$atom_structure['modify_time']        =   getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
+					$atom_structure['time_scale']         =   getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
+					$atom_structure['duration']           =   getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
+					$atom_structure['preferred_rate']     = getid3_lib::FixedPoint16_16(substr($atom_data, 20, 4));
+					$atom_structure['preferred_volume']   =   getid3_lib::FixedPoint8_8(substr($atom_data, 24, 2));
+					$atom_structure['reserved']           =                             substr($atom_data, 26, 10);
+					$atom_structure['matrix_a']           = getid3_lib::FixedPoint16_16(substr($atom_data, 36, 4));
+					$atom_structure['matrix_b']           = getid3_lib::FixedPoint16_16(substr($atom_data, 40, 4));
+					$atom_structure['matrix_u']           =  getid3_lib::FixedPoint2_30(substr($atom_data, 44, 4));
+					$atom_structure['matrix_c']           = getid3_lib::FixedPoint16_16(substr($atom_data, 48, 4));
+					$atom_structure['matrix_d']           = getid3_lib::FixedPoint16_16(substr($atom_data, 52, 4));
+					$atom_structure['matrix_v']           =  getid3_lib::FixedPoint2_30(substr($atom_data, 56, 4));
+					$atom_structure['matrix_x']           = getid3_lib::FixedPoint16_16(substr($atom_data, 60, 4));
+					$atom_structure['matrix_y']           = getid3_lib::FixedPoint16_16(substr($atom_data, 64, 4));
+					$atom_structure['matrix_w']           =  getid3_lib::FixedPoint2_30(substr($atom_data, 68, 4));
+					$atom_structure['preview_time']       =   getid3_lib::BigEndian2Int(substr($atom_data, 72, 4));
+					$atom_structure['preview_duration']   =   getid3_lib::BigEndian2Int(substr($atom_data, 76, 4));
+					$atom_structure['poster_time']        =   getid3_lib::BigEndian2Int(substr($atom_data, 80, 4));
+					$atom_structure['selection_time']     =   getid3_lib::BigEndian2Int(substr($atom_data, 84, 4));
+					$atom_structure['selection_duration'] =   getid3_lib::BigEndian2Int(substr($atom_data, 88, 4));
+					$atom_structure['current_time']       =   getid3_lib::BigEndian2Int(substr($atom_data, 92, 4));
+					$atom_structure['next_track_id']      =   getid3_lib::BigEndian2Int(substr($atom_data, 96, 4));
+
+					if ($atom_structure['time_scale'] == 0) {
+						$this->error('Corrupt Quicktime file: mvhd.time_scale == zero');
+						return false;
+					}
+					$atom_structure['creation_time_unix']        = getid3_lib::DateMac2Unix($atom_structure['creation_time']);
+					$atom_structure['modify_time_unix']          = getid3_lib::DateMac2Unix($atom_structure['modify_time']);
+					$info['quicktime']['timestamps_unix']['create'][$atom_structure['hierarchy']] = $atom_structure['creation_time_unix'];
+					$info['quicktime']['timestamps_unix']['modify'][$atom_structure['hierarchy']] = $atom_structure['modify_time_unix'];
+					$info['quicktime']['time_scale']    = ((isset($info['quicktime']['time_scale']) && ($info['quicktime']['time_scale'] < 1000)) ? max($info['quicktime']['time_scale'], $atom_structure['time_scale']) : $atom_structure['time_scale']);
+					$info['quicktime']['display_scale'] = $atom_structure['matrix_a'];
+					$info['playtime_seconds']           = $atom_structure['duration'] / $atom_structure['time_scale'];
+					break;
+
+
+				case 'tkhd': // TracK HeaDer atom
+					$atom_structure['version']             =   getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']           =   getid3_lib::BigEndian2Int(substr($atom_data,  1, 3));
+					$atom_structure['creation_time']       =   getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+					$atom_structure['modify_time']         =   getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
+					$atom_structure['trackid']             =   getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
+					$atom_structure['reserved1']           =   getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
+					$atom_structure['duration']            =   getid3_lib::BigEndian2Int(substr($atom_data, 20, 4));
+					$atom_structure['reserved2']           =   getid3_lib::BigEndian2Int(substr($atom_data, 24, 8));
+					$atom_structure['layer']               =   getid3_lib::BigEndian2Int(substr($atom_data, 32, 2));
+					$atom_structure['alternate_group']     =   getid3_lib::BigEndian2Int(substr($atom_data, 34, 2));
+					$atom_structure['volume']              =   getid3_lib::FixedPoint8_8(substr($atom_data, 36, 2));
+					$atom_structure['reserved3']           =   getid3_lib::BigEndian2Int(substr($atom_data, 38, 2));
+					// http://developer.apple.com/library/mac/#documentation/QuickTime/RM/MovieBasics/MTEditing/K-Chapter/11MatrixFunctions.html
+					// http://developer.apple.com/library/mac/#documentation/QuickTime/qtff/QTFFChap4/qtff4.html#//apple_ref/doc/uid/TP40000939-CH206-18737
+					$atom_structure['matrix_a']            = getid3_lib::FixedPoint16_16(substr($atom_data, 40, 4));
+					$atom_structure['matrix_b']            = getid3_lib::FixedPoint16_16(substr($atom_data, 44, 4));
+					$atom_structure['matrix_u']            =  getid3_lib::FixedPoint2_30(substr($atom_data, 48, 4));
+					$atom_structure['matrix_c']            = getid3_lib::FixedPoint16_16(substr($atom_data, 52, 4));
+					$atom_structure['matrix_d']            = getid3_lib::FixedPoint16_16(substr($atom_data, 56, 4));
+					$atom_structure['matrix_v']            =  getid3_lib::FixedPoint2_30(substr($atom_data, 60, 4));
+					$atom_structure['matrix_x']            = getid3_lib::FixedPoint16_16(substr($atom_data, 64, 4));
+					$atom_structure['matrix_y']            = getid3_lib::FixedPoint16_16(substr($atom_data, 68, 4));
+					$atom_structure['matrix_w']            =  getid3_lib::FixedPoint2_30(substr($atom_data, 72, 4));
+					$atom_structure['width']               = getid3_lib::FixedPoint16_16(substr($atom_data, 76, 4));
+					$atom_structure['height']              = getid3_lib::FixedPoint16_16(substr($atom_data, 80, 4));
+					$atom_structure['flags']['enabled']    = (bool) ($atom_structure['flags_raw'] & 0x0001);
+					$atom_structure['flags']['in_movie']   = (bool) ($atom_structure['flags_raw'] & 0x0002);
+					$atom_structure['flags']['in_preview'] = (bool) ($atom_structure['flags_raw'] & 0x0004);
+					$atom_structure['flags']['in_poster']  = (bool) ($atom_structure['flags_raw'] & 0x0008);
+					$atom_structure['creation_time_unix']  = getid3_lib::DateMac2Unix($atom_structure['creation_time']);
+					$atom_structure['modify_time_unix']    = getid3_lib::DateMac2Unix($atom_structure['modify_time']);
+					$info['quicktime']['timestamps_unix']['create'][$atom_structure['hierarchy']] = $atom_structure['creation_time_unix'];
+					$info['quicktime']['timestamps_unix']['modify'][$atom_structure['hierarchy']] = $atom_structure['modify_time_unix'];
+
+					// https://www.getid3.org/phpBB3/viewtopic.php?t=1908
+					// attempt to compute rotation from matrix values
+					// 2017-Dec-28: uncertain if 90/270 are correctly oriented; values returned by FixedPoint16_16 should perhaps be -1 instead of 65535(?)
+					$matrixRotation = 0;
+					switch ($atom_structure['matrix_a'].':'.$atom_structure['matrix_b'].':'.$atom_structure['matrix_c'].':'.$atom_structure['matrix_d']) {
+						case '1:0:0:1':         $matrixRotation =   0; break;
+						case '0:1:65535:0':     $matrixRotation =  90; break;
+						case '65535:0:0:65535': $matrixRotation = 180; break;
+						case '0:65535:1:0':     $matrixRotation = 270; break;
+						default: break;
+					}
+
+					// https://www.getid3.org/phpBB3/viewtopic.php?t=2468
+					// The rotation matrix can appear in the Quicktime file multiple times, at least once for each track,
+					// and it's possible that only the video track (or, in theory, one of the video tracks) is flagged as
+					// rotated while the other tracks (e.g. audio) is tagged as rotation=0 (behavior noted on iPhone 8 Plus)
+					// The correct solution would be to check if the TrackID associated with the rotation matrix is indeed
+					// a video track (or the main video track) and only set the rotation then, but since information about
+					// what track is what is not trivially there to be examined, the lazy solution is to set the rotation
+					// if it is found to be nonzero, on the assumption that tracks that don't need it will have rotation set
+					// to zero (and be effectively ignored) and the video track will have rotation set correctly, which will
+					// either be zero and automatically correct, or nonzero and be set correctly.
+					if (!isset($info['video']['rotate']) || (($info['video']['rotate'] == 0) && ($matrixRotation > 0))) {
+						$info['quicktime']['video']['rotate'] = $info['video']['rotate'] = $matrixRotation;
+					}
+
+					if ($atom_structure['flags']['enabled'] == 1) {
+						if (!isset($info['video']['resolution_x']) || !isset($info['video']['resolution_y'])) {
+							$info['video']['resolution_x'] = $atom_structure['width'];
+							$info['video']['resolution_y'] = $atom_structure['height'];
+						}
+						$info['video']['resolution_x'] = max($info['video']['resolution_x'], $atom_structure['width']);
+						$info['video']['resolution_y'] = max($info['video']['resolution_y'], $atom_structure['height']);
+						$info['quicktime']['video']['resolution_x'] = $info['video']['resolution_x'];
+						$info['quicktime']['video']['resolution_y'] = $info['video']['resolution_y'];
+					} else {
+						// see: https://www.getid3.org/phpBB3/viewtopic.php?t=1295
+						//if (isset($info['video']['resolution_x'])) { unset($info['video']['resolution_x']); }
+						//if (isset($info['video']['resolution_y'])) { unset($info['video']['resolution_y']); }
+						//if (isset($info['quicktime']['video']))    { unset($info['quicktime']['video']);    }
+					}
+					break;
+
+
+				case 'iods': // Initial Object DeScriptor atom
+					// http://www.koders.com/c/fid1FAB3E762903DC482D8A246D4A4BF9F28E049594.aspx?s=windows.h
+					// http://libquicktime.sourcearchive.com/documentation/1.0.2plus-pdebian/iods_8c-source.html
+					$offset = 0;
+					$atom_structure['version']                =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
+					$offset += 1;
+					$atom_structure['flags_raw']              =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 3));
+					$offset += 3;
+					$atom_structure['mp4_iod_tag']            =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
+					$offset += 1;
+					$atom_structure['length']                 = $this->quicktime_read_mp4_descr_length($atom_data, $offset);
+					//$offset already adjusted by quicktime_read_mp4_descr_length()
+					$atom_structure['object_descriptor_id']   =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 2));
+					$offset += 2;
+					$atom_structure['od_profile_level']       =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
+					$offset += 1;
+					$atom_structure['scene_profile_level']    =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
+					$offset += 1;
+					$atom_structure['audio_profile_id']       =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
+					$offset += 1;
+					$atom_structure['video_profile_id']       =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
+					$offset += 1;
+					$atom_structure['graphics_profile_level'] =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
+					$offset += 1;
+
+					$atom_structure['num_iods_tracks'] = ($atom_structure['length'] - 7) / 6; // 6 bytes would only be right if all tracks use 1-byte length fields
+					for ($i = 0; $i < $atom_structure['num_iods_tracks']; $i++) {
+						$atom_structure['track'][$i]['ES_ID_IncTag'] =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
+						$offset += 1;
+						$atom_structure['track'][$i]['length']       = $this->quicktime_read_mp4_descr_length($atom_data, $offset);
+						//$offset already adjusted by quicktime_read_mp4_descr_length()
+						$atom_structure['track'][$i]['track_id']     =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 4));
+						$offset += 4;
+					}
+
+					$atom_structure['audio_profile_name'] = $this->QuicktimeIODSaudioProfileName($atom_structure['audio_profile_id']);
+					$atom_structure['video_profile_name'] = $this->QuicktimeIODSvideoProfileName($atom_structure['video_profile_id']);
+					break;
+
+				case 'ftyp': // FileTYPe (?) atom (for MP4 it seems)
+					$atom_structure['signature'] =                           substr($atom_data,  0, 4);
+					$atom_structure['unknown_1'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+					$atom_structure['fourcc']    =                           substr($atom_data,  8, 4);
+					break;
+
 				case 'mdat': // Media DATa atom
-					// 'mdat' contains the actual data for the audio/video
+					// 'mdat' contains the actual data for the audio/video, possibly also subtitles
+
+	/* due to lack of known documentation, this is a kludge implementation. If you know of documentation on how mdat is properly structed, please send it to info@getid3.org */
+
+					// first, skip any 'wide' padding, and second 'mdat' header (with specified size of zero?)
+					$mdat_offset = 0;
+					while (true) {
+						if (substr($atom_data, $mdat_offset, 8) == "\x00\x00\x00\x08".'wide') {
+							$mdat_offset += 8;
+						} elseif (substr($atom_data, $mdat_offset, 8) == "\x00\x00\x00\x00".'mdat') {
+							$mdat_offset += 8;
+						} else {
+							break;
+						}
+					}
+					if (substr($atom_data, $mdat_offset, 4) == 'GPRO') {
+						$GOPRO_chunk_length = getid3_lib::LittleEndian2Int(substr($atom_data, $mdat_offset + 4, 4));
+						$GOPRO_offset = 8;
+						$atom_structure['GPRO']['raw'] = substr($atom_data, $mdat_offset + 8, $GOPRO_chunk_length - 8);
+						$atom_structure['GPRO']['firmware'] = substr($atom_structure['GPRO']['raw'],  0, 15);
+						$atom_structure['GPRO']['unknown1'] = substr($atom_structure['GPRO']['raw'], 15, 16);
+						$atom_structure['GPRO']['unknown2'] = substr($atom_structure['GPRO']['raw'], 31, 32);
+						$atom_structure['GPRO']['unknown3'] = substr($atom_structure['GPRO']['raw'], 63, 16);
+						$atom_structure['GPRO']['camera']   = substr($atom_structure['GPRO']['raw'], 79, 32);
+						$info['quicktime']['camera']['model'] = rtrim($atom_structure['GPRO']['camera'], "\x00");
+					}
+
+					// check to see if it looks like chapter titles, in the form of unterminated strings with a leading 16-bit size field
+					while (($mdat_offset < (strlen($atom_data) - 8))
+						&& ($chapter_string_length = getid3_lib::BigEndian2Int(substr($atom_data, $mdat_offset, 2)))
+						&& ($chapter_string_length < 1000)
+						&& ($chapter_string_length <= (strlen($atom_data) - $mdat_offset - 2))
+						&& preg_match('#^([\x00-\xFF]{2})([\x20-\xFF]+)$#', substr($atom_data, $mdat_offset, $chapter_string_length + 2), $chapter_matches)) {
+							list($dummy, $chapter_string_length_hex, $chapter_string) = $chapter_matches;
+							$mdat_offset += (2 + $chapter_string_length);
+							@$info['quicktime']['comments']['chapters'][] = $chapter_string;
+
+							// "encd" atom specifies encoding. In theory could be anything, almost always UTF-8, but may be UTF-16 with BOM (not currently handled)
+							if (substr($atom_data, $mdat_offset, 12) == "\x00\x00\x00\x0C\x65\x6E\x63\x64\x00\x00\x01\x00") { // UTF-8
+								$mdat_offset += 12;
+							}
+					}
+
 					if (($atomsize > 8) && (!isset($info['avdataend_tmp']) || ($info['quicktime'][$atomname]['size'] > ($info['avdataend_tmp'] - $info['avdataoffset'])))) {
 
-						$info['avdataoffset'] = $info['quicktime'][$atomname]['offset'] + 8;
+						$info['avdataoffset'] = $atom_structure['offset'] + 8;                       // $info['quicktime'][$atomname]['offset'] + 8;
 						$OldAVDataEnd         = $info['avdataend'];
-						$info['avdataend']    = $info['quicktime'][$atomname]['offset'] + $info['quicktime'][$atomname]['size'];
+						$info['avdataend']    = $atom_structure['offset'] + $atom_structure['size']; // $info['quicktime'][$atomname]['offset'] + $info['quicktime'][$atomname]['size'];
 
 						$getid3_temp = new getID3();
-						$getid3_temp->openfile($this->getid3->filename);
+						$getid3_temp->openfile($this->getid3->filename, $this->getid3->info['filesize'], $this->getid3->fp);
 						$getid3_temp->info['avdataoffset'] = $info['avdataoffset'];
 						$getid3_temp->info['avdataend']    = $info['avdataend'];
 						$getid3_mp3 = new getid3_mp3($getid3_temp);
-						if ($getid3_mp3->MPEGaudioHeaderValid($getid3_mp3->MPEGaudioHeaderDecode(fread($this->getid3->fp, 4)))) {
+						if ($getid3_mp3->MPEGaudioHeaderValid($getid3_mp3->MPEGaudioHeaderDecode($this->fread(4)))) {
 							$getid3_mp3->getOnlyMPEGaudioInfo($getid3_temp->info['avdataoffset'], false);
 							if (!empty($getid3_temp->info['warning'])) {
 								foreach ($getid3_temp->info['warning'] as $value) {
-									$info['warning'][] = $value;
+									$this->warning($value);
 								}
 							}
 							if (!empty($getid3_temp->info['mpeg'])) {
@@ -103,1248 +1510,534 @@ class getid3_quicktime extends getid3_handler
 						unset($OldAVDataEnd);
 
 					}
+
+					unset($mdat_offset, $chapter_string_length, $chapter_matches);
 					break;
 
 				case 'free': // FREE space atom
 				case 'skip': // SKIP atom
 				case 'wide': // 64-bit expansion placeholder atom
 					// 'free', 'skip' and 'wide' are just padding, contains no useful data at all
+
+					// When writing QuickTime files, it is sometimes necessary to update an atom's size.
+					// It is impossible to update a 32-bit atom to a 64-bit atom since the 32-bit atom
+					// is only 8 bytes in size, and the 64-bit atom requires 16 bytes. Therefore, QuickTime
+					// puts an 8-byte placeholder atom before any atoms it may have to update the size of.
+					// In this way, if the atom needs to be converted from a 32-bit to a 64-bit atom, the
+					// placeholder atom can be overwritten to obtain the necessary 8 extra bytes.
+					// The placeholder atom has a type of kWideAtomPlaceholderType ( 'wide' ).
 					break;
 
-				default:
-					$atomHierarchy = array();
-					$info['quicktime'][$atomname] = $this->QuicktimeParseAtom($atomname, $atomsize, fread($this->getid3->fp, $atomsize), $offset, $atomHierarchy, $this->ParseAllPossibleAtoms);
+
+				case 'nsav': // NoSAVe atom
+					// http://developer.apple.com/technotes/tn/tn2038.html
+					$atom_structure['data'] = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4));
 					break;
-			}
 
-			$offset += $atomsize;
-			$atomcounter++;
-		}
-
-		if (!empty($info['avdataend_tmp'])) {
-			// this value is assigned to a temp value and then erased because
-			// otherwise any atoms beyond the 'mdat' atom would not get parsed
-			$info['avdataend'] = $info['avdataend_tmp'];
-			unset($info['avdataend_tmp']);
-		}
-
-		if (!isset($info['bitrate']) && isset($info['playtime_seconds'])) {
-			$info['bitrate'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
-		}
-		if (isset($info['bitrate']) && !isset($info['audio']['bitrate']) && !isset($info['quicktime']['video'])) {
-			$info['audio']['bitrate'] = $info['bitrate'];
-		}
-		if (!empty($info['playtime_seconds']) && !isset($info['video']['frame_rate']) && !empty($info['quicktime']['stts_framecount'])) {
-			foreach ($info['quicktime']['stts_framecount'] as $key => $samples_count) {
-				$samples_per_second = $samples_count / $info['playtime_seconds'];
-				if ($samples_per_second > 240) {
-					// has to be audio samples
-				} else {
-					$info['video']['frame_rate'] = $samples_per_second;
-					break;
-				}
-			}
-		}
-		if (($info['audio']['dataformat'] == 'mp4') && empty($info['video']['resolution_x'])) {
-			$info['fileformat'] = 'mp4';
-			$info['mime_type']  = 'audio/mp4';
-			unset($info['video']['dataformat']);
-		}
-
-		if (!$this->ReturnAtomData) {
-			unset($info['quicktime']['moov']);
-		}
-
-		if (empty($info['audio']['dataformat']) && !empty($info['quicktime']['audio'])) {
-			$info['audio']['dataformat'] = 'quicktime';
-		}
-		if (empty($info['video']['dataformat']) && !empty($info['quicktime']['video'])) {
-			$info['video']['dataformat'] = 'quicktime';
-		}
-
-		return true;
-	}
-
-	public function QuicktimeParseAtom($atomname, $atomsize, $atom_data, $baseoffset, &$atomHierarchy, $ParseAllPossibleAtoms) {
-		// http://developer.apple.com/techpubs/quicktime/qtdevdocs/APIREF/INDEX/atomalphaindex.htm
-
-		$info = &$this->getid3->info;
-
-		$atom_parent = array_pop($atomHierarchy);
-		array_push($atomHierarchy, $atomname);
-		$atom_structure['hierarchy'] = implode(' ', $atomHierarchy);
-		$atom_structure['name']      = $atomname;
-		$atom_structure['size']      = $atomsize;
-		$atom_structure['offset']    = $baseoffset;
-//echo getid3_lib::PrintHexBytes(substr($atom_data, 0, 8)).'<br>';
-//echo getid3_lib::PrintHexBytes(substr($atom_data, 0, 8), false).'<br><br>';
-		switch ($atomname) {
-			case 'moov': // MOVie container atom
-			case 'trak': // TRAcK container atom
-			case 'clip': // CLIPping container atom
-			case 'matt': // track MATTe container atom
-			case 'edts': // EDiTS container atom
-			case 'tref': // Track REFerence container atom
-			case 'mdia': // MeDIA container atom
-			case 'minf': // Media INFormation container atom
-			case 'dinf': // Data INFormation container atom
-			case 'udta': // User DaTA container atom
-			case 'cmov': // Compressed MOVie container atom
-			case 'rmra': // Reference Movie Record Atom
-			case 'rmda': // Reference Movie Descriptor Atom
-			case 'gmhd': // Generic Media info HeaDer atom (seen on QTVR)
-				$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
-				break;
-
-			case 'ilst': // Item LiST container atom
-				$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
-
-				// some "ilst" atoms contain data atoms that have a numeric name, and the data is far more accessible if the returned array is compacted
-				$allnumericnames = true;
-				foreach ($atom_structure['subatoms'] as $subatomarray) {
-					if (!is_integer($subatomarray['name']) || (count($subatomarray['subatoms']) != 1)) {
-						$allnumericnames = false;
-						break;
-					}
-				}
-				if ($allnumericnames) {
-					$newData = array();
-					foreach ($atom_structure['subatoms'] as $subatomarray) {
-						foreach ($subatomarray['subatoms'] as $newData_subatomarray) {
-							unset($newData_subatomarray['hierarchy'], $newData_subatomarray['name']);
-							$newData[$subatomarray['name']] = $newData_subatomarray;
+				case 'ctyp': // Controller TYPe atom (seen on QTVR)
+					// http://homepages.slingshot.co.nz/~helmboy/quicktime/formats/qtm-layout.txt
+					// some controller names are:
+					//   0x00 + 'std' for linear movie
+					//   'none' for no controls
+					$atom_structure['ctyp'] = substr($atom_data, 0, 4);
+					$info['quicktime']['controller'] = $atom_structure['ctyp'];
+					switch ($atom_structure['ctyp']) {
+						case 'qtvr':
+							$info['video']['dataformat'] = 'quicktimevr';
 							break;
-						}
 					}
-					$atom_structure['data'] = $newData;
-					unset($atom_structure['subatoms']);
-				}
-				break;
+					break;
 
-			case "\x00\x00\x00\x01":
-			case "\x00\x00\x00\x02":
-			case "\x00\x00\x00\x03":
-			case "\x00\x00\x00\x04":
-			case "\x00\x00\x00\x05":
-				$atomname = getid3_lib::BigEndian2Int($atomname);
-				$atom_structure['name'] = $atomname;
-				$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
-				break;
+				case 'pano': // PANOrama track (seen on QTVR)
+					$atom_structure['pano'] = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4));
+					break;
 
-			case 'stbl': // Sample TaBLe container atom
-				$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
-				$isVideo = false;
-				$framerate  = 0;
-				$framecount = 0;
-				foreach ($atom_structure['subatoms'] as $key => $value_array) {
-					if (isset($value_array['sample_description_table'])) {
-						foreach ($value_array['sample_description_table'] as $key2 => $value_array2) {
-							if (isset($value_array2['data_format'])) {
-								switch ($value_array2['data_format']) {
-									case 'avc1':
-									case 'mp4v':
-										// video data
-										$isVideo = true;
+				case 'hint': // HINT track
+				case 'hinf': //
+				case 'hinv': //
+				case 'hnti': //
+					$info['quicktime']['hinting'] = true;
+					break;
+
+				case 'imgt': // IMaGe Track reference (kQTVRImageTrackRefType) (seen on QTVR)
+					for ($i = 0; $i < ($atom_structure['size'] - 8); $i += 4) {
+						$atom_structure['imgt'][] = getid3_lib::BigEndian2Int(substr($atom_data, $i, 4));
+					}
+					break;
+
+
+				// Observed-but-not-handled atom types are just listed here to prevent warnings being generated
+				case 'FXTC': // Something to do with Adobe After Effects (?)
+				case 'PrmA':
+				case 'code':
+				case 'FIEL': // this is NOT "fiel" (Field Ordering) as describe here: http://developer.apple.com/documentation/QuickTime/QTFF/QTFFChap3/chapter_4_section_2.html
+				case 'tapt': // TrackApertureModeDimensionsAID - http://developer.apple.com/documentation/QuickTime/Reference/QT7-1_Update_Reference/Constants/Constants.html
+							// tapt seems to be used to compute the video size [https://www.getid3.org/phpBB3/viewtopic.php?t=838]
+							// * http://lists.apple.com/archives/quicktime-api/2006/Aug/msg00014.html
+							// * http://handbrake.fr/irclogs/handbrake-dev/handbrake-dev20080128_pg2.html
+				case 'ctts'://  STCompositionOffsetAID             - http://developer.apple.com/documentation/QuickTime/Reference/QTRef_Constants/Reference/reference.html
+				case 'cslg'://  STCompositionShiftLeastGreatestAID - http://developer.apple.com/documentation/QuickTime/Reference/QTRef_Constants/Reference/reference.html
+				case 'sdtp'://  STSampleDependencyAID              - http://developer.apple.com/documentation/QuickTime/Reference/QTRef_Constants/Reference/reference.html
+				case 'stps'://  STPartialSyncSampleAID             - http://developer.apple.com/documentation/QuickTime/Reference/QTRef_Constants/Reference/reference.html
+					//$atom_structure['data'] = $atom_data;
+					break;
+
+				case "\xA9".'xyz':  // GPS latitude+longitude+altitude
+					$atom_structure['data'] = $atom_data;
+					if (preg_match('#([\\+\\-][0-9\\.]+)([\\+\\-][0-9\\.]+)([\\+\\-][0-9\\.]+)?/$#i', $atom_data, $matches)) {
+						@list($all, $latitude, $longitude, $altitude) = $matches;
+						$info['quicktime']['comments']['gps_latitude'][]  = floatval($latitude);
+						$info['quicktime']['comments']['gps_longitude'][] = floatval($longitude);
+						if (!empty($altitude)) {
+							$info['quicktime']['comments']['gps_altitude'][] = floatval($altitude);
+						}
+					} else {
+						$this->warning('QuickTime atom "Â©xyz" data does not match expected data pattern at offset '.$baseoffset.'. Please report as getID3() bug.');
+					}
+					break;
+
+				case 'NCDT':
+					// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html
+					// Nikon-specific QuickTime tags found in the NCDT atom of MOV videos from some Nikon cameras such as the Coolpix S8000 and D5100
+					$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 4, $atomHierarchy, $ParseAllPossibleAtoms);
+					break;
+				case 'NCTH': // Nikon Camera THumbnail image
+				case 'NCVW': // Nikon Camera preVieW image
+					// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html
+					if (preg_match('/^\xFF\xD8\xFF/', $atom_data)) {
+						$atom_structure['data'] = $atom_data;
+						$atom_structure['image_mime'] = 'image/jpeg';
+						$atom_structure['description'] = (($atomname == 'NCTH') ? 'Nikon Camera Thumbnail Image' : (($atomname == 'NCVW') ? 'Nikon Camera Preview Image' : 'Nikon preview image'));
+						$info['quicktime']['comments']['picture'][] = array('image_mime'=>$atom_structure['image_mime'], 'data'=>$atom_data, 'description'=>$atom_structure['description']);
+					}
+					break;
+				case 'NCTG': // Nikon - http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html#NCTG
+					$atom_structure['data'] = $this->QuicktimeParseNikonNCTG($atom_data);
+					break;
+				case 'NCHD': // Nikon:MakerNoteVersion  - http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html
+				case 'NCDB': // Nikon                   - http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html
+				case 'CNCV': // Canon:CompressorVersion - http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Canon.html
+					$atom_structure['data'] = $atom_data;
+					break;
+
+				case "\x00\x00\x00\x00":
+					// some kind of metacontainer, may contain a big data dump such as:
+					// mdta keys \005 mdtacom.apple.quicktime.make (mdtacom.apple.quicktime.creationdate ,mdtacom.apple.quicktime.location.ISO6709 $mdtacom.apple.quicktime.software !mdtacom.apple.quicktime.model ilst \01D \001 \015data \001DE\010Apple 0 \002 (data \001DE\0102011-05-11T17:54:04+0200 2 \003 *data \001DE\010+52.4936+013.3897+040.247/ \01D \004 \015data \001DE\0104.3.1 \005 \018data \001DE\010iPhone 4
+					// http://www.geocities.com/xhelmboyx/quicktime/formats/qti-layout.txt
+
+					$atom_structure['version']   =          getid3_lib::BigEndian2Int(substr($atom_data, 0, 1));
+					$atom_structure['flags_raw'] =          getid3_lib::BigEndian2Int(substr($atom_data, 1, 3));
+					$atom_structure['subatoms']  = $this->QuicktimeParseContainerAtom(substr($atom_data, 4), $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
+					//$atom_structure['subatoms']  = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
+					break;
+
+				case 'meta': // METAdata atom
+					// https://developer.apple.com/library/mac/documentation/QuickTime/QTFF/Metadata/Metadata.html
+
+					$atom_structure['version']   =          getid3_lib::BigEndian2Int(substr($atom_data, 0, 1));
+					$atom_structure['flags_raw'] =          getid3_lib::BigEndian2Int(substr($atom_data, 1, 3));
+					$atom_structure['subatoms']  = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
+					break;
+
+				case 'data': // metaDATA atom
+					static $metaDATAkey = 1; // real ugly, but so is the QuickTime structure that stores keys and values in different multinested locations that are hard to relate to each other
+					// seems to be 2 bytes language code (ASCII), 2 bytes unknown (set to 0x10B5 in sample I have), remainder is useful data
+					$atom_structure['language'] =                           substr($atom_data, 4 + 0, 2);
+					$atom_structure['unknown']  = getid3_lib::BigEndian2Int(substr($atom_data, 4 + 2, 2));
+					$atom_structure['data']     =                           substr($atom_data, 4 + 4);
+					$atom_structure['key_name'] = @$info['quicktime']['temp_meta_key_names'][$metaDATAkey++];
+
+					if ($atom_structure['key_name'] && $atom_structure['data']) {
+						@$info['quicktime']['comments'][str_replace('com.apple.quicktime.', '', $atom_structure['key_name'])][] = $atom_structure['data'];
+					}
+					break;
+
+				case 'keys': // KEYS that may be present in the metadata atom.
+					// https://developer.apple.com/library/mac/documentation/QuickTime/QTFF/Metadata/Metadata.html#//apple_ref/doc/uid/TP40000939-CH1-SW21
+					// The metadata item keys atom holds a list of the metadata keys that may be present in the metadata atom.
+					// This list is indexed starting with 1; 0 is a reserved index value. The metadata item keys atom is a full atom with an atom type of "keys".
+					$atom_structure['version']       = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+					$atom_structure['flags_raw']     = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3));
+					$atom_structure['entry_count']   = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
+					$keys_atom_offset = 8;
+					for ($i = 1; $i <= $atom_structure['entry_count']; $i++) {
+						$atom_structure['keys'][$i]['key_size']      = getid3_lib::BigEndian2Int(substr($atom_data, $keys_atom_offset + 0, 4));
+						$atom_structure['keys'][$i]['key_namespace'] =                           substr($atom_data, $keys_atom_offset + 4, 4);
+						$atom_structure['keys'][$i]['key_value']     =                           substr($atom_data, $keys_atom_offset + 8, $atom_structure['keys'][$i]['key_size'] - 8);
+						$keys_atom_offset += $atom_structure['keys'][$i]['key_size']; // key_size includes the 4+4 bytes for key_size and key_namespace
+
+						$info['quicktime']['temp_meta_key_names'][$i] = $atom_structure['keys'][$i]['key_value'];
+					}
+					break;
+
+				case 'uuid': // user-defined atom often seen containing XML data, also used for potentially many other purposes, only a few specifically handled by getID3 (e.g. 360fly spatial data)
+					//Get the UUID ID in first 16 bytes
+					$uuid_bytes_read = unpack('H8time_low/H4time_mid/H4time_hi/H4clock_seq_hi/H12clock_seq_low', substr($atom_data, 0, 16));
+					$atom_structure['uuid_field_id'] = implode('-', $uuid_bytes_read);
+
+					switch ($atom_structure['uuid_field_id']) {   // http://fileformats.archiveteam.org/wiki/Boxes/atoms_format#UUID_boxes
+
+						case '0537cdab-9d0c-4431-a72a-fa561f2a113e': // Exif                                       - http://fileformats.archiveteam.org/wiki/Exif
+						case '2c4c0100-8504-40b9-a03e-562148d6dfeb': // Photoshop Image Resources                  - http://fileformats.archiveteam.org/wiki/Photoshop_Image_Resources
+						case '33c7a4d2-b81d-4723-a0ba-f1a3e097ad38': // IPTC-IIM                                   - http://fileformats.archiveteam.org/wiki/IPTC-IIM
+						case '8974dbce-7be7-4c51-84f9-7148f9882554': // PIFF Track Encryption Box                  - http://fileformats.archiveteam.org/wiki/Protected_Interoperable_File_Format
+						case '96a9f1f1-dc98-402d-a7ae-d68e34451809': // GeoJP2 World File Box                      - http://fileformats.archiveteam.org/wiki/GeoJP2
+						case 'a2394f52-5a9b-4f14-a244-6c427c648df4': // PIFF Sample Encryption Box                 - http://fileformats.archiveteam.org/wiki/Protected_Interoperable_File_Format
+						case 'b14bf8bd-083d-4b43-a5ae-8cd7d5a6ce03': // GeoJP2 GeoTIFF Box                         - http://fileformats.archiveteam.org/wiki/GeoJP2
+						case 'd08a4f18-10f3-4a82-b6c8-32d8aba183d3': // PIFF Protection System Specific Header Box - http://fileformats.archiveteam.org/wiki/Protected_Interoperable_File_Format
+							$this->warning('Unhandled (but recognized) "uuid" atom identified by "'.$atom_structure['uuid_field_id'].'" at offset '.$atom_structure['offset'].' ('.strlen($atom_data).' bytes)');
+							break;
+
+						case 'be7acfcb-97a9-42e8-9c71-999491e3afac': // XMP data (in XML format)
+							$atom_structure['xml'] = substr($atom_data, 16, strlen($atom_data) - 16 - 8); // 16 bytes for UUID, 8 bytes header(?)
+							break;
+
+						case 'efe1589a-bb77-49ef-8095-27759eb1dc6f': // 360fly data
+							/* 360fly code in this block by Paul Lewis 2019-Oct-31 */
+							/*	Sensor Timestamps need to be calculated using the recordings base time at ['quicktime']['moov']['subatoms'][0]['creation_time_unix']. */
+							$atom_structure['title'] = '360Fly Sensor Data';
+
+							//Get the UUID HEADER data
+							$uuid_bytes_read = unpack('vheader_size/vheader_version/vtimescale/vhardware_version/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/', substr($atom_data, 16, 32));
+							$atom_structure['uuid_header'] = $uuid_bytes_read;
+
+							$start_byte = 48;
+							$atom_SENSOR_data = substr($atom_data, $start_byte);
+							$atom_structure['sensor_data']['data_type'] = array(
+									'fusion_count'   => 0,       // ID 250
+									'fusion_data'    => array(),
+									'accel_count'    => 0,       // ID 1
+									'accel_data'     => array(),
+									'gyro_count'     => 0,       // ID 2
+									'gyro_data'      => array(),
+									'magno_count'    => 0,       // ID 3
+									'magno_data'     => array(),
+									'gps_count'      => 0,       // ID 5
+									'gps_data'       => array(),
+									'rotation_count' => 0,       // ID 6
+									'rotation_data'  => array(),
+									'unknown_count'  => 0,       // ID ??
+									'unknown_data'   => array(),
+									'debug_list'     => '',      // Used to debug variables stored as comma delimited strings
+							);
+							$debug_structure['debug_items'] = array();
+							// Can start loop here to decode all sensor data in 32 Byte chunks:
+							foreach (str_split($atom_SENSOR_data, 32) as $sensor_key => $sensor_data) {
+								// This gets me a data_type code to work out what data is in the next 31 bytes.
+								$sensor_data_type = substr($sensor_data, 0, 1);
+								$sensor_data_content = substr($sensor_data, 1);
+								$uuid_bytes_read = unpack('C*', $sensor_data_type);
+								$sensor_data_array = array();
+								switch ($uuid_bytes_read[1]) {
+									case 250:
+										$atom_structure['sensor_data']['data_type']['fusion_count']++;
+										$uuid_bytes_read = unpack('cmode/Jtimestamp/Gyaw/Gpitch/Groll/x*', $sensor_data_content);
+										$sensor_data_array['mode']      = $uuid_bytes_read['mode'];
+										$sensor_data_array['timestamp'] = $uuid_bytes_read['timestamp'];
+										$sensor_data_array['yaw']       = $uuid_bytes_read['yaw'];
+										$sensor_data_array['pitch']     = $uuid_bytes_read['pitch'];
+										$sensor_data_array['roll']      = $uuid_bytes_read['roll'];
+										array_push($atom_structure['sensor_data']['data_type']['fusion_data'], $sensor_data_array);
 										break;
-									case 'mp4a':
-										// audio data
+									case 1:
+										$atom_structure['sensor_data']['data_type']['accel_count']++;
+										$uuid_bytes_read = unpack('cmode/Jtimestamp/Gyaw/Gpitch/Groll/x*', $sensor_data_content);
+										$sensor_data_array['mode']      = $uuid_bytes_read['mode'];
+										$sensor_data_array['timestamp'] = $uuid_bytes_read['timestamp'];
+										$sensor_data_array['yaw']       = $uuid_bytes_read['yaw'];
+										$sensor_data_array['pitch']     = $uuid_bytes_read['pitch'];
+										$sensor_data_array['roll']      = $uuid_bytes_read['roll'];
+										array_push($atom_structure['sensor_data']['data_type']['accel_data'], $sensor_data_array);
+										break;
+									case 2:
+										$atom_structure['sensor_data']['data_type']['gyro_count']++;
+										$uuid_bytes_read = unpack('cmode/Jtimestamp/Gyaw/Gpitch/Groll/x*', $sensor_data_content);
+										$sensor_data_array['mode']      = $uuid_bytes_read['mode'];
+										$sensor_data_array['timestamp'] = $uuid_bytes_read['timestamp'];
+										$sensor_data_array['yaw']       = $uuid_bytes_read['yaw'];
+										$sensor_data_array['pitch']     = $uuid_bytes_read['pitch'];
+										$sensor_data_array['roll']      = $uuid_bytes_read['roll'];
+										array_push($atom_structure['sensor_data']['data_type']['gyro_data'], $sensor_data_array);
+										break;
+									case 3:
+										$atom_structure['sensor_data']['data_type']['magno_count']++;
+										$uuid_bytes_read = unpack('cmode/Jtimestamp/Gmagx/Gmagy/Gmagz/x*', $sensor_data_content);
+										$sensor_data_array['mode']      = $uuid_bytes_read['mode'];
+										$sensor_data_array['timestamp'] = $uuid_bytes_read['timestamp'];
+										$sensor_data_array['magx']      = $uuid_bytes_read['magx'];
+										$sensor_data_array['magy']      = $uuid_bytes_read['magy'];
+										$sensor_data_array['magz']      = $uuid_bytes_read['magz'];
+										array_push($atom_structure['sensor_data']['data_type']['magno_data'], $sensor_data_array);
+										break;
+									case 5:
+										$atom_structure['sensor_data']['data_type']['gps_count']++;
+										$uuid_bytes_read = unpack('cmode/Jtimestamp/Glat/Glon/Galt/Gspeed/nbearing/nacc/x*', $sensor_data_content);
+										$sensor_data_array['mode']      = $uuid_bytes_read['mode'];
+										$sensor_data_array['timestamp'] = $uuid_bytes_read['timestamp'];
+										$sensor_data_array['lat']       = $uuid_bytes_read['lat'];
+										$sensor_data_array['lon']       = $uuid_bytes_read['lon'];
+										$sensor_data_array['alt']       = $uuid_bytes_read['alt'];
+										$sensor_data_array['speed']     = $uuid_bytes_read['speed'];
+										$sensor_data_array['bearing']   = $uuid_bytes_read['bearing'];
+										$sensor_data_array['acc']       = $uuid_bytes_read['acc'];
+										array_push($atom_structure['sensor_data']['data_type']['gps_data'], $sensor_data_array);
+										//array_push($debug_structure['debug_items'], $uuid_bytes_read['timestamp']);
+										break;
+									case 6:
+										$atom_structure['sensor_data']['data_type']['rotation_count']++;
+										$uuid_bytes_read = unpack('cmode/Jtimestamp/Grotx/Groty/Grotz/x*', $sensor_data_content);
+										$sensor_data_array['mode']      = $uuid_bytes_read['mode'];
+										$sensor_data_array['timestamp'] = $uuid_bytes_read['timestamp'];
+										$sensor_data_array['rotx']      = $uuid_bytes_read['rotx'];
+										$sensor_data_array['roty']      = $uuid_bytes_read['roty'];
+										$sensor_data_array['rotz']      = $uuid_bytes_read['rotz'];
+										array_push($atom_structure['sensor_data']['data_type']['rotation_data'], $sensor_data_array);
+										break;
+									default:
+										$atom_structure['sensor_data']['data_type']['unknown_count']++;
 										break;
 								}
 							}
-						}
-					} elseif (isset($value_array['time_to_sample_table'])) {
-						foreach ($value_array['time_to_sample_table'] as $key2 => $value_array2) {
-							if (isset($value_array2['sample_count']) && isset($value_array2['sample_duration']) && ($value_array2['sample_duration'] > 0)) {
-								$framerate  = round($info['quicktime']['time_scale'] / $value_array2['sample_duration'], 3);
-								$framecount = $value_array2['sample_count'];
-							}
-						}
+							//if (isset($debug_structure['debug_items']) && count($debug_structure['debug_items']) > 0) {
+							//	$atom_structure['sensor_data']['data_type']['debug_list'] = implode(',', $debug_structure['debug_items']);
+							//} else {
+								$atom_structure['sensor_data']['data_type']['debug_list'] = 'No debug items in list!';
+							//}
+							break;
+
+						default:
+							$this->warning('Unhandled "uuid" atom identified by "'.$atom_structure['uuid_field_id'].'" at offset '.$atom_structure['offset'].' ('.strlen($atom_data).' bytes)');
 					}
-				}
-				if ($isVideo && $framerate) {
-					$info['quicktime']['video']['frame_rate'] = $framerate;
-					$info['video']['frame_rate'] = $info['quicktime']['video']['frame_rate'];
-				}
-				if ($isVideo && $framecount) {
-					$info['quicktime']['video']['frame_count'] = $framecount;
-				}
-				break;
+					break;
 
+				case 'gps ':
+					// https://dashcamtalk.com/forum/threads/script-to-extract-gps-data-from-novatek-mp4.20808/page-2#post-291730
+					// The 'gps ' contains simple look up table made up of 8byte rows, that point to the 'free' atoms that contains the actual GPS data.
+					// The first row is version/metadata/notsure, I skip that.
+					// The following rows consist of 4byte address (absolute) and 4byte size (0x1000), these point to the GPS data in the file.
 
-			case 'aART': // Album ARTist
-			case 'catg': // CaTeGory
-			case 'covr': // COVeR artwork
-			case 'cpil': // ComPILation
-			case 'cprt': // CoPyRighT
-			case 'desc': // DESCription
-			case 'disk': // DISK number
-			case 'egid': // Episode Global ID
-			case 'gnre': // GeNRE
-			case 'keyw': // KEYWord
-			case 'ldes':
-			case 'pcst': // PodCaST
-			case 'pgap': // GAPless Playback
-			case 'purd': // PURchase Date
-			case 'purl': // Podcast URL
-			case 'rati':
-			case 'rndu':
-			case 'rpdu':
-			case 'rtng': // RaTiNG
-			case 'stik':
-			case 'tmpo': // TeMPO (BPM)
-			case 'trkn': // TRacK Number
-			case 'tves': // TV EpiSode
-			case 'tvnn': // TV Network Name
-			case 'tvsh': // TV SHow Name
-			case 'tvsn': // TV SeasoN
-			case 'akID': // iTunes store account type
-			case 'apID':
-			case 'atID':
-			case 'cmID':
-			case 'cnID':
-			case 'geID':
-			case 'plID':
-			case 'sfID': // iTunes store country
-			case '©alb': // ALBum
-			case '©art': // ARTist
-			case '©ART':
-			case '©aut':
-			case '©cmt': // CoMmenT
-			case '©com': // COMposer
-			case '©cpy':
-			case '©day': // content created year
-			case '©dir':
-			case '©ed1':
-			case '©ed2':
-			case '©ed3':
-			case '©ed4':
-			case '©ed5':
-			case '©ed6':
-			case '©ed7':
-			case '©ed8':
-			case '©ed9':
-			case '©enc':
-			case '©fmt':
-			case '©gen': // GENre
-			case '©grp': // GRouPing
-			case '©hst':
-			case '©inf':
-			case '©lyr': // LYRics
-			case '©mak':
-			case '©mod':
-			case '©nam': // full NAMe
-			case '©ope':
-			case '©PRD':
-			case '©prd':
-			case '©prf':
-			case '©req':
-			case '©src':
-			case '©swr':
-			case '©too': // encoder
-			case '©trk': // TRacK
-			case '©url':
-			case '©wrn':
-			case '©wrt': // WRiTer
-			case '----': // itunes specific
-				if ($atom_parent == 'udta') {
-					// User data atom handler
-					$atom_structure['data_length'] = getid3_lib::BigEndian2Int(substr($atom_data, 0, 2));
-					$atom_structure['language_id'] = getid3_lib::BigEndian2Int(substr($atom_data, 2, 2));
-					$atom_structure['data']        =                           substr($atom_data, 4);
-
-					$atom_structure['language']    = $this->QuicktimeLanguageLookup($atom_structure['language_id']);
-					if (empty($info['comments']['language']) || (!in_array($atom_structure['language'], $info['comments']['language']))) {
-						$info['comments']['language'][] = $atom_structure['language'];
-					}
-				} else {
-					// Apple item list box atom handler
-					$atomoffset = 0;
-					if (substr($atom_data, 2, 2) == "\x10\xB5") {
-						// not sure what it means, but observed on iPhone4 data.
-						// Each $atom_data has 2 bytes of datasize, plus 0x10B5, then data
-						while ($atomoffset < strlen($atom_data)) {
-							$boxsmallsize = getid3_lib::BigEndian2Int(substr($atom_data, $atomoffset,     2));
-							$boxsmalltype =                           substr($atom_data, $atomoffset + 2, 2);
-							$boxsmalldata =                           substr($atom_data, $atomoffset + 4, $boxsmallsize);
-							switch ($boxsmalltype) {
-								case "\x10\xB5":
-									$atom_structure['data'] = $boxsmalldata;
-									break;
-								default:
-									$info['warning'][] = 'Unknown QuickTime smallbox type: "'.getid3_lib::PrintHexBytes($boxsmalltype).'" at offset '.$baseoffset;
-									$atom_structure['data'] = $atom_data;
-									break;
+					$GPS_rowsize = 8; // 4 bytes for offset, 4 bytes for size
+					if (strlen($atom_data) > 0) {
+						if ((strlen($atom_data) % $GPS_rowsize) == 0) {
+							$atom_structure['gps_toc'] = array();
+							foreach (str_split($atom_data, $GPS_rowsize) as $counter => $datapair) {
+								$atom_structure['gps_toc'][] = unpack('Noffset/Nsize', substr($atom_data, $counter * $GPS_rowsize, $GPS_rowsize));
 							}
-							$atomoffset += (4 + $boxsmallsize);
+
+							$atom_structure['gps_entries'] = array();
+							$previous_offset = $this->ftell();
+							foreach ($atom_structure['gps_toc'] as $key => $gps_pointer) {
+								if ($key == 0) {
+									// "The first row is version/metadata/notsure, I skip that."
+									continue;
+								}
+								$this->fseek($gps_pointer['offset']);
+								$GPS_free_data = $this->fread($gps_pointer['size']);
+
+								/*
+								// 2017-05-10: I see some of the data, notably the Hour-Minute-Second, but cannot reconcile the rest of the data. However, the NMEA "GPRMC" line is there and relatively easy to parse, so I'm using that instead
+
+								// https://dashcamtalk.com/forum/threads/script-to-extract-gps-data-from-novatek-mp4.20808/page-2#post-291730
+								// The structure of the GPS data atom (the 'free' atoms mentioned above) is following:
+								// hour,minute,second,year,month,day,active,latitude_b,longitude_b,unknown2,latitude,longitude,speed = struct.unpack_from('<IIIIIIssssfff',data, 48)
+								// For those unfamiliar with python struct:
+								// I = int
+								// s = is string (size 1, in this case)
+								// f = float
+
+								//$atom_structure['gps_entries'][$key] = unpack('Vhour/Vminute/Vsecond/Vyear/Vmonth/Vday/Vactive/Vlatitude_b/Vlongitude_b/Vunknown2/flatitude/flongitude/fspeed', substr($GPS_free_data, 48));
+								*/
+
+								// $GPRMC,081836,A,3751.65,S,14507.36,E,000.0,360.0,130998,011.3,E*62
+								// $GPRMC,183731,A,3907.482,N,12102.436,W,000.0,360.0,080301,015.5,E*67
+								// $GPRMC,002454,A,3553.5295,N,13938.6570,E,0.0,43.1,180700,7.1,W,A*3F
+								// $GPRMC,094347.000,A,5342.0061,N,00737.9908,W,0.01,156.75,140217,,,A*7D
+								if (preg_match('#\\$GPRMC,([0-9\\.]*),([AV]),([0-9\\.]*),([NS]),([0-9\\.]*),([EW]),([0-9\\.]*),([0-9\\.]*),([0-9]*),([0-9\\.]*),([EW]?)(,[A])?(\\*[0-9A-F]{2})#', $GPS_free_data, $matches)) {
+									$GPS_this_GPRMC = array();
+									$GPS_this_GPRMC_raw = array();
+									list(
+										$GPS_this_GPRMC_raw['gprmc'],
+										$GPS_this_GPRMC_raw['timestamp'],
+										$GPS_this_GPRMC_raw['status'],
+										$GPS_this_GPRMC_raw['latitude'],
+										$GPS_this_GPRMC_raw['latitude_direction'],
+										$GPS_this_GPRMC_raw['longitude'],
+										$GPS_this_GPRMC_raw['longitude_direction'],
+										$GPS_this_GPRMC_raw['knots'],
+										$GPS_this_GPRMC_raw['angle'],
+										$GPS_this_GPRMC_raw['datestamp'],
+										$GPS_this_GPRMC_raw['variation'],
+										$GPS_this_GPRMC_raw['variation_direction'],
+										$dummy,
+										$GPS_this_GPRMC_raw['checksum'],
+									) = $matches;
+									$GPS_this_GPRMC['raw'] = $GPS_this_GPRMC_raw;
+
+									$hour   = substr($GPS_this_GPRMC['raw']['timestamp'], 0, 2);
+									$minute = substr($GPS_this_GPRMC['raw']['timestamp'], 2, 2);
+									$second = substr($GPS_this_GPRMC['raw']['timestamp'], 4, 2);
+									$ms     = substr($GPS_this_GPRMC['raw']['timestamp'], 6);    // may contain decimal seconds
+									$day    = substr($GPS_this_GPRMC['raw']['datestamp'], 0, 2);
+									$month  = substr($GPS_this_GPRMC['raw']['datestamp'], 2, 2);
+									$year   = (int) substr($GPS_this_GPRMC['raw']['datestamp'], 4, 2);
+									$year += (($year > 90) ? 1900 : 2000); // complete lack of foresight: datestamps are stored with 2-digit years, take best guess
+									$GPS_this_GPRMC['timestamp'] = $year.'-'.$month.'-'.$day.' '.$hour.':'.$minute.':'.$second.$ms;
+
+									$GPS_this_GPRMC['active'] = ($GPS_this_GPRMC['raw']['status'] == 'A'); // A=Active,V=Void
+
+									foreach (array('latitude','longitude') as $latlon) {
+										preg_match('#^([0-9]{1,3})([0-9]{2}\\.[0-9]+)$#', $GPS_this_GPRMC['raw'][$latlon], $matches);
+										list($dummy, $deg, $min) = $matches;
+										$GPS_this_GPRMC[$latlon] = $deg + ($min / 60);
+									}
+									$GPS_this_GPRMC['latitude']  *= (($GPS_this_GPRMC['raw']['latitude_direction']  == 'S') ? -1 : 1);
+									$GPS_this_GPRMC['longitude'] *= (($GPS_this_GPRMC['raw']['longitude_direction'] == 'W') ? -1 : 1);
+
+									$GPS_this_GPRMC['heading']    = $GPS_this_GPRMC['raw']['angle'];
+									$GPS_this_GPRMC['speed_knot'] = $GPS_this_GPRMC['raw']['knots'];
+									$GPS_this_GPRMC['speed_kmh']  = $GPS_this_GPRMC['raw']['knots'] * 1.852;
+									if ($GPS_this_GPRMC['raw']['variation']) {
+										$GPS_this_GPRMC['variation']  = $GPS_this_GPRMC['raw']['variation'];
+										$GPS_this_GPRMC['variation'] *= (($GPS_this_GPRMC['raw']['variation_direction'] == 'W') ? -1 : 1);
+									}
+
+									$atom_structure['gps_entries'][$key] = $GPS_this_GPRMC;
+
+									@$info['quicktime']['gps_track'][$GPS_this_GPRMC['timestamp']] = array(
+										'latitude'  => (float) $GPS_this_GPRMC['latitude'],
+										'longitude' => (float) $GPS_this_GPRMC['longitude'],
+										'speed_kmh' => (float) $GPS_this_GPRMC['speed_kmh'],
+										'heading'   => (float) $GPS_this_GPRMC['heading'],
+									);
+
+								} else {
+									$this->warning('Unhandled GPS format in "free" atom at offset '.$gps_pointer['offset']);
+								}
+							}
+							$this->fseek($previous_offset);
+
+						} else {
+							$this->warning('QuickTime atom "'.$atomname.'" is not mod-8 bytes long ('.$atomsize.' bytes) at offset '.$baseoffset);
 						}
 					} else {
-						while ($atomoffset < strlen($atom_data)) {
-							$boxsize = getid3_lib::BigEndian2Int(substr($atom_data, $atomoffset, 4));
-							$boxtype =                           substr($atom_data, $atomoffset + 4, 4);
-							$boxdata =                           substr($atom_data, $atomoffset + 8, $boxsize - 8);
-							if ($boxsize <= 1) {
-								$info['warning'][] = 'Invalid QuickTime atom box size "'.$boxsize.'" in atom "'.$atomname.'" at offset: '.($atom_structure['offset'] + $atomoffset);
-								$atom_structure['data'] = null;
-								$atomoffset = strlen($atom_data);
-								break;
-							}
-							$atomoffset += $boxsize;
+						$this->warning('QuickTime atom "'.$atomname.'" is zero bytes long at offset '.$baseoffset);
+					}
+					break;
 
-							switch ($boxtype) {
-								case 'mean':
-								case 'name':
-									$atom_structure[$boxtype] = substr($boxdata, 4);
-									break;
+				case 'loci':// 3GP location (El Loco)
+					$loffset = 0;
+					$info['quicktime']['comments']['gps_flags']     = array(  getid3_lib::BigEndian2Int(substr($atom_data, 0, 4)));
+					$info['quicktime']['comments']['gps_lang']      = array(  getid3_lib::BigEndian2Int(substr($atom_data, 4, 2)));
+					$info['quicktime']['comments']['gps_location']  = array(          $this->LociString(substr($atom_data, 6), $loffset));
+					$loci_data = substr($atom_data, 6 + $loffset);
+					$info['quicktime']['comments']['gps_role']      = array(  getid3_lib::BigEndian2Int(substr($loci_data, 0, 1)));
+					$info['quicktime']['comments']['gps_longitude'] = array(getid3_lib::FixedPoint16_16(substr($loci_data, 1, 4)));
+					$info['quicktime']['comments']['gps_latitude']  = array(getid3_lib::FixedPoint16_16(substr($loci_data, 5, 4)));
+					$info['quicktime']['comments']['gps_altitude']  = array(getid3_lib::FixedPoint16_16(substr($loci_data, 9, 4)));
+					$info['quicktime']['comments']['gps_body']      = array(          $this->LociString(substr($loci_data, 13           ), $loffset));
+					$info['quicktime']['comments']['gps_notes']     = array(          $this->LociString(substr($loci_data, 13 + $loffset), $loffset));
+					break;
 
-								case 'data':
-									$atom_structure['version']   = getid3_lib::BigEndian2Int(substr($boxdata,  0, 1));
-									$atom_structure['flags_raw'] = getid3_lib::BigEndian2Int(substr($boxdata,  1, 3));
-									switch ($atom_structure['flags_raw']) {
-										case 0:  // data flag
-										case 21: // tmpo/cpil flag
-											switch ($atomname) {
-												case 'cpil':
-												case 'pcst':
-												case 'pgap':
-													$atom_structure['data'] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 1));
-													break;
-
-												case 'tmpo':
-													$atom_structure['data'] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 2));
-													break;
-
-												case 'disk':
-												case 'trkn':
-													$num       = getid3_lib::BigEndian2Int(substr($boxdata, 10, 2));
-													$num_total = getid3_lib::BigEndian2Int(substr($boxdata, 12, 2));
-													$atom_structure['data']  = empty($num) ? '' : $num;
-													$atom_structure['data'] .= empty($num_total) ? '' : '/'.$num_total;
-													break;
-
-												case 'gnre':
-													$GenreID = getid3_lib::BigEndian2Int(substr($boxdata, 8, 4));
-													$atom_structure['data']    = getid3_id3v1::LookupGenreName($GenreID - 1);
-													break;
-
-												case 'rtng':
-													$atom_structure[$atomname] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 1));
-													$atom_structure['data']    = $this->QuicktimeContentRatingLookup($atom_structure[$atomname]);
-													break;
-
-												case 'stik':
-													$atom_structure[$atomname] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 1));
-													$atom_structure['data']    = $this->QuicktimeSTIKLookup($atom_structure[$atomname]);
-													break;
-
-												case 'sfID':
-													$atom_structure[$atomname] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 4));
-													$atom_structure['data']    = $this->QuicktimeStoreFrontCodeLookup($atom_structure[$atomname]);
-													break;
-
-												case 'egid':
-												case 'purl':
-													$atom_structure['data'] = substr($boxdata, 8);
-													break;
-
-												default:
-													$atom_structure['data'] = getid3_lib::BigEndian2Int(substr($boxdata, 8, 4));
-											}
-											break;
-
-										case 1:  // text flag
-										case 13: // image flag
-										default:
-											$atom_structure['data'] = substr($boxdata, 8);
-											break;
-
-									}
-									break;
-
-								default:
-									$info['warning'][] = 'Unknown QuickTime box type: "'.getid3_lib::PrintHexBytes($boxtype).'" at offset '.$baseoffset;
-									$atom_structure['data'] = $atom_data;
-
-							}
+				case 'chpl': // CHaPter List
+					// https://www.adobe.com/content/dam/Adobe/en/devnet/flv/pdfs/video_file_format_spec_v10.pdf
+					$chpl_version = getid3_lib::BigEndian2Int(substr($atom_data, 4, 1)); // Expected to be 0
+					$chpl_flags   = getid3_lib::BigEndian2Int(substr($atom_data, 5, 3)); // Reserved, set to 0
+					$chpl_count   = getid3_lib::BigEndian2Int(substr($atom_data, 8, 1));
+					$chpl_offset = 9;
+					for ($i = 0; $i < $chpl_count; $i++) {
+						if (($chpl_offset + 9) >= strlen($atom_data)) {
+							$this->warning('QuickTime chapter '.$i.' extends beyond end of "chpl" atom');
+							break;
 						}
+						$info['quicktime']['chapters'][$i]['timestamp'] = getid3_lib::BigEndian2Int(substr($atom_data, $chpl_offset, 8)) / 10000000; // timestamps are stored as 100-nanosecond units
+						$chpl_offset += 8;
+						$chpl_title_size = getid3_lib::BigEndian2Int(substr($atom_data, $chpl_offset, 1));
+						$chpl_offset += 1;
+						$info['quicktime']['chapters'][$i]['title']     =                           substr($atom_data, $chpl_offset, $chpl_title_size);
+						$chpl_offset += $chpl_title_size;
 					}
-				}
-				$this->CopyToAppropriateCommentsSection($atomname, $atom_structure['data'], $atom_structure['name']);
-				break;
+					break;
 
+				case 'FIRM': // FIRMware version(?), seen on GoPro Hero4
+					$info['quicktime']['camera']['firmware'] = $atom_data;
+					break;
 
-			case 'play': // auto-PLAY atom
-				$atom_structure['autoplay'] = (bool) getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
+				case 'CAME': // FIRMware version(?), seen on GoPro Hero4
+					$info['quicktime']['camera']['serial_hash'] = unpack('H*', $atom_data);
+					break;
 
-				$info['quicktime']['autoplay'] = $atom_structure['autoplay'];
-				break;
-
-
-			case 'WLOC': // Window LOCation atom
-				$atom_structure['location_x']  = getid3_lib::BigEndian2Int(substr($atom_data,  0, 2));
-				$atom_structure['location_y']  = getid3_lib::BigEndian2Int(substr($atom_data,  2, 2));
-				break;
-
-
-			case 'LOOP': // LOOPing atom
-			case 'SelO': // play SELection Only atom
-			case 'AllF': // play ALL Frames atom
-				$atom_structure['data'] = getid3_lib::BigEndian2Int($atom_data);
-				break;
-
-
-			case 'name': //
-			case 'MCPS': // Media Cleaner PRo
-			case '@PRM': // adobe PReMiere version
-			case '@PRQ': // adobe PRemiere Quicktime version
-				$atom_structure['data'] = $atom_data;
-				break;
-
-
-			case 'cmvd': // Compressed MooV Data atom
-				// Code by ubergeekØubergeek*tv based on information from
-				// http://developer.apple.com/quicktime/icefloe/dispatch012.html
-				$atom_structure['unCompressedSize'] = getid3_lib::BigEndian2Int(substr($atom_data, 0, 4));
-
-				$CompressedFileData = substr($atom_data, 4);
-				if ($UncompressedHeader = @gzuncompress($CompressedFileData)) {
-					$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($UncompressedHeader, 0, $atomHierarchy, $ParseAllPossibleAtoms);
-				} else {
-					$info['warning'][] = 'Error decompressing compressed MOV atom at offset '.$atom_structure['offset'];
-				}
-				break;
-
-
-			case 'dcom': // Data COMpression atom
-				$atom_structure['compression_id']   = $atom_data;
-				$atom_structure['compression_text'] = $this->QuicktimeDCOMLookup($atom_data);
-				break;
-
-
-			case 'rdrf': // Reference movie Data ReFerence atom
-				$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3));
-				$atom_structure['flags']['internal_data'] = (bool) ($atom_structure['flags_raw'] & 0x000001);
-
-				$atom_structure['reference_type_name']    =                           substr($atom_data,  4, 4);
-				$atom_structure['reference_length']       = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
-				switch ($atom_structure['reference_type_name']) {
-					case 'url ':
-						$atom_structure['url']            =       $this->NoNullString(substr($atom_data, 12));
-						break;
-
-					case 'alis':
-						$atom_structure['file_alias']     =                           substr($atom_data, 12);
-						break;
-
-					case 'rsrc':
-						$atom_structure['resource_alias'] =                           substr($atom_data, 12);
-						break;
-
-					default:
-						$atom_structure['data']           =                           substr($atom_data, 12);
-						break;
-				}
-				break;
-
-
-			case 'rmqu': // Reference Movie QUality atom
-				$atom_structure['movie_quality'] = getid3_lib::BigEndian2Int($atom_data);
-				break;
-
-
-			case 'rmcs': // Reference Movie Cpu Speed atom
-				$atom_structure['version']          = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']        = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['cpu_speed_rating'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
-				break;
-
-
-			case 'rmvc': // Reference Movie Version Check atom
-				$atom_structure['version']            = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']          = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['gestalt_selector']   =                           substr($atom_data,  4, 4);
-				$atom_structure['gestalt_value_mask'] = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
-				$atom_structure['gestalt_value']      = getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
-				$atom_structure['gestalt_check_type'] = getid3_lib::BigEndian2Int(substr($atom_data, 14, 2));
-				break;
-
-
-			case 'rmcd': // Reference Movie Component check atom
-				$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['component_type']         =                           substr($atom_data,  4, 4);
-				$atom_structure['component_subtype']      =                           substr($atom_data,  8, 4);
-				$atom_structure['component_manufacturer'] =                           substr($atom_data, 12, 4);
-				$atom_structure['component_flags_raw']    = getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
-				$atom_structure['component_flags_mask']   = getid3_lib::BigEndian2Int(substr($atom_data, 20, 4));
-				$atom_structure['component_min_version']  = getid3_lib::BigEndian2Int(substr($atom_data, 24, 4));
-				break;
-
-
-			case 'rmdr': // Reference Movie Data Rate atom
-				$atom_structure['version']       = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']     = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['data_rate']     = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-
-				$atom_structure['data_rate_bps'] = $atom_structure['data_rate'] * 10;
-				break;
-
-
-			case 'rmla': // Reference Movie Language Atom
-				$atom_structure['version']     = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']   = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['language_id'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
-
-				$atom_structure['language']    = $this->QuicktimeLanguageLookup($atom_structure['language_id']);
-				if (empty($info['comments']['language']) || (!in_array($atom_structure['language'], $info['comments']['language']))) {
-					$info['comments']['language'][] = $atom_structure['language'];
-				}
-				break;
-
-
-			case 'rmla': // Reference Movie Language Atom
-				$atom_structure['version']   = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw'] = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['track_id']  = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
-				break;
-
-
-			case 'ptv ': // Print To Video - defines a movie's full screen mode
-				// http://developer.apple.com/documentation/QuickTime/APIREF/SOURCESIV/at_ptv-_pg.htm
-				$atom_structure['display_size_raw']  = getid3_lib::BigEndian2Int(substr($atom_data, 0, 2));
-				$atom_structure['reserved_1']        = getid3_lib::BigEndian2Int(substr($atom_data, 2, 2)); // hardcoded: 0x0000
-				$atom_structure['reserved_2']        = getid3_lib::BigEndian2Int(substr($atom_data, 4, 2)); // hardcoded: 0x0000
-				$atom_structure['slide_show_flag']   = getid3_lib::BigEndian2Int(substr($atom_data, 6, 1));
-				$atom_structure['play_on_open_flag'] = getid3_lib::BigEndian2Int(substr($atom_data, 7, 1));
-
-				$atom_structure['flags']['play_on_open'] = (bool) $atom_structure['play_on_open_flag'];
-				$atom_structure['flags']['slide_show']   = (bool) $atom_structure['slide_show_flag'];
-
-				$ptv_lookup[0] = 'normal';
-				$ptv_lookup[1] = 'double';
-				$ptv_lookup[2] = 'half';
-				$ptv_lookup[3] = 'full';
-				$ptv_lookup[4] = 'current';
-				if (isset($ptv_lookup[$atom_structure['display_size_raw']])) {
-					$atom_structure['display_size'] = $ptv_lookup[$atom_structure['display_size_raw']];
-				} else {
-					$info['warning'][] = 'unknown "ptv " display constant ('.$atom_structure['display_size_raw'].')';
-				}
-				break;
-
-
-			case 'stsd': // Sample Table Sample Description atom
-				$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-				$stsdEntriesDataOffset = 8;
-				for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
-					$atom_structure['sample_description_table'][$i]['size']             = getid3_lib::BigEndian2Int(substr($atom_data, $stsdEntriesDataOffset, 4));
-					$stsdEntriesDataOffset += 4;
-					$atom_structure['sample_description_table'][$i]['data_format']      =                           substr($atom_data, $stsdEntriesDataOffset, 4);
-					$stsdEntriesDataOffset += 4;
-					$atom_structure['sample_description_table'][$i]['reserved']         = getid3_lib::BigEndian2Int(substr($atom_data, $stsdEntriesDataOffset, 6));
-					$stsdEntriesDataOffset += 6;
-					$atom_structure['sample_description_table'][$i]['reference_index']  = getid3_lib::BigEndian2Int(substr($atom_data, $stsdEntriesDataOffset, 2));
-					$stsdEntriesDataOffset += 2;
-					$atom_structure['sample_description_table'][$i]['data']             =                           substr($atom_data, $stsdEntriesDataOffset, ($atom_structure['sample_description_table'][$i]['size'] - 4 - 4 - 6 - 2));
-					$stsdEntriesDataOffset += ($atom_structure['sample_description_table'][$i]['size'] - 4 - 4 - 6 - 2);
-
-					$atom_structure['sample_description_table'][$i]['encoder_version']  = getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'],  0, 2));
-					$atom_structure['sample_description_table'][$i]['encoder_revision'] = getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'],  2, 2));
-					$atom_structure['sample_description_table'][$i]['encoder_vendor']   =                           substr($atom_structure['sample_description_table'][$i]['data'],  4, 4);
-
-					switch ($atom_structure['sample_description_table'][$i]['encoder_vendor']) {
-
-						case "\x00\x00\x00\x00":
-							// audio atom
-							$atom_structure['sample_description_table'][$i]['audio_channels']       =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'],  8,  2));
-							$atom_structure['sample_description_table'][$i]['audio_bit_depth']      =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 10,  2));
-							$atom_structure['sample_description_table'][$i]['audio_compression_id'] =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 12,  2));
-							$atom_structure['sample_description_table'][$i]['audio_packet_size']    =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 14,  2));
-							$atom_structure['sample_description_table'][$i]['audio_sample_rate']    = getid3_lib::FixedPoint16_16(substr($atom_structure['sample_description_table'][$i]['data'], 16,  4));
-
-							switch ($atom_structure['sample_description_table'][$i]['data_format']) {
-								case 'avc1':
-								case 'mp4v':
-									$info['fileformat'] = 'mp4';
-									$info['video']['fourcc'] = $atom_structure['sample_description_table'][$i]['data_format'];
-									//$info['warning'][] = 'This version of getID3() ['.$this->getid3->version().'] does not fully support MPEG-4 audio/video streams'; // 2011-02-18: why am I warning about this again? What's not supported?
-									break;
-
-								case 'qtvr':
-									$info['video']['dataformat'] = 'quicktimevr';
-									break;
-
-								case 'mp4a':
-								default:
-									$info['quicktime']['audio']['codec']       = $this->QuicktimeAudioCodecLookup($atom_structure['sample_description_table'][$i]['data_format']);
-									$info['quicktime']['audio']['sample_rate'] = $atom_structure['sample_description_table'][$i]['audio_sample_rate'];
-									$info['quicktime']['audio']['channels']    = $atom_structure['sample_description_table'][$i]['audio_channels'];
-									$info['quicktime']['audio']['bit_depth']   = $atom_structure['sample_description_table'][$i]['audio_bit_depth'];
-									$info['audio']['codec']                    = $info['quicktime']['audio']['codec'];
-									$info['audio']['sample_rate']              = $info['quicktime']['audio']['sample_rate'];
-									$info['audio']['channels']                 = $info['quicktime']['audio']['channels'];
-									$info['audio']['bits_per_sample']          = $info['quicktime']['audio']['bit_depth'];
-									switch ($atom_structure['sample_description_table'][$i]['data_format']) {
-										case 'raw ': // PCM
-										case 'alac': // Apple Lossless Audio Codec
-											$info['audio']['lossless'] = true;
-											break;
-										default:
-											$info['audio']['lossless'] = false;
-											break;
-									}
-									break;
+				case 'dscp':
+				case 'rcif':
+					// https://www.getid3.org/phpBB3/viewtopic.php?t=1908
+					if (substr($atom_data, 0, 7) == "\x00\x00\x00\x00\x55\xC4".'{') {
+						if ($json_decoded = @json_decode(rtrim(substr($atom_data, 6), "\x00"), true)) {
+							$info['quicktime']['camera'][$atomname] = $json_decoded;
+							if (($atomname == 'rcif') && isset($info['quicktime']['camera']['rcif']['wxcamera']['rotate'])) {
+								$info['video']['rotate'] = $info['quicktime']['video']['rotate'] = $info['quicktime']['camera']['rcif']['wxcamera']['rotate'];
 							}
-							break;
-
-						default:
-							switch ($atom_structure['sample_description_table'][$i]['data_format']) {
-								case 'mp4s':
-									$info['fileformat'] = 'mp4';
-									break;
-
-								default:
-									// video atom
-									$atom_structure['sample_description_table'][$i]['video_temporal_quality']  =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'],  8,  4));
-									$atom_structure['sample_description_table'][$i]['video_spatial_quality']   =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 12,  4));
-									$atom_structure['sample_description_table'][$i]['video_frame_width']       =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 16,  2));
-									$atom_structure['sample_description_table'][$i]['video_frame_height']      =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 18,  2));
-									$atom_structure['sample_description_table'][$i]['video_resolution_x']      = getid3_lib::FixedPoint16_16(substr($atom_structure['sample_description_table'][$i]['data'], 20,  4));
-									$atom_structure['sample_description_table'][$i]['video_resolution_y']      = getid3_lib::FixedPoint16_16(substr($atom_structure['sample_description_table'][$i]['data'], 24,  4));
-									$atom_structure['sample_description_table'][$i]['video_data_size']         =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 28,  4));
-									$atom_structure['sample_description_table'][$i]['video_frame_count']       =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 32,  2));
-									$atom_structure['sample_description_table'][$i]['video_encoder_name_len']  =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 34,  1));
-									$atom_structure['sample_description_table'][$i]['video_encoder_name']      =                             substr($atom_structure['sample_description_table'][$i]['data'], 35, $atom_structure['sample_description_table'][$i]['video_encoder_name_len']);
-									$atom_structure['sample_description_table'][$i]['video_pixel_color_depth'] =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 66,  2));
-									$atom_structure['sample_description_table'][$i]['video_color_table_id']    =   getid3_lib::BigEndian2Int(substr($atom_structure['sample_description_table'][$i]['data'], 68,  2));
-
-									$atom_structure['sample_description_table'][$i]['video_pixel_color_type']  = (($atom_structure['sample_description_table'][$i]['video_pixel_color_depth'] > 32) ? 'grayscale' : 'color');
-									$atom_structure['sample_description_table'][$i]['video_pixel_color_name']  = $this->QuicktimeColorNameLookup($atom_structure['sample_description_table'][$i]['video_pixel_color_depth']);
-
-									if ($atom_structure['sample_description_table'][$i]['video_pixel_color_name'] != 'invalid') {
-										$info['quicktime']['video']['codec_fourcc']        = $atom_structure['sample_description_table'][$i]['data_format'];
-										$info['quicktime']['video']['codec_fourcc_lookup'] = $this->QuicktimeVideoCodecLookup($atom_structure['sample_description_table'][$i]['data_format']);
-										$info['quicktime']['video']['codec']               = (($atom_structure['sample_description_table'][$i]['video_encoder_name_len'] > 0) ? $atom_structure['sample_description_table'][$i]['video_encoder_name'] : $atom_structure['sample_description_table'][$i]['data_format']);
-										$info['quicktime']['video']['color_depth']         = $atom_structure['sample_description_table'][$i]['video_pixel_color_depth'];
-										$info['quicktime']['video']['color_depth_name']    = $atom_structure['sample_description_table'][$i]['video_pixel_color_name'];
-
-										$info['video']['codec']           = $info['quicktime']['video']['codec'];
-										$info['video']['bits_per_sample'] = $info['quicktime']['video']['color_depth'];
-									}
-									$info['video']['lossless']           = false;
-									$info['video']['pixel_aspect_ratio'] = (float) 1;
-									break;
-							}
-							break;
-					}
-					switch (strtolower($atom_structure['sample_description_table'][$i]['data_format'])) {
-						case 'mp4a':
-							$info['audio']['dataformat']         = 'mp4';
-							$info['quicktime']['audio']['codec'] = 'mp4';
-							break;
-
-						case '3ivx':
-						case '3iv1':
-						case '3iv2':
-							$info['video']['dataformat'] = '3ivx';
-							break;
-
-						case 'xvid':
-							$info['video']['dataformat'] = 'xvid';
-							break;
-
-						case 'mp4v':
-							$info['video']['dataformat'] = 'mpeg4';
-							break;
-
-						case 'divx':
-						case 'div1':
-						case 'div2':
-						case 'div3':
-						case 'div4':
-						case 'div5':
-						case 'div6':
-							$info['video']['dataformat'] = 'divx';
-							break;
-
-						default:
-							// do nothing
-							break;
-					}
-					unset($atom_structure['sample_description_table'][$i]['data']);
-				}
-				break;
-
-
-			case 'stts': // Sample Table Time-to-Sample atom
-				$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-				$sttsEntriesDataOffset = 8;
-				//$FrameRateCalculatorArray = array();
-				$frames_count = 0;
-				for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
-					$atom_structure['time_to_sample_table'][$i]['sample_count']    = getid3_lib::BigEndian2Int(substr($atom_data, $sttsEntriesDataOffset, 4));
-					$sttsEntriesDataOffset += 4;
-					$atom_structure['time_to_sample_table'][$i]['sample_duration'] = getid3_lib::BigEndian2Int(substr($atom_data, $sttsEntriesDataOffset, 4));
-					$sttsEntriesDataOffset += 4;
-
-					$frames_count += $atom_structure['time_to_sample_table'][$i]['sample_count'];
-
-					// THIS SECTION REPLACED WITH CODE IN "stbl" ATOM
-					//if (!empty($info['quicktime']['time_scale']) && ($atom_structure['time_to_sample_table'][$i]['sample_duration'] > 0)) {
-					//	$stts_new_framerate = $info['quicktime']['time_scale'] / $atom_structure['time_to_sample_table'][$i]['sample_duration'];
-					//	if ($stts_new_framerate <= 60) {
-					//		// some atoms have durations of "1" giving a very large framerate, which probably is not right
-					//		$info['video']['frame_rate'] = max($info['video']['frame_rate'], $stts_new_framerate);
-					//	}
-					//}
-					//
-					//$FrameRateCalculatorArray[($info['quicktime']['time_scale'] / $atom_structure['time_to_sample_table'][$i]['sample_duration'])] += $atom_structure['time_to_sample_table'][$i]['sample_count'];
-				}
-				$info['quicktime']['stts_framecount'][] = $frames_count;
-				//$sttsFramesTotal  = 0;
-				//$sttsSecondsTotal = 0;
-				//foreach ($FrameRateCalculatorArray as $frames_per_second => $frame_count) {
-				//	if (($frames_per_second > 60) || ($frames_per_second < 1)) {
-				//		// not video FPS information, probably audio information
-				//		$sttsFramesTotal  = 0;
-				//		$sttsSecondsTotal = 0;
-				//		break;
-				//	}
-				//	$sttsFramesTotal  += $frame_count;
-				//	$sttsSecondsTotal += $frame_count / $frames_per_second;
-				//}
-				//if (($sttsFramesTotal > 0) && ($sttsSecondsTotal > 0)) {
-				//	if (($sttsFramesTotal / $sttsSecondsTotal) > $info['video']['frame_rate']) {
-				//		$info['video']['frame_rate'] = $sttsFramesTotal / $sttsSecondsTotal;
-				//	}
-				//}
-				break;
-
-
-			case 'stss': // Sample Table Sync Sample (key frames) atom
-				if ($ParseAllPossibleAtoms) {
-					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-					$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-					$stssEntriesDataOffset = 8;
-					for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
-						$atom_structure['time_to_sample_table'][$i] = getid3_lib::BigEndian2Int(substr($atom_data, $stssEntriesDataOffset, 4));
-						$stssEntriesDataOffset += 4;
-					}
-				}
-				break;
-
-
-			case 'stsc': // Sample Table Sample-to-Chunk atom
-				if ($ParseAllPossibleAtoms) {
-					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-					$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-					$stscEntriesDataOffset = 8;
-					for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
-						$atom_structure['sample_to_chunk_table'][$i]['first_chunk']        = getid3_lib::BigEndian2Int(substr($atom_data, $stscEntriesDataOffset, 4));
-						$stscEntriesDataOffset += 4;
-						$atom_structure['sample_to_chunk_table'][$i]['samples_per_chunk']  = getid3_lib::BigEndian2Int(substr($atom_data, $stscEntriesDataOffset, 4));
-						$stscEntriesDataOffset += 4;
-						$atom_structure['sample_to_chunk_table'][$i]['sample_description'] = getid3_lib::BigEndian2Int(substr($atom_data, $stscEntriesDataOffset, 4));
-						$stscEntriesDataOffset += 4;
-					}
-				}
-				break;
-
-
-			case 'stsz': // Sample Table SiZe atom
-				if ($ParseAllPossibleAtoms) {
-					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-					$atom_structure['sample_size']    = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-					$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
-					$stszEntriesDataOffset = 12;
-					if ($atom_structure['sample_size'] == 0) {
-						for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
-							$atom_structure['sample_size_table'][$i] = getid3_lib::BigEndian2Int(substr($atom_data, $stszEntriesDataOffset, 4));
-							$stszEntriesDataOffset += 4;
+						} else {
+							$this->warning('Failed to JSON decode atom "'.$atomname.'"');
+							$atom_structure['data'] = $atom_data;
 						}
+						unset($json_decoded);
+					} else {
+						$this->warning('Expecting 55 C4 7B at start of atom "'.$atomname.'", found '.getid3_lib::PrintHexBytes(substr($atom_data, 4, 3)).' instead');
+						$atom_structure['data'] = $atom_data;
 					}
-				}
-				break;
+					break;
 
-
-			case 'stco': // Sample Table Chunk Offset atom
-				if ($ParseAllPossibleAtoms) {
-					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-					$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-					$stcoEntriesDataOffset = 8;
-					for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
-						$atom_structure['chunk_offset_table'][$i] = getid3_lib::BigEndian2Int(substr($atom_data, $stcoEntriesDataOffset, 4));
-						$stcoEntriesDataOffset += 4;
-					}
-				}
-				break;
-
-
-			case 'co64': // Chunk Offset 64-bit (version of "stco" that supports > 2GB files)
-				if ($ParseAllPossibleAtoms) {
-					$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-					$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-					$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-					$stcoEntriesDataOffset = 8;
-					for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
-						$atom_structure['chunk_offset_table'][$i] = getid3_lib::BigEndian2Int(substr($atom_data, $stcoEntriesDataOffset, 8));
-						$stcoEntriesDataOffset += 8;
-					}
-				}
-				break;
-
-
-			case 'dref': // Data REFerence atom
-				$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-				$drefDataOffset = 8;
-				for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
-					$atom_structure['data_references'][$i]['size']                    = getid3_lib::BigEndian2Int(substr($atom_data, $drefDataOffset, 4));
-					$drefDataOffset += 4;
-					$atom_structure['data_references'][$i]['type']                    =               substr($atom_data, $drefDataOffset, 4);
-					$drefDataOffset += 4;
-					$atom_structure['data_references'][$i]['version']                 = getid3_lib::BigEndian2Int(substr($atom_data,  $drefDataOffset, 1));
-					$drefDataOffset += 1;
-					$atom_structure['data_references'][$i]['flags_raw']               = getid3_lib::BigEndian2Int(substr($atom_data,  $drefDataOffset, 3)); // hardcoded: 0x0000
-					$drefDataOffset += 3;
-					$atom_structure['data_references'][$i]['data']                    =               substr($atom_data, $drefDataOffset, ($atom_structure['data_references'][$i]['size'] - 4 - 4 - 1 - 3));
-					$drefDataOffset += ($atom_structure['data_references'][$i]['size'] - 4 - 4 - 1 - 3);
-
-					$atom_structure['data_references'][$i]['flags']['self_reference'] = (bool) ($atom_structure['data_references'][$i]['flags_raw'] & 0x001);
-				}
-				break;
-
-
-			case 'gmin': // base Media INformation atom
-				$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['graphics_mode']          = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
-				$atom_structure['opcolor_red']            = getid3_lib::BigEndian2Int(substr($atom_data,  6, 2));
-				$atom_structure['opcolor_green']          = getid3_lib::BigEndian2Int(substr($atom_data,  8, 2));
-				$atom_structure['opcolor_blue']           = getid3_lib::BigEndian2Int(substr($atom_data, 10, 2));
-				$atom_structure['balance']                = getid3_lib::BigEndian2Int(substr($atom_data, 12, 2));
-				$atom_structure['reserved']               = getid3_lib::BigEndian2Int(substr($atom_data, 14, 2));
-				break;
-
-
-			case 'smhd': // Sound Media information HeaDer atom
-				$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['balance']                = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
-				$atom_structure['reserved']               = getid3_lib::BigEndian2Int(substr($atom_data,  6, 2));
-				break;
-
-
-			case 'vmhd': // Video Media information HeaDer atom
-				$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3));
-				$atom_structure['graphics_mode']          = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2));
-				$atom_structure['opcolor_red']            = getid3_lib::BigEndian2Int(substr($atom_data,  6, 2));
-				$atom_structure['opcolor_green']          = getid3_lib::BigEndian2Int(substr($atom_data,  8, 2));
-				$atom_structure['opcolor_blue']           = getid3_lib::BigEndian2Int(substr($atom_data, 10, 2));
-
-				$atom_structure['flags']['no_lean_ahead'] = (bool) ($atom_structure['flags_raw'] & 0x001);
-				break;
-
-
-			case 'hdlr': // HanDLeR reference atom
-				$atom_structure['version']                = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']              = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['component_type']         =                           substr($atom_data,  4, 4);
-				$atom_structure['component_subtype']      =                           substr($atom_data,  8, 4);
-				$atom_structure['component_manufacturer'] =                           substr($atom_data, 12, 4);
-				$atom_structure['component_flags_raw']    = getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
-				$atom_structure['component_flags_mask']   = getid3_lib::BigEndian2Int(substr($atom_data, 20, 4));
-				$atom_structure['component_name']         =      $this->Pascal2String(substr($atom_data, 24));
-
-				if (($atom_structure['component_subtype'] == 'STpn') && ($atom_structure['component_manufacturer'] == 'zzzz')) {
-					$info['video']['dataformat'] = 'quicktimevr';
-				}
-				break;
-
-
-			case 'mdhd': // MeDia HeaDer atom
-				$atom_structure['version']               = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']             = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['creation_time']         = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-				$atom_structure['modify_time']           = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
-				$atom_structure['time_scale']            = getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
-				$atom_structure['duration']              = getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
-				$atom_structure['language_id']           = getid3_lib::BigEndian2Int(substr($atom_data, 20, 2));
-				$atom_structure['quality']               = getid3_lib::BigEndian2Int(substr($atom_data, 22, 2));
-
-				if ($atom_structure['time_scale'] == 0) {
-					$info['error'][] = 'Corrupt Quicktime file: mdhd.time_scale == zero';
-					return false;
-				}
-				$info['quicktime']['time_scale'] = (isset($info['quicktime']['time_scale']) ? max($info['quicktime']['time_scale'], $atom_structure['time_scale']) : $atom_structure['time_scale']);
-
-				$atom_structure['creation_time_unix']    = getid3_lib::DateMac2Unix($atom_structure['creation_time']);
-				$atom_structure['modify_time_unix']      = getid3_lib::DateMac2Unix($atom_structure['modify_time']);
-				$atom_structure['playtime_seconds']      = $atom_structure['duration'] / $atom_structure['time_scale'];
-				$atom_structure['language']              = $this->QuicktimeLanguageLookup($atom_structure['language_id']);
-				if (empty($info['comments']['language']) || (!in_array($atom_structure['language'], $info['comments']['language']))) {
-					$info['comments']['language'][] = $atom_structure['language'];
-				}
-				break;
-
-
-			case 'pnot': // Preview atom
-				$atom_structure['modification_date']      = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4)); // "standard Macintosh format"
-				$atom_structure['version_number']         = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2)); // hardcoded: 0x00
-				$atom_structure['atom_type']              =               substr($atom_data,  6, 4);        // usually: 'PICT'
-				$atom_structure['atom_index']             = getid3_lib::BigEndian2Int(substr($atom_data, 10, 2)); // usually: 0x01
-
-				$atom_structure['modification_date_unix'] = getid3_lib::DateMac2Unix($atom_structure['modification_date']);
-				break;
-
-
-			case 'crgn': // Clipping ReGioN atom
-				$atom_structure['region_size']   = getid3_lib::BigEndian2Int(substr($atom_data,  0, 2)); // The Region size, Region boundary box,
-				$atom_structure['boundary_box']  = getid3_lib::BigEndian2Int(substr($atom_data,  2, 8)); // and Clipping region data fields
-				$atom_structure['clipping_data'] =               substr($atom_data, 10);           // constitute a QuickDraw region.
-				break;
-
-
-			case 'load': // track LOAD settings atom
-				$atom_structure['preload_start_time'] = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4));
-				$atom_structure['preload_duration']   = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-				$atom_structure['preload_flags_raw']  = getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
-				$atom_structure['default_hints_raw']  = getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
-
-				$atom_structure['default_hints']['double_buffer'] = (bool) ($atom_structure['default_hints_raw'] & 0x0020);
-				$atom_structure['default_hints']['high_quality']  = (bool) ($atom_structure['default_hints_raw'] & 0x0100);
-				break;
-
-
-			case 'tmcd': // TiMe CoDe atom
-			case 'chap': // CHAPter list atom
-			case 'sync': // SYNChronization atom
-			case 'scpt': // tranSCriPT atom
-			case 'ssrc': // non-primary SouRCe atom
-				for ($i = 0; $i < (strlen($atom_data) % 4); $i++) {
-					$atom_structure['track_id'][$i] = getid3_lib::BigEndian2Int(substr($atom_data, $i * 4, 4));
-				}
-				break;
-
-
-			case 'elst': // Edit LiST atom
-				$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['number_entries'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-				for ($i = 0; $i < $atom_structure['number_entries']; $i++ ) {
-					$atom_structure['edit_list'][$i]['track_duration'] =   getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($i * 12) + 0, 4));
-					$atom_structure['edit_list'][$i]['media_time']     =   getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($i * 12) + 4, 4));
-					$atom_structure['edit_list'][$i]['media_rate']     = getid3_lib::FixedPoint16_16(substr($atom_data, 8 + ($i * 12) + 8, 4));
-				}
-				break;
-
-
-			case 'kmat': // compressed MATte atom
-				$atom_structure['version']        = getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']      = getid3_lib::BigEndian2Int(substr($atom_data,  1, 3)); // hardcoded: 0x0000
-				$atom_structure['matte_data_raw'] =               substr($atom_data,  4);
-				break;
-
-
-			case 'ctab': // Color TABle atom
-				$atom_structure['color_table_seed']   = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4)); // hardcoded: 0x00000000
-				$atom_structure['color_table_flags']  = getid3_lib::BigEndian2Int(substr($atom_data,  4, 2)); // hardcoded: 0x8000
-				$atom_structure['color_table_size']   = getid3_lib::BigEndian2Int(substr($atom_data,  6, 2)) + 1;
-				for ($colortableentry = 0; $colortableentry < $atom_structure['color_table_size']; $colortableentry++) {
-					$atom_structure['color_table'][$colortableentry]['alpha'] = getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($colortableentry * 8) + 0, 2));
-					$atom_structure['color_table'][$colortableentry]['red']   = getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($colortableentry * 8) + 2, 2));
-					$atom_structure['color_table'][$colortableentry]['green'] = getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($colortableentry * 8) + 4, 2));
-					$atom_structure['color_table'][$colortableentry]['blue']  = getid3_lib::BigEndian2Int(substr($atom_data, 8 + ($colortableentry * 8) + 6, 2));
-				}
-				break;
-
-
-			case 'mvhd': // MoVie HeaDer atom
-				$atom_structure['version']            =   getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']          =   getid3_lib::BigEndian2Int(substr($atom_data,  1, 3));
-				$atom_structure['creation_time']      =   getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-				$atom_structure['modify_time']        =   getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
-				$atom_structure['time_scale']         =   getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
-				$atom_structure['duration']           =   getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
-				$atom_structure['preferred_rate']     = getid3_lib::FixedPoint16_16(substr($atom_data, 20, 4));
-				$atom_structure['preferred_volume']   =   getid3_lib::FixedPoint8_8(substr($atom_data, 24, 2));
-				$atom_structure['reserved']           =                             substr($atom_data, 26, 10);
-				$atom_structure['matrix_a']           = getid3_lib::FixedPoint16_16(substr($atom_data, 36, 4));
-				$atom_structure['matrix_b']           = getid3_lib::FixedPoint16_16(substr($atom_data, 40, 4));
-				$atom_structure['matrix_u']           =  getid3_lib::FixedPoint2_30(substr($atom_data, 44, 4));
-				$atom_structure['matrix_c']           = getid3_lib::FixedPoint16_16(substr($atom_data, 48, 4));
-				$atom_structure['matrix_d']           = getid3_lib::FixedPoint16_16(substr($atom_data, 52, 4));
-				$atom_structure['matrix_v']           =  getid3_lib::FixedPoint2_30(substr($atom_data, 56, 4));
-				$atom_structure['matrix_x']           = getid3_lib::FixedPoint16_16(substr($atom_data, 60, 4));
-				$atom_structure['matrix_y']           = getid3_lib::FixedPoint16_16(substr($atom_data, 64, 4));
-				$atom_structure['matrix_w']           =  getid3_lib::FixedPoint2_30(substr($atom_data, 68, 4));
-				$atom_structure['preview_time']       =   getid3_lib::BigEndian2Int(substr($atom_data, 72, 4));
-				$atom_structure['preview_duration']   =   getid3_lib::BigEndian2Int(substr($atom_data, 76, 4));
-				$atom_structure['poster_time']        =   getid3_lib::BigEndian2Int(substr($atom_data, 80, 4));
-				$atom_structure['selection_time']     =   getid3_lib::BigEndian2Int(substr($atom_data, 84, 4));
-				$atom_structure['selection_duration'] =   getid3_lib::BigEndian2Int(substr($atom_data, 88, 4));
-				$atom_structure['current_time']       =   getid3_lib::BigEndian2Int(substr($atom_data, 92, 4));
-				$atom_structure['next_track_id']      =   getid3_lib::BigEndian2Int(substr($atom_data, 96, 4));
-
-				if ($atom_structure['time_scale'] == 0) {
-					$info['error'][] = 'Corrupt Quicktime file: mvhd.time_scale == zero';
-					return false;
-				}
-				$atom_structure['creation_time_unix']        = getid3_lib::DateMac2Unix($atom_structure['creation_time']);
-				$atom_structure['modify_time_unix']          = getid3_lib::DateMac2Unix($atom_structure['modify_time']);
-				$info['quicktime']['time_scale']    = (isset($info['quicktime']['time_scale']) ? max($info['quicktime']['time_scale'], $atom_structure['time_scale']) : $atom_structure['time_scale']);
-				$info['quicktime']['display_scale'] = $atom_structure['matrix_a'];
-				$info['playtime_seconds']           = $atom_structure['duration'] / $atom_structure['time_scale'];
-				break;
-
-
-			case 'tkhd': // TracK HeaDer atom
-				$atom_structure['version']             =   getid3_lib::BigEndian2Int(substr($atom_data,  0, 1));
-				$atom_structure['flags_raw']           =   getid3_lib::BigEndian2Int(substr($atom_data,  1, 3));
-				$atom_structure['creation_time']       =   getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-				$atom_structure['modify_time']         =   getid3_lib::BigEndian2Int(substr($atom_data,  8, 4));
-				$atom_structure['trackid']             =   getid3_lib::BigEndian2Int(substr($atom_data, 12, 4));
-				$atom_structure['reserved1']           =   getid3_lib::BigEndian2Int(substr($atom_data, 16, 4));
-				$atom_structure['duration']            =   getid3_lib::BigEndian2Int(substr($atom_data, 20, 4));
-				$atom_structure['reserved2']           =   getid3_lib::BigEndian2Int(substr($atom_data, 24, 8));
-				$atom_structure['layer']               =   getid3_lib::BigEndian2Int(substr($atom_data, 32, 2));
-				$atom_structure['alternate_group']     =   getid3_lib::BigEndian2Int(substr($atom_data, 34, 2));
-				$atom_structure['volume']              =   getid3_lib::FixedPoint8_8(substr($atom_data, 36, 2));
-				$atom_structure['reserved3']           =   getid3_lib::BigEndian2Int(substr($atom_data, 38, 2));
-				$atom_structure['matrix_a']            = getid3_lib::FixedPoint16_16(substr($atom_data, 40, 4));
-				$atom_structure['matrix_b']            = getid3_lib::FixedPoint16_16(substr($atom_data, 44, 4));
-				$atom_structure['matrix_u']            = getid3_lib::FixedPoint16_16(substr($atom_data, 48, 4));
-				$atom_structure['matrix_c']            = getid3_lib::FixedPoint16_16(substr($atom_data, 52, 4));
-				$atom_structure['matrix_d']            = getid3_lib::FixedPoint16_16(substr($atom_data, 56, 4));
-				$atom_structure['matrix_v']            = getid3_lib::FixedPoint16_16(substr($atom_data, 60, 4));
-				$atom_structure['matrix_x']            =  getid3_lib::FixedPoint2_30(substr($atom_data, 64, 4));
-				$atom_structure['matrix_y']            =  getid3_lib::FixedPoint2_30(substr($atom_data, 68, 4));
-				$atom_structure['matrix_w']            =  getid3_lib::FixedPoint2_30(substr($atom_data, 72, 4));
-				$atom_structure['width']               = getid3_lib::FixedPoint16_16(substr($atom_data, 76, 4));
-				$atom_structure['height']              = getid3_lib::FixedPoint16_16(substr($atom_data, 80, 4));
-
-				$atom_structure['flags']['enabled']    = (bool) ($atom_structure['flags_raw'] & 0x0001);
-				$atom_structure['flags']['in_movie']   = (bool) ($atom_structure['flags_raw'] & 0x0002);
-				$atom_structure['flags']['in_preview'] = (bool) ($atom_structure['flags_raw'] & 0x0004);
-				$atom_structure['flags']['in_poster']  = (bool) ($atom_structure['flags_raw'] & 0x0008);
-				$atom_structure['creation_time_unix']  = getid3_lib::DateMac2Unix($atom_structure['creation_time']);
-				$atom_structure['modify_time_unix']    = getid3_lib::DateMac2Unix($atom_structure['modify_time']);
-
-				if ($atom_structure['flags']['enabled'] == 1) {
-					if (!isset($info['video']['resolution_x']) || !isset($info['video']['resolution_y'])) {
-						$info['video']['resolution_x'] = $atom_structure['width'];
-						$info['video']['resolution_y'] = $atom_structure['height'];
-					}
-					$info['video']['resolution_x'] = max($info['video']['resolution_x'], $atom_structure['width']);
-					$info['video']['resolution_y'] = max($info['video']['resolution_y'], $atom_structure['height']);
-					$info['quicktime']['video']['resolution_x'] = $info['video']['resolution_x'];
-					$info['quicktime']['video']['resolution_y'] = $info['video']['resolution_y'];
-				} else {
-					// see: http://www.getid3.org/phpBB3/viewtopic.php?t=1295
-					//if (isset($info['video']['resolution_x'])) { unset($info['video']['resolution_x']); }
-					//if (isset($info['video']['resolution_y'])) { unset($info['video']['resolution_y']); }
-					//if (isset($info['quicktime']['video']))    { unset($info['quicktime']['video']);    }
-				}
-				break;
-
-
-			case 'iods': // Initial Object DeScriptor atom
-				// http://www.koders.com/c/fid1FAB3E762903DC482D8A246D4A4BF9F28E049594.aspx?s=windows.h
-				// http://libquicktime.sourcearchive.com/documentation/1.0.2plus-pdebian/iods_8c-source.html
-				$offset = 0;
-				$atom_structure['version']                =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
-				$offset += 1;
-				$atom_structure['flags_raw']              =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 3));
-				$offset += 3;
-				$atom_structure['mp4_iod_tag']            =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
-				$offset += 1;
-				$atom_structure['length']                 = $this->quicktime_read_mp4_descr_length($atom_data, $offset);
-				//$offset already adjusted by quicktime_read_mp4_descr_length()
-				$atom_structure['object_descriptor_id']   =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 2));
-				$offset += 2;
-				$atom_structure['od_profile_level']       =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
-				$offset += 1;
-				$atom_structure['scene_profile_level']    =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
-				$offset += 1;
-				$atom_structure['audio_profile_id']       =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
-				$offset += 1;
-				$atom_structure['video_profile_id']       =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
-				$offset += 1;
-				$atom_structure['graphics_profile_level'] =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
-				$offset += 1;
-
-				$atom_structure['num_iods_tracks'] = ($atom_structure['length'] - 7) / 6; // 6 bytes would only be right if all tracks use 1-byte length fields
-				for ($i = 0; $i < $atom_structure['num_iods_tracks']; $i++) {
-					$atom_structure['track'][$i]['ES_ID_IncTag'] =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 1));
-					$offset += 1;
-					$atom_structure['track'][$i]['length']       = $this->quicktime_read_mp4_descr_length($atom_data, $offset);
-					//$offset already adjusted by quicktime_read_mp4_descr_length()
-					$atom_structure['track'][$i]['track_id']     =       getid3_lib::BigEndian2Int(substr($atom_data, $offset, 4));
-					$offset += 4;
-				}
-
-				$atom_structure['audio_profile_name'] = $this->QuicktimeIODSaudioProfileName($atom_structure['audio_profile_id']);
-				$atom_structure['video_profile_name'] = $this->QuicktimeIODSvideoProfileName($atom_structure['video_profile_id']);
-				break;
-
-			case 'ftyp': // FileTYPe (?) atom (for MP4 it seems)
-				$atom_structure['signature'] =                           substr($atom_data,  0, 4);
-				$atom_structure['unknown_1'] = getid3_lib::BigEndian2Int(substr($atom_data,  4, 4));
-				$atom_structure['fourcc']    =                           substr($atom_data,  8, 4);
-				break;
-
-			case 'mdat': // Media DATa atom
-			case 'free': // FREE space atom
-			case 'skip': // SKIP atom
-			case 'wide': // 64-bit expansion placeholder atom
-				// 'mdat' data is too big to deal with, contains no useful metadata
-				// 'free', 'skip' and 'wide' are just padding, contains no useful data at all
-
-				// When writing QuickTime files, it is sometimes necessary to update an atom's size.
-				// It is impossible to update a 32-bit atom to a 64-bit atom since the 32-bit atom
-				// is only 8 bytes in size, and the 64-bit atom requires 16 bytes. Therefore, QuickTime
-				// puts an 8-byte placeholder atom before any atoms it may have to update the size of.
-				// In this way, if the atom needs to be converted from a 32-bit to a 64-bit atom, the
-				// placeholder atom can be overwritten to obtain the necessary 8 extra bytes.
-				// The placeholder atom has a type of kWideAtomPlaceholderType ( 'wide' ).
-				break;
-
-
-			case 'nsav': // NoSAVe atom
-				// http://developer.apple.com/technotes/tn/tn2038.html
-				$atom_structure['data'] = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4));
-				break;
-
-			case 'ctyp': // Controller TYPe atom (seen on QTVR)
-				// http://homepages.slingshot.co.nz/~helmboy/quicktime/formats/qtm-layout.txt
-				// some controller names are:
-				//   0x00 + 'std' for linear movie
-				//   'none' for no controls
-				$atom_structure['ctyp'] = substr($atom_data, 0, 4);
-				$info['quicktime']['controller'] = $atom_structure['ctyp'];
-				switch ($atom_structure['ctyp']) {
-					case 'qtvr':
-						$info['video']['dataformat'] = 'quicktimevr';
-						break;
-				}
-				break;
-
-			case 'pano': // PANOrama track (seen on QTVR)
-				$atom_structure['pano'] = getid3_lib::BigEndian2Int(substr($atom_data,  0, 4));
-				break;
-
-			case 'hint': // HINT track
-			case 'hinf': //
-			case 'hinv': //
-			case 'hnti': //
-				$info['quicktime']['hinting'] = true;
-				break;
-
-			case 'imgt': // IMaGe Track reference (kQTVRImageTrackRefType) (seen on QTVR)
-				for ($i = 0; $i < ($atom_structure['size'] - 8); $i += 4) {
-					$atom_structure['imgt'][] = getid3_lib::BigEndian2Int(substr($atom_data, $i, 4));
-				}
-				break;
-
-
-			// Observed-but-not-handled atom types are just listed here to prevent warnings being generated
-			case 'FXTC': // Something to do with Adobe After Effects (?)
-			case 'PrmA':
-			case 'code':
-			case 'FIEL': // this is NOT "fiel" (Field Ordering) as describe here: http://developer.apple.com/documentation/QuickTime/QTFF/QTFFChap3/chapter_4_section_2.html
-			case 'tapt': // TrackApertureModeDimensionsAID - http://developer.apple.com/documentation/QuickTime/Reference/QT7-1_Update_Reference/Constants/Constants.html
-						// tapt seems to be used to compute the video size [http://www.getid3.org/phpBB3/viewtopic.php?t=838]
-						// * http://lists.apple.com/archives/quicktime-api/2006/Aug/msg00014.html
-						// * http://handbrake.fr/irclogs/handbrake-dev/handbrake-dev20080128_pg2.html
-			case 'ctts'://  STCompositionOffsetAID             - http://developer.apple.com/documentation/QuickTime/Reference/QTRef_Constants/Reference/reference.html
-			case 'cslg'://  STCompositionShiftLeastGreatestAID - http://developer.apple.com/documentation/QuickTime/Reference/QTRef_Constants/Reference/reference.html
-			case 'sdtp'://  STSampleDependencyAID              - http://developer.apple.com/documentation/QuickTime/Reference/QTRef_Constants/Reference/reference.html
-			case 'stps'://  STPartialSyncSampleAID             - http://developer.apple.com/documentation/QuickTime/Reference/QTRef_Constants/Reference/reference.html
-				//$atom_structure['data'] = $atom_data;
-				break;
-
-			case '©xyz':  // GPS latitude+longitude+altitude
-				$atom_structure['data'] = $atom_data;
-				if (preg_match('#([\\+\\-][0-9\\.]+)([\\+\\-][0-9\\.]+)([\\+\\-][0-9\\.]+)?/$#i', $atom_data, $matches)) {
-					@list($all, $latitude, $longitude, $altitude) = $matches;
-					$info['quicktime']['comments']['gps_latitude'][]  = floatval($latitude);
-					$info['quicktime']['comments']['gps_longitude'][] = floatval($longitude);
-					if (!empty($altitude)) {
-						$info['quicktime']['comments']['gps_altitude'][] = floatval($altitude);
-					}
-				} else {
-					$info['warning'][] = 'QuickTime atom "©xyz" data does not match expected data pattern at offset '.$baseoffset.'. Please report as getID3() bug.';
-				}
-				break;
-
-			case 'NCDT':
-				// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html
-				// Nikon-specific QuickTime tags found in the NCDT atom of MOV videos from some Nikon cameras such as the Coolpix S8000 and D5100
-				$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 4, $atomHierarchy, $ParseAllPossibleAtoms);
-				break;
-			case 'NCTH': // Nikon Camera THumbnail image
-			case 'NCVW': // Nikon Camera preVieW image
-				// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html
-				if (preg_match('/^\xFF\xD8\xFF/', $atom_data)) {
+				case 'frea':
+					// https://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Kodak.html#frea
+					// may contain "scra" (PreviewImage) and/or "thma" (ThumbnailImage)
+					$atom_structure['subatoms'] = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 4, $atomHierarchy, $ParseAllPossibleAtoms);
+					break;
+				case 'tima': // subatom to "frea"
+					// no idea what this does, the one sample file I've seen has a value of 0x00000027
 					$atom_structure['data'] = $atom_data;
-					$atom_structure['image_mime'] = 'image/jpeg';
-					$atom_structure['description'] = (($atomname == 'NCTH') ? 'Nikon Camera Thumbnail Image' : (($atomname == 'NCVW') ? 'Nikon Camera Preview Image' : 'Nikon preview image'));
-					$info['quicktime']['comments']['picture'][] = array('image_mime'=>$atom_structure['image_mime'], 'data'=>$atom_data, 'description'=>$atom_structure['description']);
-				}
-				break;
-			case 'NCHD': // MakerNoteVersion
-				// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html
-				$atom_structure['data'] = $atom_data;
-				break;
-			case 'NCTG': // NikonTags
-				// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html#NCTG
-				$atom_structure['data'] = $this->QuicktimeParseNikonNCTG($atom_data);
-				break;
-			case 'NCDB': // NikonTags
-				// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html
-				$atom_structure['data'] = $atom_data;
-				break;
+					break;
+				case 'ver ': // subatom to "frea"
+					// some kind of version number, the one sample file I've seen has a value of "3.00.073"
+					$atom_structure['data'] = $atom_data;
+					break;
+				case 'thma': // subatom to "frea" -- "ThumbnailImage"
+					// https://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Kodak.html#frea
+					if (strlen($atom_data) > 0) {
+						$info['quicktime']['comments']['picture'][] = array('data'=>$atom_data, 'image_mime'=>'image/jpeg', 'description'=>'ThumbnailImage');
+					}
+					break;
+				case 'scra': // subatom to "frea" -- "PreviewImage"
+					// https://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Kodak.html#frea
+					// but the only sample file I've seen has no useful data here
+					if (strlen($atom_data) > 0) {
+						$info['quicktime']['comments']['picture'][] = array('data'=>$atom_data, 'image_mime'=>'image/jpeg', 'description'=>'PreviewImage');
+					}
+					break;
 
-			case "\x00\x00\x00\x00":
-			case 'meta': // METAdata atom
-				// some kind of metacontainer, may contain a big data dump such as:
-				// mdta keys  mdtacom.apple.quicktime.make (mdtacom.apple.quicktime.creationdate ,mdtacom.apple.quicktime.location.ISO6709 $mdtacom.apple.quicktime.software !mdtacom.apple.quicktime.model ilst   data DEApple 0  (data DE2011-05-11T17:54:04+0200 2  *data DE+52.4936+013.3897+040.247/   data DE4.3.1  data DEiPhone 4
-				// http://www.geocities.com/xhelmboyx/quicktime/formats/qti-layout.txt
+				case 'cdsc': // timed metadata reference
+					// A QuickTime movie can contain none, one, or several timed metadata tracks. Timed metadata tracks can refer to multiple tracks.
+					// Metadata tracks are linked to the tracks they describe using a track-reference of type 'cdsc'. The metadata track holds the 'cdsc' track reference.
+					$atom_structure['track_number'] = getid3_lib::BigEndian2Int($atom_data);
+					break;
 
-	            $atom_structure['version']   =          getid3_lib::BigEndian2Int(substr($atom_data, 0, 1));
-	            $atom_structure['flags_raw'] =          getid3_lib::BigEndian2Int(substr($atom_data, 1, 3));
-	            $atom_structure['subatoms']  = $this->QuicktimeParseContainerAtom(substr($atom_data, 4), $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
-				//$atom_structure['subatoms']  = $this->QuicktimeParseContainerAtom($atom_data, $baseoffset + 8, $atomHierarchy, $ParseAllPossibleAtoms);
-				break;
-
-			case 'data': // metaDATA atom
-				// seems to be 2 bytes language code (ASCII), 2 bytes unknown (set to 0x10B5 in sample I have), remainder is useful data
-				$atom_structure['language'] =                           substr($atom_data, 4 + 0, 2);
-				$atom_structure['unknown']  = getid3_lib::BigEndian2Int(substr($atom_data, 4 + 2, 2));
-				$atom_structure['data']     =                           substr($atom_data, 4 + 4);
-				break;
-
-			default:
-				$info['warning'][] = 'Unknown QuickTime atom type: "'.$atomname.'" ('.trim(getid3_lib::PrintHexBytes($atomname)).') at offset '.$baseoffset;
-				$atom_structure['data'] = $atom_data;
-				break;
+				default:
+					$this->warning('Unknown QuickTime atom type: "'.preg_replace('#[^a-zA-Z0-9 _\\-]#', '?', $atomname).'" ('.trim(getid3_lib::PrintHexBytes($atomname)).'), '.$atomsize.' bytes at offset '.$baseoffset);
+					$atom_structure['data'] = $atom_data;
+					break;
+			}
 		}
 		array_pop($atomHierarchy);
 		return $atom_structure;
 	}
 
+	/**
+	 * @param string $atom_data
+	 * @param int    $baseoffset
+	 * @param array  $atomHierarchy
+	 * @param bool   $ParseAllPossibleAtoms
+	 *
+	 * @return array|false
+	 */
 	public function QuicktimeParseContainerAtom($atom_data, $baseoffset, &$atomHierarchy, $ParseAllPossibleAtoms) {
-//echo 'QuicktimeParseContainerAtom('.substr($atom_data, 4, 4).') @ '.$baseoffset.'<br><br>';
 		$atom_structure  = false;
 		$subatomoffset  = 0;
 		$subatomcounter = 0;
@@ -1359,18 +2052,30 @@ class getid3_quicktime extends getid3_handler
 				// Furthermore, for historical reasons the list of atoms is optionally
 				// terminated by a 32-bit integer set to 0. If you are writing a program
 				// to read user data atoms, you should allow for the terminating 0.
+				if (strlen($atom_data) > 12) {
+					$subatomoffset += 4;
+					continue;
+				}
 				return $atom_structure;
 			}
-
-			$atom_structure[$subatomcounter] = $this->QuicktimeParseAtom($subatomname, $subatomsize, $subatomdata, $baseoffset + $subatomoffset, $atomHierarchy, $ParseAllPossibleAtoms);
-
+			if (strlen($subatomdata) < ($subatomsize - 8)) {
+			    // we don't have enough data to decode the subatom.
+			    // this may be because we are refusing to parse large subatoms, or it may be because this atom had its size set too large
+			    // so we passed in the start of a following atom incorrectly?
+			    return $atom_structure;
+			}
+			$atom_structure[$subatomcounter++] = $this->QuicktimeParseAtom($subatomname, $subatomsize, $subatomdata, $baseoffset + $subatomoffset, $atomHierarchy, $ParseAllPossibleAtoms);
 			$subatomoffset += $subatomsize;
-			$subatomcounter++;
 		}
 		return $atom_structure;
 	}
 
-
+	/**
+	 * @param string $data
+	 * @param int    $offset
+	 *
+	 * @return int
+	 */
 	public function quicktime_read_mp4_descr_length($data, &$offset) {
 		// http://libquicktime.sourcearchive.com/documentation/2:1.0.2plus-pdebian-2build1/esds_8c-source.html
 		$num_bytes = 0;
@@ -1382,124 +2087,153 @@ class getid3_quicktime extends getid3_handler
 		return $length;
 	}
 
-
+	/**
+	 * @param int $languageid
+	 *
+	 * @return string
+	 */
 	public function QuicktimeLanguageLookup($languageid) {
+		// http://developer.apple.com/library/mac/#documentation/QuickTime/QTFF/QTFFChap4/qtff4.html#//apple_ref/doc/uid/TP40000939-CH206-34353
 		static $QuicktimeLanguageLookup = array();
 		if (empty($QuicktimeLanguageLookup)) {
-			$QuicktimeLanguageLookup[0]   = 'English';
-			$QuicktimeLanguageLookup[1]   = 'French';
-			$QuicktimeLanguageLookup[2]   = 'German';
-			$QuicktimeLanguageLookup[3]   = 'Italian';
-			$QuicktimeLanguageLookup[4]   = 'Dutch';
-			$QuicktimeLanguageLookup[5]   = 'Swedish';
-			$QuicktimeLanguageLookup[6]   = 'Spanish';
-			$QuicktimeLanguageLookup[7]   = 'Danish';
-			$QuicktimeLanguageLookup[8]   = 'Portuguese';
-			$QuicktimeLanguageLookup[9]   = 'Norwegian';
-			$QuicktimeLanguageLookup[10]  = 'Hebrew';
-			$QuicktimeLanguageLookup[11]  = 'Japanese';
-			$QuicktimeLanguageLookup[12]  = 'Arabic';
-			$QuicktimeLanguageLookup[13]  = 'Finnish';
-			$QuicktimeLanguageLookup[14]  = 'Greek';
-			$QuicktimeLanguageLookup[15]  = 'Icelandic';
-			$QuicktimeLanguageLookup[16]  = 'Maltese';
-			$QuicktimeLanguageLookup[17]  = 'Turkish';
-			$QuicktimeLanguageLookup[18]  = 'Croatian';
-			$QuicktimeLanguageLookup[19]  = 'Chinese (Traditional)';
-			$QuicktimeLanguageLookup[20]  = 'Urdu';
-			$QuicktimeLanguageLookup[21]  = 'Hindi';
-			$QuicktimeLanguageLookup[22]  = 'Thai';
-			$QuicktimeLanguageLookup[23]  = 'Korean';
-			$QuicktimeLanguageLookup[24]  = 'Lithuanian';
-			$QuicktimeLanguageLookup[25]  = 'Polish';
-			$QuicktimeLanguageLookup[26]  = 'Hungarian';
-			$QuicktimeLanguageLookup[27]  = 'Estonian';
-			$QuicktimeLanguageLookup[28]  = 'Lettish';
-			$QuicktimeLanguageLookup[28]  = 'Latvian';
-			$QuicktimeLanguageLookup[29]  = 'Saamisk';
-			$QuicktimeLanguageLookup[29]  = 'Lappish';
-			$QuicktimeLanguageLookup[30]  = 'Faeroese';
-			$QuicktimeLanguageLookup[31]  = 'Farsi';
-			$QuicktimeLanguageLookup[31]  = 'Persian';
-			$QuicktimeLanguageLookup[32]  = 'Russian';
-			$QuicktimeLanguageLookup[33]  = 'Chinese (Simplified)';
-			$QuicktimeLanguageLookup[34]  = 'Flemish';
-			$QuicktimeLanguageLookup[35]  = 'Irish';
-			$QuicktimeLanguageLookup[36]  = 'Albanian';
-			$QuicktimeLanguageLookup[37]  = 'Romanian';
-			$QuicktimeLanguageLookup[38]  = 'Czech';
-			$QuicktimeLanguageLookup[39]  = 'Slovak';
-			$QuicktimeLanguageLookup[40]  = 'Slovenian';
-			$QuicktimeLanguageLookup[41]  = 'Yiddish';
-			$QuicktimeLanguageLookup[42]  = 'Serbian';
-			$QuicktimeLanguageLookup[43]  = 'Macedonian';
-			$QuicktimeLanguageLookup[44]  = 'Bulgarian';
-			$QuicktimeLanguageLookup[45]  = 'Ukrainian';
-			$QuicktimeLanguageLookup[46]  = 'Byelorussian';
-			$QuicktimeLanguageLookup[47]  = 'Uzbek';
-			$QuicktimeLanguageLookup[48]  = 'Kazakh';
-			$QuicktimeLanguageLookup[49]  = 'Azerbaijani';
-			$QuicktimeLanguageLookup[50]  = 'AzerbaijanAr';
-			$QuicktimeLanguageLookup[51]  = 'Armenian';
-			$QuicktimeLanguageLookup[52]  = 'Georgian';
-			$QuicktimeLanguageLookup[53]  = 'Moldavian';
-			$QuicktimeLanguageLookup[54]  = 'Kirghiz';
-			$QuicktimeLanguageLookup[55]  = 'Tajiki';
-			$QuicktimeLanguageLookup[56]  = 'Turkmen';
-			$QuicktimeLanguageLookup[57]  = 'Mongolian';
-			$QuicktimeLanguageLookup[58]  = 'MongolianCyr';
-			$QuicktimeLanguageLookup[59]  = 'Pashto';
-			$QuicktimeLanguageLookup[60]  = 'Kurdish';
-			$QuicktimeLanguageLookup[61]  = 'Kashmiri';
-			$QuicktimeLanguageLookup[62]  = 'Sindhi';
-			$QuicktimeLanguageLookup[63]  = 'Tibetan';
-			$QuicktimeLanguageLookup[64]  = 'Nepali';
-			$QuicktimeLanguageLookup[65]  = 'Sanskrit';
-			$QuicktimeLanguageLookup[66]  = 'Marathi';
-			$QuicktimeLanguageLookup[67]  = 'Bengali';
-			$QuicktimeLanguageLookup[68]  = 'Assamese';
-			$QuicktimeLanguageLookup[69]  = 'Gujarati';
-			$QuicktimeLanguageLookup[70]  = 'Punjabi';
-			$QuicktimeLanguageLookup[71]  = 'Oriya';
-			$QuicktimeLanguageLookup[72]  = 'Malayalam';
-			$QuicktimeLanguageLookup[73]  = 'Kannada';
-			$QuicktimeLanguageLookup[74]  = 'Tamil';
-			$QuicktimeLanguageLookup[75]  = 'Telugu';
-			$QuicktimeLanguageLookup[76]  = 'Sinhalese';
-			$QuicktimeLanguageLookup[77]  = 'Burmese';
-			$QuicktimeLanguageLookup[78]  = 'Khmer';
-			$QuicktimeLanguageLookup[79]  = 'Lao';
-			$QuicktimeLanguageLookup[80]  = 'Vietnamese';
-			$QuicktimeLanguageLookup[81]  = 'Indonesian';
-			$QuicktimeLanguageLookup[82]  = 'Tagalog';
-			$QuicktimeLanguageLookup[83]  = 'MalayRoman';
-			$QuicktimeLanguageLookup[84]  = 'MalayArabic';
-			$QuicktimeLanguageLookup[85]  = 'Amharic';
-			$QuicktimeLanguageLookup[86]  = 'Tigrinya';
-			$QuicktimeLanguageLookup[87]  = 'Galla';
-			$QuicktimeLanguageLookup[87]  = 'Oromo';
-			$QuicktimeLanguageLookup[88]  = 'Somali';
-			$QuicktimeLanguageLookup[89]  = 'Swahili';
-			$QuicktimeLanguageLookup[90]  = 'Ruanda';
-			$QuicktimeLanguageLookup[91]  = 'Rundi';
-			$QuicktimeLanguageLookup[92]  = 'Chewa';
-			$QuicktimeLanguageLookup[93]  = 'Malagasy';
-			$QuicktimeLanguageLookup[94]  = 'Esperanto';
-			$QuicktimeLanguageLookup[128] = 'Welsh';
-			$QuicktimeLanguageLookup[129] = 'Basque';
-			$QuicktimeLanguageLookup[130] = 'Catalan';
-			$QuicktimeLanguageLookup[131] = 'Latin';
-			$QuicktimeLanguageLookup[132] = 'Quechua';
-			$QuicktimeLanguageLookup[133] = 'Guarani';
-			$QuicktimeLanguageLookup[134] = 'Aymara';
-			$QuicktimeLanguageLookup[135] = 'Tatar';
-			$QuicktimeLanguageLookup[136] = 'Uighur';
-			$QuicktimeLanguageLookup[137] = 'Dzongkha';
-			$QuicktimeLanguageLookup[138] = 'JavaneseRom';
+			$QuicktimeLanguageLookup[0]     = 'English';
+			$QuicktimeLanguageLookup[1]     = 'French';
+			$QuicktimeLanguageLookup[2]     = 'German';
+			$QuicktimeLanguageLookup[3]     = 'Italian';
+			$QuicktimeLanguageLookup[4]     = 'Dutch';
+			$QuicktimeLanguageLookup[5]     = 'Swedish';
+			$QuicktimeLanguageLookup[6]     = 'Spanish';
+			$QuicktimeLanguageLookup[7]     = 'Danish';
+			$QuicktimeLanguageLookup[8]     = 'Portuguese';
+			$QuicktimeLanguageLookup[9]     = 'Norwegian';
+			$QuicktimeLanguageLookup[10]    = 'Hebrew';
+			$QuicktimeLanguageLookup[11]    = 'Japanese';
+			$QuicktimeLanguageLookup[12]    = 'Arabic';
+			$QuicktimeLanguageLookup[13]    = 'Finnish';
+			$QuicktimeLanguageLookup[14]    = 'Greek';
+			$QuicktimeLanguageLookup[15]    = 'Icelandic';
+			$QuicktimeLanguageLookup[16]    = 'Maltese';
+			$QuicktimeLanguageLookup[17]    = 'Turkish';
+			$QuicktimeLanguageLookup[18]    = 'Croatian';
+			$QuicktimeLanguageLookup[19]    = 'Chinese (Traditional)';
+			$QuicktimeLanguageLookup[20]    = 'Urdu';
+			$QuicktimeLanguageLookup[21]    = 'Hindi';
+			$QuicktimeLanguageLookup[22]    = 'Thai';
+			$QuicktimeLanguageLookup[23]    = 'Korean';
+			$QuicktimeLanguageLookup[24]    = 'Lithuanian';
+			$QuicktimeLanguageLookup[25]    = 'Polish';
+			$QuicktimeLanguageLookup[26]    = 'Hungarian';
+			$QuicktimeLanguageLookup[27]    = 'Estonian';
+			$QuicktimeLanguageLookup[28]    = 'Lettish';
+			$QuicktimeLanguageLookup[28]    = 'Latvian';
+			$QuicktimeLanguageLookup[29]    = 'Saamisk';
+			$QuicktimeLanguageLookup[29]    = 'Lappish';
+			$QuicktimeLanguageLookup[30]    = 'Faeroese';
+			$QuicktimeLanguageLookup[31]    = 'Farsi';
+			$QuicktimeLanguageLookup[31]    = 'Persian';
+			$QuicktimeLanguageLookup[32]    = 'Russian';
+			$QuicktimeLanguageLookup[33]    = 'Chinese (Simplified)';
+			$QuicktimeLanguageLookup[34]    = 'Flemish';
+			$QuicktimeLanguageLookup[35]    = 'Irish';
+			$QuicktimeLanguageLookup[36]    = 'Albanian';
+			$QuicktimeLanguageLookup[37]    = 'Romanian';
+			$QuicktimeLanguageLookup[38]    = 'Czech';
+			$QuicktimeLanguageLookup[39]    = 'Slovak';
+			$QuicktimeLanguageLookup[40]    = 'Slovenian';
+			$QuicktimeLanguageLookup[41]    = 'Yiddish';
+			$QuicktimeLanguageLookup[42]    = 'Serbian';
+			$QuicktimeLanguageLookup[43]    = 'Macedonian';
+			$QuicktimeLanguageLookup[44]    = 'Bulgarian';
+			$QuicktimeLanguageLookup[45]    = 'Ukrainian';
+			$QuicktimeLanguageLookup[46]    = 'Byelorussian';
+			$QuicktimeLanguageLookup[47]    = 'Uzbek';
+			$QuicktimeLanguageLookup[48]    = 'Kazakh';
+			$QuicktimeLanguageLookup[49]    = 'Azerbaijani';
+			$QuicktimeLanguageLookup[50]    = 'AzerbaijanAr';
+			$QuicktimeLanguageLookup[51]    = 'Armenian';
+			$QuicktimeLanguageLookup[52]    = 'Georgian';
+			$QuicktimeLanguageLookup[53]    = 'Moldavian';
+			$QuicktimeLanguageLookup[54]    = 'Kirghiz';
+			$QuicktimeLanguageLookup[55]    = 'Tajiki';
+			$QuicktimeLanguageLookup[56]    = 'Turkmen';
+			$QuicktimeLanguageLookup[57]    = 'Mongolian';
+			$QuicktimeLanguageLookup[58]    = 'MongolianCyr';
+			$QuicktimeLanguageLookup[59]    = 'Pashto';
+			$QuicktimeLanguageLookup[60]    = 'Kurdish';
+			$QuicktimeLanguageLookup[61]    = 'Kashmiri';
+			$QuicktimeLanguageLookup[62]    = 'Sindhi';
+			$QuicktimeLanguageLookup[63]    = 'Tibetan';
+			$QuicktimeLanguageLookup[64]    = 'Nepali';
+			$QuicktimeLanguageLookup[65]    = 'Sanskrit';
+			$QuicktimeLanguageLookup[66]    = 'Marathi';
+			$QuicktimeLanguageLookup[67]    = 'Bengali';
+			$QuicktimeLanguageLookup[68]    = 'Assamese';
+			$QuicktimeLanguageLookup[69]    = 'Gujarati';
+			$QuicktimeLanguageLookup[70]    = 'Punjabi';
+			$QuicktimeLanguageLookup[71]    = 'Oriya';
+			$QuicktimeLanguageLookup[72]    = 'Malayalam';
+			$QuicktimeLanguageLookup[73]    = 'Kannada';
+			$QuicktimeLanguageLookup[74]    = 'Tamil';
+			$QuicktimeLanguageLookup[75]    = 'Telugu';
+			$QuicktimeLanguageLookup[76]    = 'Sinhalese';
+			$QuicktimeLanguageLookup[77]    = 'Burmese';
+			$QuicktimeLanguageLookup[78]    = 'Khmer';
+			$QuicktimeLanguageLookup[79]    = 'Lao';
+			$QuicktimeLanguageLookup[80]    = 'Vietnamese';
+			$QuicktimeLanguageLookup[81]    = 'Indonesian';
+			$QuicktimeLanguageLookup[82]    = 'Tagalog';
+			$QuicktimeLanguageLookup[83]    = 'MalayRoman';
+			$QuicktimeLanguageLookup[84]    = 'MalayArabic';
+			$QuicktimeLanguageLookup[85]    = 'Amharic';
+			$QuicktimeLanguageLookup[86]    = 'Tigrinya';
+			$QuicktimeLanguageLookup[87]    = 'Galla';
+			$QuicktimeLanguageLookup[87]    = 'Oromo';
+			$QuicktimeLanguageLookup[88]    = 'Somali';
+			$QuicktimeLanguageLookup[89]    = 'Swahili';
+			$QuicktimeLanguageLookup[90]    = 'Ruanda';
+			$QuicktimeLanguageLookup[91]    = 'Rundi';
+			$QuicktimeLanguageLookup[92]    = 'Chewa';
+			$QuicktimeLanguageLookup[93]    = 'Malagasy';
+			$QuicktimeLanguageLookup[94]    = 'Esperanto';
+			$QuicktimeLanguageLookup[128]   = 'Welsh';
+			$QuicktimeLanguageLookup[129]   = 'Basque';
+			$QuicktimeLanguageLookup[130]   = 'Catalan';
+			$QuicktimeLanguageLookup[131]   = 'Latin';
+			$QuicktimeLanguageLookup[132]   = 'Quechua';
+			$QuicktimeLanguageLookup[133]   = 'Guarani';
+			$QuicktimeLanguageLookup[134]   = 'Aymara';
+			$QuicktimeLanguageLookup[135]   = 'Tatar';
+			$QuicktimeLanguageLookup[136]   = 'Uighur';
+			$QuicktimeLanguageLookup[137]   = 'Dzongkha';
+			$QuicktimeLanguageLookup[138]   = 'JavaneseRom';
+			$QuicktimeLanguageLookup[32767] = 'Unspecified';
+		}
+		if (($languageid > 138) && ($languageid < 32767)) {
+			/*
+			ISO Language Codes - http://www.loc.gov/standards/iso639-2/php/code_list.php
+			Because the language codes specified by ISO 639-2/T are three characters long, they must be packed to fit into a 16-bit field.
+			The packing algorithm must map each of the three characters, which are always lowercase, into a 5-bit integer and then concatenate
+			these integers into the least significant 15 bits of a 16-bit integer, leaving the 16-bit integer's most significant bit set to zero.
+
+			One algorithm for performing this packing is to treat each ISO character as a 16-bit integer. Subtract 0x60 from the first character
+			and multiply by 2^10 (0x400), subtract 0x60 from the second character and multiply by 2^5 (0x20), subtract 0x60 from the third character,
+			and add the three 16-bit values. This will result in a single 16-bit value with the three codes correctly packed into the 15 least
+			significant bits and the most significant bit set to zero.
+			*/
+			$iso_language_id  = '';
+			$iso_language_id .= chr((($languageid & 0x7C00) >> 10) + 0x60);
+			$iso_language_id .= chr((($languageid & 0x03E0) >>  5) + 0x60);
+			$iso_language_id .= chr((($languageid & 0x001F) >>  0) + 0x60);
+			$QuicktimeLanguageLookup[$languageid] = getid3_id3v2::LanguageLookup($iso_language_id);
 		}
 		return (isset($QuicktimeLanguageLookup[$languageid]) ? $QuicktimeLanguageLookup[$languageid] : 'invalid');
 	}
 
+	/**
+	 * @param string $codecid
+	 *
+	 * @return string
+	 */
 	public function QuicktimeVideoCodecLookup($codecid) {
 		static $QuicktimeVideoCodecLookup = array();
 		if (empty($QuicktimeVideoCodecLookup)) {
@@ -1559,6 +2293,11 @@ class getid3_quicktime extends getid3_handler
 		return (isset($QuicktimeVideoCodecLookup[$codecid]) ? $QuicktimeVideoCodecLookup[$codecid] : '');
 	}
 
+	/**
+	 * @param string $codecid
+	 *
+	 * @return mixed|string
+	 */
 	public function QuicktimeAudioCodecLookup($codecid) {
 		static $QuicktimeAudioCodecLookup = array();
 		if (empty($QuicktimeAudioCodecLookup)) {
@@ -1604,6 +2343,11 @@ class getid3_quicktime extends getid3_handler
 		return (isset($QuicktimeAudioCodecLookup[$codecid]) ? $QuicktimeAudioCodecLookup[$codecid] : '');
 	}
 
+	/**
+	 * @param string $compressionid
+	 *
+	 * @return string
+	 */
 	public function QuicktimeDCOMLookup($compressionid) {
 		static $QuicktimeDCOMLookup = array();
 		if (empty($QuicktimeDCOMLookup)) {
@@ -1613,6 +2357,11 @@ class getid3_quicktime extends getid3_handler
 		return (isset($QuicktimeDCOMLookup[$compressionid]) ? $QuicktimeDCOMLookup[$compressionid] : '');
 	}
 
+	/**
+	 * @param int $colordepthid
+	 *
+	 * @return string
+	 */
 	public function QuicktimeColorNameLookup($colordepthid) {
 		static $QuicktimeColorNameLookup = array();
 		if (empty($QuicktimeColorNameLookup)) {
@@ -1631,6 +2380,11 @@ class getid3_quicktime extends getid3_handler
 		return (isset($QuicktimeColorNameLookup[$colordepthid]) ? $QuicktimeColorNameLookup[$colordepthid] : 'invalid');
 	}
 
+	/**
+	 * @param int $stik
+	 *
+	 * @return string
+	 */
 	public function QuicktimeSTIKLookup($stik) {
 		static $QuicktimeSTIKLookup = array();
 		if (empty($QuicktimeSTIKLookup)) {
@@ -1648,66 +2402,75 @@ class getid3_quicktime extends getid3_handler
 		return (isset($QuicktimeSTIKLookup[$stik]) ? $QuicktimeSTIKLookup[$stik] : 'invalid');
 	}
 
+	/**
+	 * @param int $audio_profile_id
+	 *
+	 * @return string
+	 */
 	public function QuicktimeIODSaudioProfileName($audio_profile_id) {
 		static $QuicktimeIODSaudioProfileNameLookup = array();
 		if (empty($QuicktimeIODSaudioProfileNameLookup)) {
 			$QuicktimeIODSaudioProfileNameLookup = array(
-			    0x00 => 'ISO Reserved (0x00)',
-			    0x01 => 'Main Audio Profile @ Level 1',
-			    0x02 => 'Main Audio Profile @ Level 2',
-			    0x03 => 'Main Audio Profile @ Level 3',
-			    0x04 => 'Main Audio Profile @ Level 4',
-			    0x05 => 'Scalable Audio Profile @ Level 1',
-			    0x06 => 'Scalable Audio Profile @ Level 2',
-			    0x07 => 'Scalable Audio Profile @ Level 3',
-			    0x08 => 'Scalable Audio Profile @ Level 4',
-			    0x09 => 'Speech Audio Profile @ Level 1',
-			    0x0A => 'Speech Audio Profile @ Level 2',
-			    0x0B => 'Synthetic Audio Profile @ Level 1',
-			    0x0C => 'Synthetic Audio Profile @ Level 2',
-			    0x0D => 'Synthetic Audio Profile @ Level 3',
-			    0x0E => 'High Quality Audio Profile @ Level 1',
-			    0x0F => 'High Quality Audio Profile @ Level 2',
-			    0x10 => 'High Quality Audio Profile @ Level 3',
-			    0x11 => 'High Quality Audio Profile @ Level 4',
-			    0x12 => 'High Quality Audio Profile @ Level 5',
-			    0x13 => 'High Quality Audio Profile @ Level 6',
-			    0x14 => 'High Quality Audio Profile @ Level 7',
-			    0x15 => 'High Quality Audio Profile @ Level 8',
-			    0x16 => 'Low Delay Audio Profile @ Level 1',
-			    0x17 => 'Low Delay Audio Profile @ Level 2',
-			    0x18 => 'Low Delay Audio Profile @ Level 3',
-			    0x19 => 'Low Delay Audio Profile @ Level 4',
-			    0x1A => 'Low Delay Audio Profile @ Level 5',
-			    0x1B => 'Low Delay Audio Profile @ Level 6',
-			    0x1C => 'Low Delay Audio Profile @ Level 7',
-			    0x1D => 'Low Delay Audio Profile @ Level 8',
-			    0x1E => 'Natural Audio Profile @ Level 1',
-			    0x1F => 'Natural Audio Profile @ Level 2',
-			    0x20 => 'Natural Audio Profile @ Level 3',
-			    0x21 => 'Natural Audio Profile @ Level 4',
-			    0x22 => 'Mobile Audio Internetworking Profile @ Level 1',
-			    0x23 => 'Mobile Audio Internetworking Profile @ Level 2',
-			    0x24 => 'Mobile Audio Internetworking Profile @ Level 3',
-			    0x25 => 'Mobile Audio Internetworking Profile @ Level 4',
-			    0x26 => 'Mobile Audio Internetworking Profile @ Level 5',
-			    0x27 => 'Mobile Audio Internetworking Profile @ Level 6',
-			    0x28 => 'AAC Profile @ Level 1',
-			    0x29 => 'AAC Profile @ Level 2',
-			    0x2A => 'AAC Profile @ Level 4',
-			    0x2B => 'AAC Profile @ Level 5',
-			    0x2C => 'High Efficiency AAC Profile @ Level 2',
-			    0x2D => 'High Efficiency AAC Profile @ Level 3',
-			    0x2E => 'High Efficiency AAC Profile @ Level 4',
-			    0x2F => 'High Efficiency AAC Profile @ Level 5',
-			    0xFE => 'Not part of MPEG-4 audio profiles',
-			    0xFF => 'No audio capability required',
+				0x00 => 'ISO Reserved (0x00)',
+				0x01 => 'Main Audio Profile @ Level 1',
+				0x02 => 'Main Audio Profile @ Level 2',
+				0x03 => 'Main Audio Profile @ Level 3',
+				0x04 => 'Main Audio Profile @ Level 4',
+				0x05 => 'Scalable Audio Profile @ Level 1',
+				0x06 => 'Scalable Audio Profile @ Level 2',
+				0x07 => 'Scalable Audio Profile @ Level 3',
+				0x08 => 'Scalable Audio Profile @ Level 4',
+				0x09 => 'Speech Audio Profile @ Level 1',
+				0x0A => 'Speech Audio Profile @ Level 2',
+				0x0B => 'Synthetic Audio Profile @ Level 1',
+				0x0C => 'Synthetic Audio Profile @ Level 2',
+				0x0D => 'Synthetic Audio Profile @ Level 3',
+				0x0E => 'High Quality Audio Profile @ Level 1',
+				0x0F => 'High Quality Audio Profile @ Level 2',
+				0x10 => 'High Quality Audio Profile @ Level 3',
+				0x11 => 'High Quality Audio Profile @ Level 4',
+				0x12 => 'High Quality Audio Profile @ Level 5',
+				0x13 => 'High Quality Audio Profile @ Level 6',
+				0x14 => 'High Quality Audio Profile @ Level 7',
+				0x15 => 'High Quality Audio Profile @ Level 8',
+				0x16 => 'Low Delay Audio Profile @ Level 1',
+				0x17 => 'Low Delay Audio Profile @ Level 2',
+				0x18 => 'Low Delay Audio Profile @ Level 3',
+				0x19 => 'Low Delay Audio Profile @ Level 4',
+				0x1A => 'Low Delay Audio Profile @ Level 5',
+				0x1B => 'Low Delay Audio Profile @ Level 6',
+				0x1C => 'Low Delay Audio Profile @ Level 7',
+				0x1D => 'Low Delay Audio Profile @ Level 8',
+				0x1E => 'Natural Audio Profile @ Level 1',
+				0x1F => 'Natural Audio Profile @ Level 2',
+				0x20 => 'Natural Audio Profile @ Level 3',
+				0x21 => 'Natural Audio Profile @ Level 4',
+				0x22 => 'Mobile Audio Internetworking Profile @ Level 1',
+				0x23 => 'Mobile Audio Internetworking Profile @ Level 2',
+				0x24 => 'Mobile Audio Internetworking Profile @ Level 3',
+				0x25 => 'Mobile Audio Internetworking Profile @ Level 4',
+				0x26 => 'Mobile Audio Internetworking Profile @ Level 5',
+				0x27 => 'Mobile Audio Internetworking Profile @ Level 6',
+				0x28 => 'AAC Profile @ Level 1',
+				0x29 => 'AAC Profile @ Level 2',
+				0x2A => 'AAC Profile @ Level 4',
+				0x2B => 'AAC Profile @ Level 5',
+				0x2C => 'High Efficiency AAC Profile @ Level 2',
+				0x2D => 'High Efficiency AAC Profile @ Level 3',
+				0x2E => 'High Efficiency AAC Profile @ Level 4',
+				0x2F => 'High Efficiency AAC Profile @ Level 5',
+				0xFE => 'Not part of MPEG-4 audio profiles',
+				0xFF => 'No audio capability required',
 			);
 		}
 		return (isset($QuicktimeIODSaudioProfileNameLookup[$audio_profile_id]) ? $QuicktimeIODSaudioProfileNameLookup[$audio_profile_id] : 'ISO Reserved / User Private');
 	}
 
-
+	/**
+	 * @param int $video_profile_id
+	 *
+	 * @return string
+	 */
 	public function QuicktimeIODSvideoProfileName($video_profile_id) {
 		static $QuicktimeIODSvideoProfileNameLookup = array();
 		if (empty($QuicktimeIODSvideoProfileNameLookup)) {
@@ -1779,7 +2542,11 @@ class getid3_quicktime extends getid3_handler
 		return (isset($QuicktimeIODSvideoProfileNameLookup[$video_profile_id]) ? $QuicktimeIODSvideoProfileNameLookup[$video_profile_id] : 'ISO Reserved Profile');
 	}
 
-
+	/**
+	 * @param int $rtng
+	 *
+	 * @return string
+	 */
 	public function QuicktimeContentRatingLookup($rtng) {
 		static $QuicktimeContentRatingLookup = array();
 		if (empty($QuicktimeContentRatingLookup)) {
@@ -1790,6 +2557,11 @@ class getid3_quicktime extends getid3_handler
 		return (isset($QuicktimeContentRatingLookup[$rtng]) ? $QuicktimeContentRatingLookup[$rtng] : 'invalid');
 	}
 
+	/**
+	 * @param int $akid
+	 *
+	 * @return string
+	 */
 	public function QuicktimeStoreAccountTypeLookup($akid) {
 		static $QuicktimeStoreAccountTypeLookup = array();
 		if (empty($QuicktimeStoreAccountTypeLookup)) {
@@ -1799,6 +2571,11 @@ class getid3_quicktime extends getid3_handler
 		return (isset($QuicktimeStoreAccountTypeLookup[$akid]) ? $QuicktimeStoreAccountTypeLookup[$akid] : 'invalid');
 	}
 
+	/**
+	 * @param int $sfid
+	 *
+	 * @return string
+	 */
 	public function QuicktimeStoreFrontCodeLookup($sfid) {
 		static $QuicktimeStoreFrontCodeLookup = array();
 		if (empty($QuicktimeStoreFrontCodeLookup)) {
@@ -1828,6 +2605,11 @@ class getid3_quicktime extends getid3_handler
 		return (isset($QuicktimeStoreFrontCodeLookup[$sfid]) ? $QuicktimeStoreFrontCodeLookup[$sfid] : 'invalid');
 	}
 
+	/**
+	 * @param string $atom_data
+	 *
+	 * @return array
+	 */
 	public function QuicktimeParseNikonNCTG($atom_data) {
 		// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html#NCTG
 		// Nikon-specific QuickTime tags found in the NCDT atom of MOV videos from some Nikon cameras such as the Coolpix S8000 and D5100
@@ -1870,10 +2652,10 @@ class getid3_quicktime extends getid3_handler
 		);
 
 		$offset = 0;
+		$data = null;
 		$datalength = strlen($atom_data);
 		$parsed = array();
 		while ($offset < $datalength) {
-//echo getid3_lib::PrintHexBytes(substr($atom_data, $offset, 4)).'<br>';
 			$record_type       = getid3_lib::BigEndian2Int(substr($atom_data, $offset, 4));  $offset += 4;
 			$data_size_type    = getid3_lib::BigEndian2Int(substr($atom_data, $offset, 2));  $offset += 2;
 			$data_size         = getid3_lib::BigEndian2Int(substr($atom_data, $offset, 2));  $offset += 2;
@@ -1928,7 +2710,7 @@ class getid3_quicktime extends getid3_handler
 					$offset += ($data_size * 2);
 					break;
 				default:
-echo 'QuicktimeParseNikonNCTG()::unknown $data_size_type: '.$data_size_type.'<br>';
+					echo 'QuicktimeParseNikonNCTG()::unknown $data_size_type: '.$data_size_type.'<br>';
 					break 2;
 			}
 
@@ -2006,80 +2788,92 @@ echo 'QuicktimeParseNikonNCTG()::unknown $data_size_type: '.$data_size_type.'<br
 		return $parsed;
 	}
 
-
+	/**
+	 * @param string $keyname
+	 * @param string|array $data
+	 * @param string $boxname
+	 *
+	 * @return bool
+	 */
 	public function CopyToAppropriateCommentsSection($keyname, $data, $boxname='') {
 		static $handyatomtranslatorarray = array();
 		if (empty($handyatomtranslatorarray)) {
-			$handyatomtranslatorarray['©cpy'] = 'copyright';
-			$handyatomtranslatorarray['©day'] = 'creation_date';    // iTunes 4.0
-			$handyatomtranslatorarray['©dir'] = 'director';
-			$handyatomtranslatorarray['©ed1'] = 'edit1';
-			$handyatomtranslatorarray['©ed2'] = 'edit2';
-			$handyatomtranslatorarray['©ed3'] = 'edit3';
-			$handyatomtranslatorarray['©ed4'] = 'edit4';
-			$handyatomtranslatorarray['©ed5'] = 'edit5';
-			$handyatomtranslatorarray['©ed6'] = 'edit6';
-			$handyatomtranslatorarray['©ed7'] = 'edit7';
-			$handyatomtranslatorarray['©ed8'] = 'edit8';
-			$handyatomtranslatorarray['©ed9'] = 'edit9';
-			$handyatomtranslatorarray['©fmt'] = 'format';
-			$handyatomtranslatorarray['©inf'] = 'information';
-			$handyatomtranslatorarray['©prd'] = 'producer';
-			$handyatomtranslatorarray['©prf'] = 'performers';
-			$handyatomtranslatorarray['©req'] = 'system_requirements';
-			$handyatomtranslatorarray['©src'] = 'source_credit';
-			$handyatomtranslatorarray['©wrt'] = 'writer';
-
 			// http://www.geocities.com/xhelmboyx/quicktime/formats/qtm-layout.txt
-			$handyatomtranslatorarray['©nam'] = 'title';           // iTunes 4.0
-			$handyatomtranslatorarray['©cmt'] = 'comment';         // iTunes 4.0
-			$handyatomtranslatorarray['©wrn'] = 'warning';
-			$handyatomtranslatorarray['©hst'] = 'host_computer';
-			$handyatomtranslatorarray['©mak'] = 'make';
-			$handyatomtranslatorarray['©mod'] = 'model';
-			$handyatomtranslatorarray['©PRD'] = 'product';
-			$handyatomtranslatorarray['©swr'] = 'software';
-			$handyatomtranslatorarray['©aut'] = 'author';
-			$handyatomtranslatorarray['©ART'] = 'artist';
-			$handyatomtranslatorarray['©trk'] = 'track';
-			$handyatomtranslatorarray['©alb'] = 'album';           // iTunes 4.0
-			$handyatomtranslatorarray['©com'] = 'comment';
-			$handyatomtranslatorarray['©gen'] = 'genre';           // iTunes 4.0
-			$handyatomtranslatorarray['©ope'] = 'composer';
-			$handyatomtranslatorarray['©url'] = 'url';
-			$handyatomtranslatorarray['©enc'] = 'encoder';
-
-			// http://atomicparsley.sourceforge.net/mpeg-4files.html
-			$handyatomtranslatorarray['©art'] = 'artist';           // iTunes 4.0
-			$handyatomtranslatorarray['aART'] = 'album_artist';
-			$handyatomtranslatorarray['trkn'] = 'track_number';     // iTunes 4.0
-			$handyatomtranslatorarray['disk'] = 'disc_number';      // iTunes 4.0
-			$handyatomtranslatorarray['gnre'] = 'genre';            // iTunes 4.0
-			$handyatomtranslatorarray['©too'] = 'encoder';          // iTunes 4.0
-			$handyatomtranslatorarray['tmpo'] = 'bpm';              // iTunes 4.0
-			$handyatomtranslatorarray['cprt'] = 'copyright';        // iTunes 4.0?
-			$handyatomtranslatorarray['cpil'] = 'compilation';      // iTunes 4.0
-			$handyatomtranslatorarray['covr'] = 'picture';          // iTunes 4.0
-			$handyatomtranslatorarray['rtng'] = 'rating';           // iTunes 4.0
-			$handyatomtranslatorarray['©grp'] = 'grouping';         // iTunes 4.2
-			$handyatomtranslatorarray['stik'] = 'stik';             // iTunes 4.9
-			$handyatomtranslatorarray['pcst'] = 'podcast';          // iTunes 4.9
-			$handyatomtranslatorarray['catg'] = 'category';         // iTunes 4.9
-			$handyatomtranslatorarray['keyw'] = 'keyword';          // iTunes 4.9
-			$handyatomtranslatorarray['purl'] = 'podcast_url';      // iTunes 4.9
-			$handyatomtranslatorarray['egid'] = 'episode_guid';     // iTunes 4.9
-			$handyatomtranslatorarray['desc'] = 'description';      // iTunes 5.0
-			$handyatomtranslatorarray['©lyr'] = 'lyrics';           // iTunes 5.0
-			$handyatomtranslatorarray['tvnn'] = 'tv_network_name';  // iTunes 6.0
-			$handyatomtranslatorarray['tvsh'] = 'tv_show_name';     // iTunes 6.0
-			$handyatomtranslatorarray['tvsn'] = 'tv_season';        // iTunes 6.0
-			$handyatomtranslatorarray['tves'] = 'tv_episode';       // iTunes 6.0
-			$handyatomtranslatorarray['purd'] = 'purchase_date';    // iTunes 6.0.2
-			$handyatomtranslatorarray['pgap'] = 'gapless_playback'; // iTunes 7.0
-
 			// http://www.geocities.com/xhelmboyx/quicktime/formats/mp4-layout.txt
-
-
+			// http://atomicparsley.sourceforge.net/mpeg-4files.html
+			// https://code.google.com/p/mp4v2/wiki/iTunesMetadata
+			$handyatomtranslatorarray["\xA9".'alb'] = 'album';               // iTunes 4.0
+			$handyatomtranslatorarray["\xA9".'ART'] = 'artist';
+			$handyatomtranslatorarray["\xA9".'art'] = 'artist';              // iTunes 4.0
+			$handyatomtranslatorarray["\xA9".'aut'] = 'author';
+			$handyatomtranslatorarray["\xA9".'cmt'] = 'comment';             // iTunes 4.0
+			$handyatomtranslatorarray["\xA9".'com'] = 'comment';
+			$handyatomtranslatorarray["\xA9".'cpy'] = 'copyright';
+			$handyatomtranslatorarray["\xA9".'day'] = 'creation_date';       // iTunes 4.0
+			$handyatomtranslatorarray["\xA9".'dir'] = 'director';
+			$handyatomtranslatorarray["\xA9".'ed1'] = 'edit1';
+			$handyatomtranslatorarray["\xA9".'ed2'] = 'edit2';
+			$handyatomtranslatorarray["\xA9".'ed3'] = 'edit3';
+			$handyatomtranslatorarray["\xA9".'ed4'] = 'edit4';
+			$handyatomtranslatorarray["\xA9".'ed5'] = 'edit5';
+			$handyatomtranslatorarray["\xA9".'ed6'] = 'edit6';
+			$handyatomtranslatorarray["\xA9".'ed7'] = 'edit7';
+			$handyatomtranslatorarray["\xA9".'ed8'] = 'edit8';
+			$handyatomtranslatorarray["\xA9".'ed9'] = 'edit9';
+			$handyatomtranslatorarray["\xA9".'enc'] = 'encoded_by';
+			$handyatomtranslatorarray["\xA9".'fmt'] = 'format';
+			$handyatomtranslatorarray["\xA9".'gen'] = 'genre';               // iTunes 4.0
+			$handyatomtranslatorarray["\xA9".'grp'] = 'grouping';            // iTunes 4.2
+			$handyatomtranslatorarray["\xA9".'hst'] = 'host_computer';
+			$handyatomtranslatorarray["\xA9".'inf'] = 'information';
+			$handyatomtranslatorarray["\xA9".'lyr'] = 'lyrics';              // iTunes 5.0
+			$handyatomtranslatorarray["\xA9".'mak'] = 'make';
+			$handyatomtranslatorarray["\xA9".'mod'] = 'model';
+			$handyatomtranslatorarray["\xA9".'nam'] = 'title';               // iTunes 4.0
+			$handyatomtranslatorarray["\xA9".'ope'] = 'composer';
+			$handyatomtranslatorarray["\xA9".'prd'] = 'producer';
+			$handyatomtranslatorarray["\xA9".'PRD'] = 'product';
+			$handyatomtranslatorarray["\xA9".'prf'] = 'performers';
+			$handyatomtranslatorarray["\xA9".'req'] = 'system_requirements';
+			$handyatomtranslatorarray["\xA9".'src'] = 'source_credit';
+			$handyatomtranslatorarray["\xA9".'swr'] = 'software';
+			$handyatomtranslatorarray["\xA9".'too'] = 'encoding_tool';       // iTunes 4.0
+			$handyatomtranslatorarray["\xA9".'trk'] = 'track_number';
+			$handyatomtranslatorarray["\xA9".'url'] = 'url';
+			$handyatomtranslatorarray["\xA9".'wrn'] = 'warning';
+			$handyatomtranslatorarray["\xA9".'wrt'] = 'composer';
+			$handyatomtranslatorarray['aART'] = 'album_artist';
+			$handyatomtranslatorarray['apID'] = 'purchase_account';
+			$handyatomtranslatorarray['catg'] = 'category';            // iTunes 4.9
+			$handyatomtranslatorarray['covr'] = 'picture';             // iTunes 4.0
+			$handyatomtranslatorarray['cpil'] = 'compilation';         // iTunes 4.0
+			$handyatomtranslatorarray['cprt'] = 'copyright';           // iTunes 4.0?
+			$handyatomtranslatorarray['desc'] = 'description';         // iTunes 5.0
+			$handyatomtranslatorarray['disk'] = 'disc_number';         // iTunes 4.0
+			$handyatomtranslatorarray['egid'] = 'episode_guid';        // iTunes 4.9
+			$handyatomtranslatorarray['gnre'] = 'genre';               // iTunes 4.0
+			$handyatomtranslatorarray['hdvd'] = 'hd_video';            // iTunes 4.0
+			$handyatomtranslatorarray['ldes'] = 'description_long';    //
+			$handyatomtranslatorarray['keyw'] = 'keyword';             // iTunes 4.9
+			$handyatomtranslatorarray['pcst'] = 'podcast';             // iTunes 4.9
+			$handyatomtranslatorarray['pgap'] = 'gapless_playback';    // iTunes 7.0
+			$handyatomtranslatorarray['purd'] = 'purchase_date';       // iTunes 6.0.2
+			$handyatomtranslatorarray['purl'] = 'podcast_url';         // iTunes 4.9
+			$handyatomtranslatorarray['rtng'] = 'rating';              // iTunes 4.0
+			$handyatomtranslatorarray['soaa'] = 'sort_album_artist';   //
+			$handyatomtranslatorarray['soal'] = 'sort_album';          //
+			$handyatomtranslatorarray['soar'] = 'sort_artist';         //
+			$handyatomtranslatorarray['soco'] = 'sort_composer';       //
+			$handyatomtranslatorarray['sonm'] = 'sort_title';          //
+			$handyatomtranslatorarray['sosn'] = 'sort_show';           //
+			$handyatomtranslatorarray['stik'] = 'stik';                // iTunes 4.9
+			$handyatomtranslatorarray['tmpo'] = 'bpm';                 // iTunes 4.0
+			$handyatomtranslatorarray['trkn'] = 'track_number';        // iTunes 4.0
+			$handyatomtranslatorarray['tven'] = 'tv_episode_id';       //
+			$handyatomtranslatorarray['tves'] = 'tv_episode';          // iTunes 6.0
+			$handyatomtranslatorarray['tvnn'] = 'tv_network_name';     // iTunes 6.0
+			$handyatomtranslatorarray['tvsh'] = 'tv_show_name';        // iTunes 6.0
+			$handyatomtranslatorarray['tvsn'] = 'tv_season';           // iTunes 6.0
 
 			// boxnames:
 			/*
@@ -2097,8 +2891,8 @@ echo 'QuicktimeParseNikonNCTG()::unknown $data_size_type: '.$data_size_type.'<br
 			$handyatomtranslatorarray['MusicBrainz Disc Id']         = 'MusicBrainz Disc Id';
 
 			// http://age.hobba.nl/audio/tag_frame_reference.html
-			$handyatomtranslatorarray['PLAY_COUNTER']                = 'play_counter'; // Foobar2000 - http://www.getid3.org/phpBB3/viewtopic.php?t=1355
-			$handyatomtranslatorarray['MEDIATYPE']                   = 'mediatype';    // Foobar2000 - http://www.getid3.org/phpBB3/viewtopic.php?t=1355
+			$handyatomtranslatorarray['PLAY_COUNTER']                = 'play_counter'; // Foobar2000 - https://www.getid3.org/phpBB3/viewtopic.php?t=1355
+			$handyatomtranslatorarray['MEDIATYPE']                   = 'mediatype';    // Foobar2000 - https://www.getid3.org/phpBB3/viewtopic.php?t=1355
 			*/
 		}
 		$info = &$this->getid3->info;
@@ -2110,25 +2904,66 @@ echo 'QuicktimeParseNikonNCTG()::unknown $data_size_type: '.$data_size_type.'<br
 		}
 		if ($comment_key) {
 			if ($comment_key == 'picture') {
-				if (!is_array($data)) {
-					$image_mime = '';
-					if (preg_match('#^\x89\x50\x4E\x47\x0D\x0A\x1A\x0A#', $data)) {
-						$image_mime = 'image/png';
-					} elseif (preg_match('#^\xFF\xD8\xFF#', $data)) {
-						$image_mime = 'image/jpeg';
-					} elseif (preg_match('#^GIF#', $data)) {
-						$image_mime = 'image/gif';
-					} elseif (preg_match('#^BM#', $data)) {
-						$image_mime = 'image/bmp';
-					}
-					$data = array('data'=>$data, 'image_mime'=>$image_mime);
-				}
+				// already copied directly into [comments][picture] elsewhere, do not re-copy here
+				return true;
 			}
-			$info['quicktime']['comments'][$comment_key][] = $data;
+			$gooddata = array($data);
+			if ($comment_key == 'genre') {
+				// some other taggers separate multiple genres with semicolon, e.g. "Heavy Metal;Thrash Metal;Metal"
+				$gooddata = explode(';', $data);
+			}
+			foreach ($gooddata as $data) {
+				if (!empty($info['quicktime']['comments'][$comment_key]) && in_array($data, $info['quicktime']['comments'][$comment_key], true)) {
+					// avoid duplicate copies of identical data
+					continue;
+				}
+				$info['quicktime']['comments'][$comment_key][] = $data;
+			}
 		}
 		return true;
 	}
 
+	/**
+	 * @param string $lstring
+	 * @param int    $count
+	 *
+	 * @return string
+	 */
+	public function LociString($lstring, &$count) {
+		// Loci strings are UTF-8 or UTF-16 and null (x00/x0000) terminated. UTF-16 has a BOM
+		// Also need to return the number of bytes the string occupied so additional fields can be extracted
+		$len = strlen($lstring);
+		if ($len == 0) {
+			$count = 0;
+			return '';
+		}
+		if ($lstring[0] == "\x00") {
+			$count = 1;
+			return '';
+		}
+		// check for BOM
+		if (($len > 2) && ((($lstring[0] == "\xFE") && ($lstring[1] == "\xFF")) || (($lstring[0] == "\xFF") && ($lstring[1] == "\xFE")))) {
+			// UTF-16
+			if (preg_match('/(.*)\x00/', $lstring, $lmatches)) {
+				$count = strlen($lmatches[1]) * 2 + 2; //account for 2 byte characters and trailing \x0000
+				return getid3_lib::iconv_fallback_utf16_utf8($lmatches[1]);
+			} else {
+				return '';
+			}
+		}
+		// UTF-8
+		if (preg_match('/(.*)\x00/', $lstring, $lmatches)) {
+			$count = strlen($lmatches[1]) + 1; //account for trailing \x00
+			return $lmatches[1];
+		}
+		return '';
+	}
+
+	/**
+	 * @param string $nullterminatedstring
+	 *
+	 * @return string
+	 */
 	public function NoNullString($nullterminatedstring) {
 		// remove the single null terminator on null terminated strings
 		if (substr($nullterminatedstring, strlen($nullterminatedstring) - 1, 1) === "\x00") {
@@ -2137,9 +2972,128 @@ echo 'QuicktimeParseNikonNCTG()::unknown $data_size_type: '.$data_size_type.'<br
 		return $nullterminatedstring;
 	}
 
+	/**
+	 * @param string $pascalstring
+	 *
+	 * @return string
+	 */
 	public function Pascal2String($pascalstring) {
 		// Pascal strings have 1 unsigned byte at the beginning saying how many chars (1-255) are in the string
 		return substr($pascalstring, 1);
 	}
+
+	/**
+	 * @param string $pascalstring
+	 *
+	 * @return string
+	 */
+	public function MaybePascal2String($pascalstring) {
+		// Pascal strings have 1 unsigned byte at the beginning saying how many chars (1-255) are in the string
+		// Check if string actually is in this format or written incorrectly, straight string, or null-terminated string
+		if (ord(substr($pascalstring, 0, 1)) == (strlen($pascalstring) - 1)) {
+			return substr($pascalstring, 1);
+		} elseif (substr($pascalstring, -1, 1) == "\x00") {
+			// appears to be null-terminated instead of Pascal-style
+			return substr($pascalstring, 0, -1);
+		}
+		return $pascalstring;
+	}
+
+
+	/**
+	 * Helper functions for m4b audiobook chapters
+	 * code by Steffen Hartmann 2015-Nov-08.
+	 *
+	 * @param array  $info
+	 * @param string $tag
+	 * @param string $history
+	 * @param array  $result
+	 */
+	public function search_tag_by_key($info, $tag, $history, &$result) {
+		foreach ($info as $key => $value) {
+			$key_history = $history.'/'.$key;
+			if ($key === $tag) {
+				$result[] = array($key_history, $info);
+			} else {
+				if (is_array($value)) {
+					$this->search_tag_by_key($value, $tag, $key_history, $result);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param array  $info
+	 * @param string $k
+	 * @param string $v
+	 * @param string $history
+	 * @param array  $result
+	 */
+	public function search_tag_by_pair($info, $k, $v, $history, &$result) {
+		foreach ($info as $key => $value) {
+			$key_history = $history.'/'.$key;
+			if (($key === $k) && ($value === $v)) {
+				$result[] = array($key_history, $info);
+			} else {
+				if (is_array($value)) {
+					$this->search_tag_by_pair($value, $k, $v, $key_history, $result);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param array $info
+	 *
+	 * @return array
+	 */
+	public function quicktime_time_to_sample_table($info) {
+		$res = array();
+		$this->search_tag_by_pair($info['quicktime']['moov'], 'name', 'stbl', 'quicktime/moov', $res);
+		foreach ($res as $value) {
+			$stbl_res = array();
+			$this->search_tag_by_pair($value[1], 'data_format', 'text', $value[0], $stbl_res);
+			if (count($stbl_res) > 0) {
+				$stts_res = array();
+				$this->search_tag_by_key($value[1], 'time_to_sample_table', $value[0], $stts_res);
+				if (count($stts_res) > 0) {
+					return $stts_res[0][1]['time_to_sample_table'];
+				}
+			}
+		}
+		return array();
+	}
+
+	/**
+	 * @param array $info
+	 *
+	 * @return int
+	 */
+	public function quicktime_bookmark_time_scale($info) {
+		$time_scale = '';
+		$ts_prefix_len = 0;
+		$res = array();
+		$this->search_tag_by_pair($info['quicktime']['moov'], 'name', 'stbl', 'quicktime/moov', $res);
+		foreach ($res as $value) {
+			$stbl_res = array();
+			$this->search_tag_by_pair($value[1], 'data_format', 'text', $value[0], $stbl_res);
+			if (count($stbl_res) > 0) {
+				$ts_res = array();
+				$this->search_tag_by_key($info['quicktime']['moov'], 'time_scale', 'quicktime/moov', $ts_res);
+				foreach ($ts_res as $sub_value) {
+					$prefix = substr($sub_value[0], 0, -12);
+					if ((substr($stbl_res[0][0], 0, strlen($prefix)) === $prefix) && ($ts_prefix_len < strlen($prefix))) {
+						$time_scale = $sub_value[1]['time_scale'];
+						$ts_prefix_len = strlen($prefix);
+					}
+				}
+			}
+		}
+		return $time_scale;
+	}
+	/*
+	// END helper functions for m4b audiobook chapters
+	*/
+
 
 }

--- a/application/libraries/getid3/module.audio-video.real.php
+++ b/application/libraries/getid3/module.audio-video.real.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio-video.real.php                                 //
@@ -13,11 +14,16 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio-video.riff.php', __FILE__, true);
 
 class getid3_real extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -25,15 +31,15 @@ class getid3_real extends getid3_handler
 		$info['bitrate']          = 0;
 		$info['playtime_seconds'] = 0;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+		$this->fseek($info['avdataoffset']);
 		$ChunkCounter = 0;
-		while (ftell($this->getid3->fp) < $info['avdataend']) {
-			$ChunkData  = fread($this->getid3->fp, 8);
+		while ($this->ftell() < $info['avdataend']) {
+			$ChunkData  = $this->fread(8);
 			$ChunkName  =                           substr($ChunkData, 0, 4);
 			$ChunkSize  = getid3_lib::BigEndian2Int(substr($ChunkData, 4, 4));
 
 			if ($ChunkName == '.ra'."\xFD") {
-				$ChunkData .= fread($this->getid3->fp, $ChunkSize - 8);
+				$ChunkData .= $this->fread($ChunkSize - 8);
 				if ($this->ParseOldRAheader(substr($ChunkData, 0, 128), $info['real']['old_ra_header'])) {
 					$info['audio']['dataformat']      = 'real';
 					$info['audio']['lossless']        = false;
@@ -52,7 +58,7 @@ class getid3_real extends getid3_handler
 					}
 					return true;
 				}
-				$info['error'][] = 'There was a problem parsing this RealAudio file. Please submit it for analysis to info@getid3.org';
+				$this->error('There was a problem parsing this RealAudio file. Please submit it for analysis to info@getid3.org');
 				unset($info['bitrate']);
 				unset($info['playtime_seconds']);
 				return false;
@@ -63,21 +69,21 @@ class getid3_real extends getid3_handler
 			$thisfile_real_chunks_currentchunk = &$info['real']['chunks'][$ChunkCounter];
 
 			$thisfile_real_chunks_currentchunk['name']   = $ChunkName;
-			$thisfile_real_chunks_currentchunk['offset'] = ftell($this->getid3->fp) - 8;
+			$thisfile_real_chunks_currentchunk['offset'] = $this->ftell() - 8;
 			$thisfile_real_chunks_currentchunk['length'] = $ChunkSize;
 			if (($thisfile_real_chunks_currentchunk['offset'] + $thisfile_real_chunks_currentchunk['length']) > $info['avdataend']) {
-				$info['warning'][] = 'Chunk "'.$thisfile_real_chunks_currentchunk['name'].'" at offset '.$thisfile_real_chunks_currentchunk['offset'].' claims to be '.$thisfile_real_chunks_currentchunk['length'].' bytes long, which is beyond end of file';
+				$this->warning('Chunk "'.$thisfile_real_chunks_currentchunk['name'].'" at offset '.$thisfile_real_chunks_currentchunk['offset'].' claims to be '.$thisfile_real_chunks_currentchunk['length'].' bytes long, which is beyond end of file');
 				return false;
 			}
 
 			if ($ChunkSize > ($this->getid3->fread_buffer_size() + 8)) {
 
-				$ChunkData .= fread($this->getid3->fp, $this->getid3->fread_buffer_size() - 8);
-				fseek($this->getid3->fp, $thisfile_real_chunks_currentchunk['offset'] + $ChunkSize, SEEK_SET);
+				$ChunkData .= $this->fread($this->getid3->fread_buffer_size() - 8);
+				$this->fseek($thisfile_real_chunks_currentchunk['offset'] + $ChunkSize);
 
 			} elseif(($ChunkSize - 8) > 0) {
 
-				$ChunkData .= fread($this->getid3->fp, $ChunkSize - 8);
+				$ChunkData .= $this->fread($ChunkSize - 8);
 
 			}
 			$offset = 8;
@@ -97,7 +103,7 @@ class getid3_real extends getid3_handler
 							break;
 
 						default:
-							//$info['warning'][] = 'Expected .RMF-object_version to be "0", actual value is "'.$thisfile_real_chunks_currentchunk['object_version'].'" (should not be a problem)';
+							//$this->warning('Expected .RMF-object_version to be "0", actual value is "'.$thisfile_real_chunks_currentchunk['object_version'].'" (should not be a problem)');
 							break;
 
 					}
@@ -347,13 +353,13 @@ class getid3_real extends getid3_handler
 							break 2;
 						} else {
 							// non-last index chunk, seek to next index chunk (skipping actual index data)
-							fseek($this->getid3->fp, $thisfile_real_chunks_currentchunk['next_index_header'], SEEK_SET);
+							$this->fseek($thisfile_real_chunks_currentchunk['next_index_header']);
 						}
 					}
 					break;
 
 				default:
-					$info['warning'][] = 'Unhandled RealMedia chunk "'.$ChunkName.'" at offset '.$thisfile_real_chunks_currentchunk['offset'];
+					$this->warning('Unhandled RealMedia chunk "'.$ChunkName.'" at offset '.$thisfile_real_chunks_currentchunk['offset']);
 					break;
 			}
 			$ChunkCounter++;
@@ -369,7 +375,12 @@ class getid3_real extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @param string $OldRAheaderData
+	 * @param array  $ParsedArray
+	 *
+	 * @return bool
+	 */
 	public function ParseOldRAheader($OldRAheaderData, &$ParsedArray) {
 		// http://www.freelists.org/archives/matroska-devel/07-2003/msg00010.html
 
@@ -475,8 +486,9 @@ class getid3_real extends getid3_handler
 			$ParsedArray['fourcc'] = $ParsedArray['fourcc3'];
 
 		}
+		/** @var string[]|false[] $value */
 		foreach ($ParsedArray['comments'] as $key => $value) {
-			if ($ParsedArray['comments'][$key][0] === false) {
+			if ($value[0] === false) {
 				$ParsedArray['comments'][$key][0] = '';
 			}
 		}
@@ -484,6 +496,12 @@ class getid3_real extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $fourcc
+	 * @param int    $bitrate
+	 *
+	 * @return string
+	 */
 	public function RealAudioCodecFourCClookup($fourcc, $bitrate) {
 		static $RealAudioCodecFourCClookup = array();
 		if (empty($RealAudioCodecFourCClookup)) {

--- a/application/libraries/getid3/module.audio-video.swf.php
+++ b/application/libraries/getid3/module.audio-video.swf.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio-video.swf.php                                  //
@@ -13,11 +14,17 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_swf extends getid3_handler
 {
 	public $ReturnAllTagData = false;
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -26,9 +33,9 @@ class getid3_swf extends getid3_handler
 
 		// http://www.openswf.org/spec/SWFfileformat.html
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+		$this->fseek($info['avdataoffset']);
 
-		$SWFfileData = fread($this->getid3->fp, $info['avdataend'] - $info['avdataoffset']); // 8 + 2 + 2 + max(9) bytes NOT including Frame_Size RECT data
+		$SWFfileData = $this->fread($info['avdataend'] - $info['avdataoffset']); // 8 + 2 + 2 + max(9) bytes NOT including Frame_Size RECT data
 
 		$info['swf']['header']['signature']  = substr($SWFfileData, 0, 3);
 		switch ($info['swf']['header']['signature']) {
@@ -41,11 +48,10 @@ class getid3_swf extends getid3_handler
 				break;
 
 			default:
-				$info['error'][] = 'Expecting "FWS" or "CWS" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['swf']['header']['signature']).'"';
+				$this->error('Expecting "FWS" or "CWS" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['swf']['header']['signature']).'"');
 				unset($info['swf']);
 				unset($info['fileformat']);
 				return false;
-				break;
 		}
 		$info['swf']['header']['version'] = getid3_lib::LittleEndian2Int(substr($SWFfileData, 3, 1));
 		$info['swf']['header']['length']  = getid3_lib::LittleEndian2Int(substr($SWFfileData, 4, 4));
@@ -56,7 +62,7 @@ class getid3_swf extends getid3_handler
 			if ($decompressed = @gzuncompress($SWFfileData)) {
 				$SWFfileData = $SWFHead.$decompressed;
 			} else {
-				$info['error'][] = 'Error decompressing compressed SWF data ('.strlen($SWFfileData).' bytes compressed, should be '.($info['swf']['header']['length'] - 8).' bytes uncompressed)';
+				$this->error('Error decompressing compressed SWF data ('.strlen($SWFfileData).' bytes compressed, should be '.($info['swf']['header']['length'] - 8).' bytes uncompressed)');
 				return false;
 			}
 		}

--- a/application/libraries/getid3/module.audio-video.ts.php
+++ b/application/libraries/getid3/module.audio-video.ts.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio-video.ts.php                                   //
@@ -13,18 +14,23 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_ts extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$TSheader = fread($this->getid3->fp, 19);
+		$this->fseek($info['avdataoffset']);
+		$TSheader = $this->fread(19);
 		$magic = "\x47";
 		if (substr($TSheader, 0, 1) != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at '.$info['avdataoffset'].', found '.getid3_lib::PrintHexBytes(substr($TSheader, 0, 1)).' instead.';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at '.$info['avdataoffset'].', found '.getid3_lib::PrintHexBytes(substr($TSheader, 0, 1)).' instead.');
 			return false;
 		}
 		$info['fileformat'] = 'ts';
@@ -65,12 +71,16 @@ class getid3_ts extends getid3_handler
 			}
 		}
 
-$info['error'][] = 'MPEG Transport Stream (.ts) parsing not enabled in this version of getID3() ['.$this->getid3->version().']';
-return false;
+		$this->error('MPEG Transport Stream (.ts) parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
+		return false;
 
 	}
 
-
+	/**
+	 * @param int $raw
+	 *
+	 * @return string
+	 */
 	public function TSscramblingControlLookup($raw) {
 		$TSscramblingControlLookup = array(0x00=>'not scrambled', 0x01=>'reserved', 0x02=>'scrambled, even key', 0x03=>'scrambled, odd key');
 		return (isset($TSscramblingControlLookup[$raw]) ? $TSscramblingControlLookup[$raw] : 'invalid');

--- a/application/libraries/getid3/module.audio-video.wtv.php
+++ b/application/libraries/getid3/module.audio-video.wtv.php
@@ -1,5 +1,4 @@
 <?php
-
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at https://github.com/JamesHeinrich/getID3       //
@@ -8,8 +7,9 @@
 //  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
-// module.misc.msoffice.php                                    //
-// module for analyzing MS Office (.doc, .xls, etc) files      //
+// module.audio.wtv.php                                        //
+// module for analyzing WTV (Windows Recorded TV Show)         //
+//   audio-video files                                         //
 // dependencies: NONE                                          //
 //                                                            ///
 /////////////////////////////////////////////////////////////////
@@ -18,7 +18,7 @@ if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that acce
 	exit;
 }
 
-class getid3_msoffice extends getid3_handler
+class getid3_wtv extends getid3_handler
 {
 	/**
 	 * @return bool
@@ -26,18 +26,12 @@ class getid3_msoffice extends getid3_handler
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		$this->fseek($info['avdataoffset']);
-		$DOCFILEheader = $this->fread(8);
-		$magic = "\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1";
-		if (substr($DOCFILEheader, 0, 8) != $magic) {
-			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at '.$info['avdataoffset'].', found '.getid3_lib::PrintHexBytes(substr($DOCFILEheader, 0, 8)).' instead.');
-			return false;
-		}
-		$info['fileformat'] = 'msoffice';
+		$info['fileformat']          = 'wtv';
+		$info['video']['dataformat'] = 'wtv';
 
-		$this->error('MS Office (.doc, .xls, etc) parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
-		return false;
+		$this->error('WTV (Windows Recorded TV Show) files not properly processed by this version of getID3() ['.$this->getid3->version().']');
 
+		return true;
 	}
 
 }

--- a/application/libraries/getid3/module.audio.aa.php
+++ b/application/libraries/getid3/module.audio.aa.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.aa.php                                         //
@@ -13,41 +14,46 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_aa extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$AAheader  = fread($this->getid3->fp, 8);
+		$this->fseek($info['avdataoffset']);
+		$AAheader  = $this->fread(8);
 
 		$magic = "\x57\x90\x75\x36";
 		if (substr($AAheader, 4, 4) != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($AAheader, 4, 4)).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($AAheader, 4, 4)).'"');
 			return false;
 		}
 
 		// shortcut
 		$info['aa'] = array();
-		$thisfile_au = &$info['aa'];
+		$thisfile_aa = &$info['aa'];
 
 		$info['fileformat']            = 'aa';
 		$info['audio']['dataformat']   = 'aa';
-$info['error'][] = 'Audible Audiobook (.aa) parsing not enabled in this version of getID3() ['.$this->getid3->version().']';
-return false;
+		$this->error('Audible Audiobook (.aa) parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
+		return false;
 		$info['audio']['bitrate_mode'] = 'cbr'; // is it?
-		$thisfile_au['encoding']       = 'ISO-8859-1';
+		$thisfile_aa['encoding']       = 'ISO-8859-1';
 
-		$thisfile_au['filesize'] = getid3_lib::BigEndian2Int(substr($AUheader,  0, 4));
-		if ($thisfile_au['filesize'] > ($info['avdataend'] - $info['avdataoffset'])) {
-			$info['warning'][] = 'Possible truncated file - expecting "'.$thisfile_au['filesize'].'" bytes of data, only found '.($info['avdataend'] - $info['avdataoffset']).' bytes"';
+		$thisfile_aa['filesize'] = getid3_lib::BigEndian2Int(substr($AAheader,  0, 4));
+		if ($thisfile_aa['filesize'] > ($info['avdataend'] - $info['avdataoffset'])) {
+			$this->warning('Possible truncated file - expecting "'.$thisfile_aa['filesize'].'" bytes of data, only found '.($info['avdataend'] - $info['avdataoffset']).' bytes"');
 		}
 
 		$info['audio']['bits_per_sample'] = 16; // is it?
-		$info['audio']['sample_rate'] = $thisfile_au['sample_rate'];
-		$info['audio']['channels']    = $thisfile_au['channels'];
+		$info['audio']['sample_rate'] = $thisfile_aa['sample_rate'];
+		$info['audio']['channels']    = $thisfile_aa['channels'];
 
 		//$info['playtime_seconds'] = 0;
 		//$info['audio']['bitrate'] = 0;

--- a/application/libraries/getid3/module.audio.aac.php
+++ b/application/libraries/getid3/module.audio.aac.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.aac.php                                        //
@@ -13,13 +14,19 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_aac extends getid3_handler
 {
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		if (fread($this->getid3->fp, 4) == 'ADIF') {
+		$this->fseek($info['avdataoffset']);
+		if ($this->fread(4) == 'ADIF') {
 			$this->getAACADIFheaderFilepointer();
 		} else {
 			$this->getAACADTSheaderFilepointer();
@@ -27,16 +34,17 @@ class getid3_aac extends getid3_handler
 		return true;
 	}
 
-
-
+	/**
+	 * @return bool
+	 */
 	public function getAACADIFheaderFilepointer() {
 		$info = &$this->getid3->info;
 		$info['fileformat']          = 'aac';
 		$info['audio']['dataformat'] = 'aac';
 		$info['audio']['lossless']   = false;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$AACheader = fread($this->getid3->fp, 1024);
+		$this->fseek($info['avdataoffset']);
+		$AACheader = $this->fread(1024);
 		$offset    = 0;
 
 		if (substr($AACheader, 0, 4) == 'ADIF') {
@@ -68,17 +76,17 @@ class getid3_aac extends getid3_handler
 			$bitoffset += 32;
 			$info['aac']['header']['mpeg_version']        = 4;
 
-			$info['aac']['header']['copyright']           = (bool) (substr($AACheaderBitstream, $bitoffset, 1) == '1');
+			$info['aac']['header']['copyright']           = substr($AACheaderBitstream, $bitoffset, 1) == '1';
 			$bitoffset += 1;
 			if ($info['aac']['header']['copyright']) {
 				$info['aac']['header']['copyright_id']    = getid3_lib::Bin2String(substr($AACheaderBitstream, $bitoffset, 72));
 				$bitoffset += 72;
 			}
-			$info['aac']['header']['original_copy']       = (bool) (substr($AACheaderBitstream, $bitoffset, 1) == '1');
+			$info['aac']['header']['original_copy']       = substr($AACheaderBitstream, $bitoffset, 1) == '1';
 			$bitoffset += 1;
-			$info['aac']['header']['home']                = (bool) (substr($AACheaderBitstream, $bitoffset, 1) == '1');
+			$info['aac']['header']['home']                = substr($AACheaderBitstream, $bitoffset, 1) == '1';
 			$bitoffset += 1;
-			$info['aac']['header']['is_vbr']              = (bool) (substr($AACheaderBitstream, $bitoffset, 1) == '1');
+			$info['aac']['header']['is_vbr']              = substr($AACheaderBitstream, $bitoffset, 1) == '1';
 			$bitoffset += 1;
 			if ($info['aac']['header']['is_vbr']) {
 				$info['audio']['bitrate_mode']            = 'vbr';
@@ -91,7 +99,7 @@ class getid3_aac extends getid3_handler
 				$info['audio']['bitrate']                 = $info['aac']['header']['bitrate'];
 			}
 			if ($info['audio']['bitrate'] == 0) {
-				$info['error'][] = 'Corrupt AAC file: bitrate_audio == zero';
+				$this->error('Corrupt AAC file: bitrate_audio == zero');
 				return false;
 			}
 			$info['aac']['header']['num_program_configs'] = 1 + getid3_lib::Bin2Dec(substr($AACheaderBitstream, $bitoffset, 4));
@@ -249,18 +257,23 @@ class getid3_aac extends getid3_handler
 
 			unset($info['fileformat']);
 			unset($info['aac']);
-			$info['error'][] = 'AAC-ADIF synch not found at offset '.$info['avdataoffset'].' (expected "ADIF", found "'.substr($AACheader, 0, 4).'" instead)';
+			$this->error('AAC-ADIF synch not found at offset '.$info['avdataoffset'].' (expected "ADIF", found "'.substr($AACheader, 0, 4).'" instead)');
 			return false;
 
 		}
 
 	}
 
-
+	/**
+	 * @param int  $MaxFramesToScan
+	 * @param bool $ReturnExtendedInfo
+	 *
+	 * @return bool
+	 */
 	public function getAACADTSheaderFilepointer($MaxFramesToScan=1000000, $ReturnExtendedInfo=false) {
 		$info = &$this->getid3->info;
 
-		// based loosely on code from AACfile by Jurgen Faul  <jfaulØgmx.de>
+		// based loosely on code from AACfile by Jurgen Faul  <jfaulÃ˜gmx.de>
 		// http://jfaul.de/atl  or  http://j-faul.virtualave.net/atl/atl.html
 
 
@@ -310,16 +323,16 @@ class getid3_aac extends getid3_handler
 			// or MaxFramesToScan frames have been scanned
 
 			if (!getid3_lib::intValueSupported($byteoffset)) {
-				$info['warning'][] = 'Unable to parse AAC file beyond '.ftell($this->getid3->fp).' (PHP does not support file operations beyond '.round(PHP_INT_MAX / 1073741824).'GB)';
+				$this->warning('Unable to parse AAC file beyond '.$this->ftell().' (PHP does not support file operations beyond '.round(PHP_INT_MAX / 1073741824).'GB)');
 				return false;
 			}
-			fseek($this->getid3->fp, $byteoffset, SEEK_SET);
+			$this->fseek($byteoffset);
 
 			// First get substring
-			$substring = fread($this->getid3->fp, 9); // header is 7 bytes (or 9 if CRC is present)
+			$substring = $this->fread(9); // header is 7 bytes (or 9 if CRC is present)
 			$substringlength = strlen($substring);
 			if ($substringlength != 9) {
-				$info['error'][] = 'Failed to read 7 bytes at offset '.(ftell($this->getid3->fp) - $substringlength).' (only read '.$substringlength.' bytes)';
+				$this->error('Failed to read 7 bytes at offset '.($this->ftell() - $substringlength).' (only read '.$substringlength.' bytes)');
 				return false;
 			}
 			// this would be easier with 64-bit math, but split it up to allow for 32-bit:
@@ -329,7 +342,7 @@ class getid3_aac extends getid3_handler
 
 			$info['aac']['header']['raw']['syncword']          = ($header1 & 0xFFF0) >> 4;
 			if ($info['aac']['header']['raw']['syncword'] != 0x0FFF) {
-				$info['error'][] = 'Synch pattern (0x0FFF) not found at offset '.(ftell($this->getid3->fp) - $substringlength).' (found 0x0'.strtoupper(dechex($info['aac']['header']['raw']['syncword'])).' instead)';
+				$this->error('Synch pattern (0x0FFF) not found at offset '.($this->ftell() - $substringlength).' (found 0x0'.strtoupper(dechex($info['aac']['header']['raw']['syncword'])).' instead)');
 				//if ($info['fileformat'] == 'aac') {
 				//	return true;
 				//}
@@ -371,10 +384,10 @@ class getid3_aac extends getid3_handler
 				}
 
 				if ($info['aac']['header']['raw']['mpeg_layer'] != 0) {
-					$info['warning'][] = 'Layer error - expected "0", found "'.$info['aac']['header']['raw']['mpeg_layer'].'" instead';
+					$this->warning('Layer error - expected "0", found "'.$info['aac']['header']['raw']['mpeg_layer'].'" instead');
 				}
 				if ($info['aac']['header']['sample_frequency'] == 0) {
-					$info['error'][] = 'Corrupt AAC file: sample_frequency == zero';
+					$this->error('Corrupt AAC file: sample_frequency == zero');
 					return false;
 				}
 
@@ -427,7 +440,7 @@ class getid3_aac extends getid3_handler
 				$info['aac']['frames']    = $framenumber;
 				$info['playtime_seconds'] = ($info['avdataend'] / $byteoffset) * (($framenumber * 1024) / $info['aac']['header']['sample_frequency']);  // (1 / % of file scanned) * (samples / (samples/sec)) = seconds
 				if ($info['playtime_seconds'] == 0) {
-					$info['error'][] = 'Corrupt AAC file: playtime_seconds == zero';
+					$this->error('Corrupt AAC file: playtime_seconds == zero');
 					return false;
 				}
 				$info['audio']['bitrate']    = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
@@ -442,6 +455,11 @@ class getid3_aac extends getid3_handler
 		// should never get here.
 	}
 
+	/**
+	 * @param int $samplerateid
+	 *
+	 * @return int|string
+	 */
 	public static function AACsampleRateLookup($samplerateid) {
 		static $AACsampleRateLookup = array();
 		if (empty($AACsampleRateLookup)) {
@@ -465,6 +483,12 @@ class getid3_aac extends getid3_handler
 		return (isset($AACsampleRateLookup[$samplerateid]) ? $AACsampleRateLookup[$samplerateid] : 'invalid');
 	}
 
+	/**
+	 * @param int $profileid
+	 * @param int $mpegversion
+	 *
+	 * @return string
+	 */
 	public static function AACprofileLookup($profileid, $mpegversion) {
 		static $AACprofileLookup = array();
 		if (empty($AACprofileLookup)) {
@@ -480,6 +504,11 @@ class getid3_aac extends getid3_handler
 		return (isset($AACprofileLookup[$mpegversion][$profileid]) ? $AACprofileLookup[$mpegversion][$profileid] : 'invalid');
 	}
 
+	/**
+	 * @param array $program_configs
+	 *
+	 * @return int
+	 */
 	public static function AACchannelCountCalculate($program_configs) {
 		$channels = 0;
 		for ($i = 0; $i < $program_configs['num_front_channel_elements']; $i++) {

--- a/application/libraries/getid3/module.audio.ac3.php
+++ b/application/libraries/getid3/module.audio.ac3.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.ac3.php                                        //
@@ -13,14 +14,27 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_ac3 extends getid3_handler
 {
-    private $AC3header = array();
-    private $BSIoffset = 0;
+	/**
+	 * @var array
+	 */
+	private $AC3header = array();
 
-    const syncword = "\x0B\x77";
+	/**
+	 * @var int
+	 */
+	private $BSIoffset = 0;
 
+	const syncword = 0x0B77;
+
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -54,55 +68,393 @@ class getid3_ac3 extends getid3_handler
 		// } /* end of syncinfo */
 
 		$this->fseek($info['avdataoffset']);
-		$this->AC3header['syncinfo'] = $this->fread(5);
+		$tempAC3header = $this->fread(100); // should be enough to cover all data, there are some variable-length fields...?
+		$this->AC3header['syncinfo']  =     getid3_lib::BigEndian2Int(substr($tempAC3header, 0, 2));
+		$this->AC3header['bsi']       =     getid3_lib::BigEndian2Bin(substr($tempAC3header, 2));
+		$thisfile_ac3_raw_bsi['bsid'] = (getid3_lib::LittleEndian2Int(substr($tempAC3header, 5, 1)) & 0xF8) >> 3; // AC3 and E-AC3 put the "bsid" version identifier in the same place, but unfortnately the 4 bytes between the syncword and the version identifier are interpreted differently, so grab it here so the following code structure can make sense
+		unset($tempAC3header);
 
-		if (strpos($this->AC3header['syncinfo'], self::syncword) === 0) {
-			$thisfile_ac3_raw['synchinfo']['synchword'] = self::syncword;
-			$offset = 2;
-		} else {
+		if ($this->AC3header['syncinfo'] !== self::syncword) {
 			if (!$this->isDependencyFor('matroska')) {
 				unset($info['fileformat'], $info['ac3']);
-				return $this->error('Expecting "'.getid3_lib::PrintHexBytes(self::syncword).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($this->AC3header['syncinfo'], 0, 2)).'"');
+				return $this->error('Expecting "'.dechex(self::syncword).'" at offset '.$info['avdataoffset'].', found "'.dechex($this->AC3header['syncinfo']).'"');
 			}
-			$offset = 0;
-			$this->fseek(-2, SEEK_CUR);
 		}
 
 		$info['audio']['dataformat']   = 'ac3';
 		$info['audio']['bitrate_mode'] = 'cbr';
 		$info['audio']['lossless']     = false;
 
-		$thisfile_ac3_raw['synchinfo']['crc1']       = getid3_lib::LittleEndian2Int(substr($this->AC3header['syncinfo'], $offset, 2));
-		$ac3_synchinfo_fscod_frmsizecod              = getid3_lib::LittleEndian2Int(substr($this->AC3header['syncinfo'], ($offset + 2), 1));
-		$thisfile_ac3_raw['synchinfo']['fscod']      = ($ac3_synchinfo_fscod_frmsizecod & 0xC0) >> 6;
-		$thisfile_ac3_raw['synchinfo']['frmsizecod'] = ($ac3_synchinfo_fscod_frmsizecod & 0x3F);
+		if ($thisfile_ac3_raw_bsi['bsid'] <= 8) {
 
-		$thisfile_ac3['sample_rate'] = self::sampleRateCodeLookup($thisfile_ac3_raw['synchinfo']['fscod']);
-		if ($thisfile_ac3_raw['synchinfo']['fscod'] <= 3) {
-			$info['audio']['sample_rate'] = $thisfile_ac3['sample_rate'];
+			$thisfile_ac3_raw_bsi['crc1']       = getid3_lib::Bin2Dec($this->readHeaderBSI(16));
+			$thisfile_ac3_raw_bsi['fscod']      =                     $this->readHeaderBSI(2);   // 5.4.1.3
+			$thisfile_ac3_raw_bsi['frmsizecod'] =                     $this->readHeaderBSI(6);   // 5.4.1.4
+			if ($thisfile_ac3_raw_bsi['frmsizecod'] > 37) { // binary: 100101 - see Table 5.18 Frame Size Code Table (1 word = 16 bits)
+				$this->warning('Unexpected ac3.bsi.frmsizecod value: '.$thisfile_ac3_raw_bsi['frmsizecod'].', bitrate not set correctly');
+			}
+
+			$thisfile_ac3_raw_bsi['bsid']  = $this->readHeaderBSI(5); // we already know this from pre-parsing the version identifier, but re-read it to let the bitstream flow as intended
+			$thisfile_ac3_raw_bsi['bsmod'] = $this->readHeaderBSI(3);
+			$thisfile_ac3_raw_bsi['acmod'] = $this->readHeaderBSI(3);
+
+			if ($thisfile_ac3_raw_bsi['acmod'] & 0x01) {
+				// If the lsb of acmod is a 1, center channel is in use and cmixlev follows in the bit stream.
+				$thisfile_ac3_raw_bsi['cmixlev'] = $this->readHeaderBSI(2);
+				$thisfile_ac3['center_mix_level'] = self::centerMixLevelLookup($thisfile_ac3_raw_bsi['cmixlev']);
+			}
+
+			if ($thisfile_ac3_raw_bsi['acmod'] & 0x04) {
+				// If the msb of acmod is a 1, surround channels are in use and surmixlev follows in the bit stream.
+				$thisfile_ac3_raw_bsi['surmixlev'] = $this->readHeaderBSI(2);
+				$thisfile_ac3['surround_mix_level'] = self::surroundMixLevelLookup($thisfile_ac3_raw_bsi['surmixlev']);
+			}
+
+			if ($thisfile_ac3_raw_bsi['acmod'] == 0x02) {
+				// When operating in the two channel mode, this 2-bit code indicates whether or not the program has been encoded in Dolby Surround.
+				$thisfile_ac3_raw_bsi['dsurmod'] = $this->readHeaderBSI(2);
+				$thisfile_ac3['dolby_surround_mode'] = self::dolbySurroundModeLookup($thisfile_ac3_raw_bsi['dsurmod']);
+			}
+
+			$thisfile_ac3_raw_bsi['flags']['lfeon'] = (bool) $this->readHeaderBSI(1);
+
+			// This indicates how far the average dialogue level is below digital 100 percent. Valid values are 1-31.
+			// The value of 0 is reserved. The values of 1 to 31 are interpreted as -1 dB to -31 dB with respect to digital 100 percent.
+			$thisfile_ac3_raw_bsi['dialnorm'] = $this->readHeaderBSI(5);                 // 5.4.2.8 dialnorm: Dialogue Normalization, 5 Bits
+
+			$thisfile_ac3_raw_bsi['flags']['compr'] = (bool) $this->readHeaderBSI(1);       // 5.4.2.9 compre: Compression Gain Word Exists, 1 Bit
+			if ($thisfile_ac3_raw_bsi['flags']['compr']) {
+				$thisfile_ac3_raw_bsi['compr'] = $this->readHeaderBSI(8);                // 5.4.2.10 compr: Compression Gain Word, 8 Bits
+				$thisfile_ac3['heavy_compression'] = self::heavyCompression($thisfile_ac3_raw_bsi['compr']);
+			}
+
+			$thisfile_ac3_raw_bsi['flags']['langcod'] = (bool) $this->readHeaderBSI(1);     // 5.4.2.11 langcode: Language Code Exists, 1 Bit
+			if ($thisfile_ac3_raw_bsi['flags']['langcod']) {
+				$thisfile_ac3_raw_bsi['langcod'] = $this->readHeaderBSI(8);              // 5.4.2.12 langcod: Language Code, 8 Bits
+			}
+
+			$thisfile_ac3_raw_bsi['flags']['audprodinfo'] = (bool) $this->readHeaderBSI(1);  // 5.4.2.13 audprodie: Audio Production Information Exists, 1 Bit
+			if ($thisfile_ac3_raw_bsi['flags']['audprodinfo']) {
+				$thisfile_ac3_raw_bsi['mixlevel'] = $this->readHeaderBSI(5);             // 5.4.2.14 mixlevel: Mixing Level, 5 Bits
+				$thisfile_ac3_raw_bsi['roomtyp']  = $this->readHeaderBSI(2);             // 5.4.2.15 roomtyp: Room Type, 2 Bits
+
+				$thisfile_ac3['mixing_level'] = (80 + $thisfile_ac3_raw_bsi['mixlevel']).'dB';
+				$thisfile_ac3['room_type']    = self::roomTypeLookup($thisfile_ac3_raw_bsi['roomtyp']);
+			}
+
+
+			$thisfile_ac3_raw_bsi['dialnorm2'] = $this->readHeaderBSI(5);                // 5.4.2.16 dialnorm2: Dialogue Normalization, ch2, 5 Bits
+			$thisfile_ac3['dialogue_normalization2'] = '-'.$thisfile_ac3_raw_bsi['dialnorm2'].'dB';  // This indicates how far the average dialogue level is below digital 100 percent. Valid values are 1-31. The value of 0 is reserved. The values of 1 to 31 are interpreted as -1 dB to -31 dB with respect to digital 100 percent.
+
+			$thisfile_ac3_raw_bsi['flags']['compr2'] = (bool) $this->readHeaderBSI(1);       // 5.4.2.17 compr2e: Compression Gain Word Exists, ch2, 1 Bit
+			if ($thisfile_ac3_raw_bsi['flags']['compr2']) {
+				$thisfile_ac3_raw_bsi['compr2'] = $this->readHeaderBSI(8);               // 5.4.2.18 compr2: Compression Gain Word, ch2, 8 Bits
+				$thisfile_ac3['heavy_compression2'] = self::heavyCompression($thisfile_ac3_raw_bsi['compr2']);
+			}
+
+			$thisfile_ac3_raw_bsi['flags']['langcod2'] = (bool) $this->readHeaderBSI(1);    // 5.4.2.19 langcod2e: Language Code Exists, ch2, 1 Bit
+			if ($thisfile_ac3_raw_bsi['flags']['langcod2']) {
+				$thisfile_ac3_raw_bsi['langcod2'] = $this->readHeaderBSI(8);             // 5.4.2.20 langcod2: Language Code, ch2, 8 Bits
+			}
+
+			$thisfile_ac3_raw_bsi['flags']['audprodinfo2'] = (bool) $this->readHeaderBSI(1); // 5.4.2.21 audprodi2e: Audio Production Information Exists, ch2, 1 Bit
+			if ($thisfile_ac3_raw_bsi['flags']['audprodinfo2']) {
+				$thisfile_ac3_raw_bsi['mixlevel2'] = $this->readHeaderBSI(5);            // 5.4.2.22 mixlevel2: Mixing Level, ch2, 5 Bits
+				$thisfile_ac3_raw_bsi['roomtyp2']  = $this->readHeaderBSI(2);            // 5.4.2.23 roomtyp2: Room Type, ch2, 2 Bits
+
+				$thisfile_ac3['mixing_level2'] = (80 + $thisfile_ac3_raw_bsi['mixlevel2']).'dB';
+				$thisfile_ac3['room_type2']    = self::roomTypeLookup($thisfile_ac3_raw_bsi['roomtyp2']);
+			}
+
+			$thisfile_ac3_raw_bsi['copyright'] = (bool) $this->readHeaderBSI(1);         // 5.4.2.24 copyrightb: Copyright Bit, 1 Bit
+
+			$thisfile_ac3_raw_bsi['original']  = (bool) $this->readHeaderBSI(1);         // 5.4.2.25 origbs: Original Bit Stream, 1 Bit
+
+			$thisfile_ac3_raw_bsi['flags']['timecod1'] = $this->readHeaderBSI(2);            // 5.4.2.26 timecod1e, timcode2e: Time Code (first and second) Halves Exist, 2 Bits
+			if ($thisfile_ac3_raw_bsi['flags']['timecod1'] & 0x01) {
+				$thisfile_ac3_raw_bsi['timecod1'] = $this->readHeaderBSI(14);            // 5.4.2.27 timecod1: Time code first half, 14 bits
+				$thisfile_ac3['timecode1'] = 0;
+				$thisfile_ac3['timecode1'] += (($thisfile_ac3_raw_bsi['timecod1'] & 0x3E00) >>  9) * 3600;  // The first 5 bits of this 14-bit field represent the time in hours, with valid values of 0�23
+				$thisfile_ac3['timecode1'] += (($thisfile_ac3_raw_bsi['timecod1'] & 0x01F8) >>  3) *   60;  // The next 6 bits represent the time in minutes, with valid values of 0�59
+				$thisfile_ac3['timecode1'] += (($thisfile_ac3_raw_bsi['timecod1'] & 0x0003) >>  0) *    8;  // The final 3 bits represents the time in 8 second increments, with valid values of 0�7 (representing 0, 8, 16, ... 56 seconds)
+			}
+			if ($thisfile_ac3_raw_bsi['flags']['timecod1'] & 0x02) {
+				$thisfile_ac3_raw_bsi['timecod2'] = $this->readHeaderBSI(14);            // 5.4.2.28 timecod2: Time code second half, 14 bits
+				$thisfile_ac3['timecode2'] = 0;
+				$thisfile_ac3['timecode2'] += (($thisfile_ac3_raw_bsi['timecod2'] & 0x3800) >> 11) *   1;              // The first 3 bits of this 14-bit field represent the time in seconds, with valid values from 0�7 (representing 0-7 seconds)
+				$thisfile_ac3['timecode2'] += (($thisfile_ac3_raw_bsi['timecod2'] & 0x07C0) >>  6) *  (1 / 30);        // The next 5 bits represents the time in frames, with valid values from 0�29 (one frame = 1/30th of a second)
+				$thisfile_ac3['timecode2'] += (($thisfile_ac3_raw_bsi['timecod2'] & 0x003F) >>  0) * ((1 / 30) / 60);  // The final 6 bits represents fractions of 1/64 of a frame, with valid values from 0�63
+			}
+
+			$thisfile_ac3_raw_bsi['flags']['addbsi'] = (bool) $this->readHeaderBSI(1);
+			if ($thisfile_ac3_raw_bsi['flags']['addbsi']) {
+				$thisfile_ac3_raw_bsi['addbsi_length'] = $this->readHeaderBSI(6) + 1; // This 6-bit code, which exists only if addbside is a 1, indicates the length in bytes of additional bit stream information. The valid range of addbsil is 0�63, indicating 1�64 additional bytes, respectively.
+
+				$this->AC3header['bsi'] .= getid3_lib::BigEndian2Bin($this->fread($thisfile_ac3_raw_bsi['addbsi_length']));
+
+				$thisfile_ac3_raw_bsi['addbsi_data'] = substr($this->AC3header['bsi'], $this->BSIoffset, $thisfile_ac3_raw_bsi['addbsi_length'] * 8);
+				$this->BSIoffset += $thisfile_ac3_raw_bsi['addbsi_length'] * 8;
+			}
+
+
+		} elseif ($thisfile_ac3_raw_bsi['bsid'] <= 16) { // E-AC3
+
+
+			$this->error('E-AC3 parsing is incomplete and experimental in this version of getID3 ('.$this->getid3->version().'). Notably the bitrate calculations are wrong -- value might (or not) be correct, but it is not calculated correctly. Email info@getid3.org if you know how to calculate EAC3 bitrate correctly.');
+			$info['audio']['dataformat'] = 'eac3';
+
+			$thisfile_ac3_raw_bsi['strmtyp']          =        $this->readHeaderBSI(2);
+			$thisfile_ac3_raw_bsi['substreamid']      =        $this->readHeaderBSI(3);
+			$thisfile_ac3_raw_bsi['frmsiz']           =        $this->readHeaderBSI(11);
+			$thisfile_ac3_raw_bsi['fscod']            =        $this->readHeaderBSI(2);
+			if ($thisfile_ac3_raw_bsi['fscod'] == 3) {
+				$thisfile_ac3_raw_bsi['fscod2']       =        $this->readHeaderBSI(2);
+				$thisfile_ac3_raw_bsi['numblkscod'] = 3; // six blocks per syncframe
+			} else {
+				$thisfile_ac3_raw_bsi['numblkscod']   =        $this->readHeaderBSI(2);
+			}
+			$thisfile_ac3['bsi']['blocks_per_sync_frame'] = self::blocksPerSyncFrame($thisfile_ac3_raw_bsi['numblkscod']);
+			$thisfile_ac3_raw_bsi['acmod']            =        $this->readHeaderBSI(3);
+			$thisfile_ac3_raw_bsi['flags']['lfeon']   = (bool) $this->readHeaderBSI(1);
+			$thisfile_ac3_raw_bsi['bsid']             =        $this->readHeaderBSI(5); // we already know this from pre-parsing the version identifier, but re-read it to let the bitstream flow as intended
+			$thisfile_ac3_raw_bsi['dialnorm']         =        $this->readHeaderBSI(5);
+			$thisfile_ac3_raw_bsi['flags']['compr']       = (bool) $this->readHeaderBSI(1);
+			if ($thisfile_ac3_raw_bsi['flags']['compr']) {
+				$thisfile_ac3_raw_bsi['compr']        =        $this->readHeaderBSI(8);
+			}
+			if ($thisfile_ac3_raw_bsi['acmod'] == 0) { // if 1+1 mode (dual mono, so some items need a second value)
+				$thisfile_ac3_raw_bsi['dialnorm2']    =        $this->readHeaderBSI(5);
+				$thisfile_ac3_raw_bsi['flags']['compr2']  = (bool) $this->readHeaderBSI(1);
+				if ($thisfile_ac3_raw_bsi['flags']['compr2']) {
+					$thisfile_ac3_raw_bsi['compr2']   =        $this->readHeaderBSI(8);
+				}
+			}
+			if ($thisfile_ac3_raw_bsi['strmtyp'] == 1) { // if dependent stream
+				$thisfile_ac3_raw_bsi['flags']['chanmap'] = (bool) $this->readHeaderBSI(1);
+				if ($thisfile_ac3_raw_bsi['flags']['chanmap']) {
+					$thisfile_ac3_raw_bsi['chanmap']  =        $this->readHeaderBSI(8);
+				}
+			}
+			$thisfile_ac3_raw_bsi['flags']['mixmdat']     = (bool) $this->readHeaderBSI(1);
+			if ($thisfile_ac3_raw_bsi['flags']['mixmdat']) { // Mixing metadata
+				if ($thisfile_ac3_raw_bsi['acmod'] > 2) { // if more than 2 channels
+					$thisfile_ac3_raw_bsi['dmixmod']  =        $this->readHeaderBSI(2);
+				}
+				if (($thisfile_ac3_raw_bsi['acmod'] & 0x01) && ($thisfile_ac3_raw_bsi['acmod'] > 2)) { // if three front channels exist
+					$thisfile_ac3_raw_bsi['ltrtcmixlev'] =        $this->readHeaderBSI(3);
+					$thisfile_ac3_raw_bsi['lorocmixlev'] =        $this->readHeaderBSI(3);
+				}
+				if ($thisfile_ac3_raw_bsi['acmod'] & 0x04) { // if a surround channel exists
+					$thisfile_ac3_raw_bsi['ltrtsurmixlev'] =        $this->readHeaderBSI(3);
+					$thisfile_ac3_raw_bsi['lorosurmixlev'] =        $this->readHeaderBSI(3);
+				}
+				if ($thisfile_ac3_raw_bsi['flags']['lfeon']) { // if the LFE channel exists
+					$thisfile_ac3_raw_bsi['flags']['lfemixlevcod'] = (bool) $this->readHeaderBSI(1);
+					if ($thisfile_ac3_raw_bsi['flags']['lfemixlevcod']) {
+						$thisfile_ac3_raw_bsi['lfemixlevcod']  =        $this->readHeaderBSI(5);
+					}
+				}
+				if ($thisfile_ac3_raw_bsi['strmtyp'] == 0) { // if independent stream
+					$thisfile_ac3_raw_bsi['flags']['pgmscl'] = (bool) $this->readHeaderBSI(1);
+					if ($thisfile_ac3_raw_bsi['flags']['pgmscl']) {
+						$thisfile_ac3_raw_bsi['pgmscl']  =        $this->readHeaderBSI(6);
+					}
+					if ($thisfile_ac3_raw_bsi['acmod'] == 0) { // if 1+1 mode (dual mono, so some items need a second value)
+						$thisfile_ac3_raw_bsi['flags']['pgmscl2'] = (bool) $this->readHeaderBSI(1);
+						if ($thisfile_ac3_raw_bsi['flags']['pgmscl2']) {
+							$thisfile_ac3_raw_bsi['pgmscl2']  =        $this->readHeaderBSI(6);
+						}
+					}
+					$thisfile_ac3_raw_bsi['flags']['extpgmscl'] = (bool) $this->readHeaderBSI(1);
+					if ($thisfile_ac3_raw_bsi['flags']['extpgmscl']) {
+						$thisfile_ac3_raw_bsi['extpgmscl']  =        $this->readHeaderBSI(6);
+					}
+					$thisfile_ac3_raw_bsi['mixdef']  =        $this->readHeaderBSI(2);
+					if ($thisfile_ac3_raw_bsi['mixdef'] == 1) { // mixing option 2
+						$thisfile_ac3_raw_bsi['premixcmpsel']  = (bool) $this->readHeaderBSI(1);
+						$thisfile_ac3_raw_bsi['drcsrc']        = (bool) $this->readHeaderBSI(1);
+						$thisfile_ac3_raw_bsi['premixcmpscl']  =        $this->readHeaderBSI(3);
+					} elseif ($thisfile_ac3_raw_bsi['mixdef'] == 2) { // mixing option 3
+						$thisfile_ac3_raw_bsi['mixdata']       =        $this->readHeaderBSI(12);
+					} elseif ($thisfile_ac3_raw_bsi['mixdef'] == 3) { // mixing option 4
+						$mixdefbitsread = 0;
+						$thisfile_ac3_raw_bsi['mixdeflen']     =        $this->readHeaderBSI(5); $mixdefbitsread += 5;
+						$thisfile_ac3_raw_bsi['flags']['mixdata2'] = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+						if ($thisfile_ac3_raw_bsi['flags']['mixdata2']) {
+							$thisfile_ac3_raw_bsi['premixcmpsel']  = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							$thisfile_ac3_raw_bsi['drcsrc']        = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							$thisfile_ac3_raw_bsi['premixcmpscl']  =        $this->readHeaderBSI(3); $mixdefbitsread += 3;
+							$thisfile_ac3_raw_bsi['flags']['extpgmlscl']   = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							if ($thisfile_ac3_raw_bsi['flags']['extpgmlscl']) {
+								$thisfile_ac3_raw_bsi['extpgmlscl']    =        $this->readHeaderBSI(4); $mixdefbitsread += 4;
+							}
+							$thisfile_ac3_raw_bsi['flags']['extpgmcscl']   = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							if ($thisfile_ac3_raw_bsi['flags']['extpgmcscl']) {
+								$thisfile_ac3_raw_bsi['extpgmcscl']    =        $this->readHeaderBSI(4); $mixdefbitsread += 4;
+							}
+							$thisfile_ac3_raw_bsi['flags']['extpgmrscl']   = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							if ($thisfile_ac3_raw_bsi['flags']['extpgmrscl']) {
+								$thisfile_ac3_raw_bsi['extpgmrscl']    =        $this->readHeaderBSI(4);
+							}
+							$thisfile_ac3_raw_bsi['flags']['extpgmlsscl']  = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							if ($thisfile_ac3_raw_bsi['flags']['extpgmlsscl']) {
+								$thisfile_ac3_raw_bsi['extpgmlsscl']   =        $this->readHeaderBSI(4); $mixdefbitsread += 4;
+							}
+							$thisfile_ac3_raw_bsi['flags']['extpgmrsscl']  = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							if ($thisfile_ac3_raw_bsi['flags']['extpgmrsscl']) {
+								$thisfile_ac3_raw_bsi['extpgmrsscl']   =        $this->readHeaderBSI(4); $mixdefbitsread += 4;
+							}
+							$thisfile_ac3_raw_bsi['flags']['extpgmlfescl'] = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							if ($thisfile_ac3_raw_bsi['flags']['extpgmlfescl']) {
+								$thisfile_ac3_raw_bsi['extpgmlfescl']  =        $this->readHeaderBSI(4); $mixdefbitsread += 4;
+							}
+							$thisfile_ac3_raw_bsi['flags']['dmixscl']      = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							if ($thisfile_ac3_raw_bsi['flags']['dmixscl']) {
+								$thisfile_ac3_raw_bsi['dmixscl']       =        $this->readHeaderBSI(4); $mixdefbitsread += 4;
+							}
+							$thisfile_ac3_raw_bsi['flags']['addch']        = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							if ($thisfile_ac3_raw_bsi['flags']['addch']) {
+								$thisfile_ac3_raw_bsi['flags']['extpgmaux1scl']   = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+								if ($thisfile_ac3_raw_bsi['flags']['extpgmaux1scl']) {
+									$thisfile_ac3_raw_bsi['extpgmaux1scl']    =        $this->readHeaderBSI(4); $mixdefbitsread += 4;
+								}
+								$thisfile_ac3_raw_bsi['flags']['extpgmaux2scl']   = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+								if ($thisfile_ac3_raw_bsi['flags']['extpgmaux2scl']) {
+									$thisfile_ac3_raw_bsi['extpgmaux2scl']    =        $this->readHeaderBSI(4); $mixdefbitsread += 4;
+								}
+							}
+						}
+						$thisfile_ac3_raw_bsi['flags']['mixdata3'] = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+						if ($thisfile_ac3_raw_bsi['flags']['mixdata3']) {
+							$thisfile_ac3_raw_bsi['spchdat']   =        $this->readHeaderBSI(5); $mixdefbitsread += 5;
+							$thisfile_ac3_raw_bsi['flags']['addspchdat'] = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+							if ($thisfile_ac3_raw_bsi['flags']['addspchdat']) {
+								$thisfile_ac3_raw_bsi['spchdat1']   =         $this->readHeaderBSI(5); $mixdefbitsread += 5;
+								$thisfile_ac3_raw_bsi['spchan1att'] =         $this->readHeaderBSI(2); $mixdefbitsread += 2;
+								$thisfile_ac3_raw_bsi['flags']['addspchdat1'] = (bool) $this->readHeaderBSI(1); $mixdefbitsread += 1;
+								if ($thisfile_ac3_raw_bsi['flags']['addspchdat1']) {
+									$thisfile_ac3_raw_bsi['spchdat2']   =         $this->readHeaderBSI(5); $mixdefbitsread += 5;
+									$thisfile_ac3_raw_bsi['spchan2att'] =         $this->readHeaderBSI(3); $mixdefbitsread += 3;
+								}
+							}
+						}
+						$mixdata_bits = (8 * ($thisfile_ac3_raw_bsi['mixdeflen'] + 2)) - $mixdefbitsread;
+						$mixdata_fill = (($mixdata_bits % 8) ? 8 - ($mixdata_bits % 8) : 0);
+						$thisfile_ac3_raw_bsi['mixdata']     =        $this->readHeaderBSI($mixdata_bits);
+						$thisfile_ac3_raw_bsi['mixdatafill'] =        $this->readHeaderBSI($mixdata_fill);
+						unset($mixdefbitsread, $mixdata_bits, $mixdata_fill);
+					}
+					if ($thisfile_ac3_raw_bsi['acmod'] < 2) { // if mono or dual mono source
+						$thisfile_ac3_raw_bsi['flags']['paninfo'] = (bool) $this->readHeaderBSI(1);
+						if ($thisfile_ac3_raw_bsi['flags']['paninfo']) {
+							$thisfile_ac3_raw_bsi['panmean']   =        $this->readHeaderBSI(8);
+							$thisfile_ac3_raw_bsi['paninfo']   =        $this->readHeaderBSI(6);
+						}
+						if ($thisfile_ac3_raw_bsi['acmod'] == 0) { // if 1+1 mode (dual mono, so some items need a second value)
+							$thisfile_ac3_raw_bsi['flags']['paninfo2'] = (bool) $this->readHeaderBSI(1);
+							if ($thisfile_ac3_raw_bsi['flags']['paninfo2']) {
+								$thisfile_ac3_raw_bsi['panmean2']   =        $this->readHeaderBSI(8);
+								$thisfile_ac3_raw_bsi['paninfo2']   =        $this->readHeaderBSI(6);
+							}
+						}
+					}
+					$thisfile_ac3_raw_bsi['flags']['frmmixcfginfo'] = (bool) $this->readHeaderBSI(1);
+					if ($thisfile_ac3_raw_bsi['flags']['frmmixcfginfo']) { // mixing configuration information
+						if ($thisfile_ac3_raw_bsi['numblkscod'] == 0) {
+							$thisfile_ac3_raw_bsi['blkmixcfginfo'][0]  =        $this->readHeaderBSI(5);
+						} else {
+							for ($blk = 0; $blk < $thisfile_ac3_raw_bsi['numblkscod']; $blk++) {
+								$thisfile_ac3_raw_bsi['flags']['blkmixcfginfo'.$blk] = (bool) $this->readHeaderBSI(1);
+								if ($thisfile_ac3_raw_bsi['flags']['blkmixcfginfo'.$blk]) { // mixing configuration information
+									$thisfile_ac3_raw_bsi['blkmixcfginfo'][$blk]  =        $this->readHeaderBSI(5);
+								}
+							}
+						}
+					}
+				}
+			}
+			$thisfile_ac3_raw_bsi['flags']['infomdat']          = (bool) $this->readHeaderBSI(1);
+			if ($thisfile_ac3_raw_bsi['flags']['infomdat']) { // Informational metadata
+				$thisfile_ac3_raw_bsi['bsmod']                  =        $this->readHeaderBSI(3);
+				$thisfile_ac3_raw_bsi['flags']['copyrightb']    = (bool) $this->readHeaderBSI(1);
+				$thisfile_ac3_raw_bsi['flags']['origbs']        = (bool) $this->readHeaderBSI(1);
+				if ($thisfile_ac3_raw_bsi['acmod'] == 2) { //  if in 2/0 mode
+					$thisfile_ac3_raw_bsi['dsurmod']            =        $this->readHeaderBSI(2);
+					$thisfile_ac3_raw_bsi['dheadphonmod']       =        $this->readHeaderBSI(2);
+				}
+				if ($thisfile_ac3_raw_bsi['acmod'] >= 6) { //  if both surround channels exist
+					$thisfile_ac3_raw_bsi['dsurexmod']          =        $this->readHeaderBSI(2);
+				}
+				$thisfile_ac3_raw_bsi['flags']['audprodi']      = (bool) $this->readHeaderBSI(1);
+				if ($thisfile_ac3_raw_bsi['flags']['audprodi']) {
+					$thisfile_ac3_raw_bsi['mixlevel']           =        $this->readHeaderBSI(5);
+					$thisfile_ac3_raw_bsi['roomtyp']            =        $this->readHeaderBSI(2);
+					$thisfile_ac3_raw_bsi['flags']['adconvtyp'] = (bool) $this->readHeaderBSI(1);
+				}
+				if ($thisfile_ac3_raw_bsi['acmod'] == 0) { //  if 1+1 mode (dual mono, so some items need a second value)
+					$thisfile_ac3_raw_bsi['flags']['audprodi2']      = (bool) $this->readHeaderBSI(1);
+					if ($thisfile_ac3_raw_bsi['flags']['audprodi2']) {
+						$thisfile_ac3_raw_bsi['mixlevel2']           =        $this->readHeaderBSI(5);
+						$thisfile_ac3_raw_bsi['roomtyp2']            =        $this->readHeaderBSI(2);
+						$thisfile_ac3_raw_bsi['flags']['adconvtyp2'] = (bool) $this->readHeaderBSI(1);
+					}
+				}
+				if ($thisfile_ac3_raw_bsi['fscod'] < 3) { // if not half sample rate
+					$thisfile_ac3_raw_bsi['flags']['sourcefscod'] = (bool) $this->readHeaderBSI(1);
+				}
+			}
+			if (($thisfile_ac3_raw_bsi['strmtyp'] == 0) && ($thisfile_ac3_raw_bsi['numblkscod'] != 3)) { //  if both surround channels exist
+				$thisfile_ac3_raw_bsi['flags']['convsync'] = (bool) $this->readHeaderBSI(1);
+			}
+			if ($thisfile_ac3_raw_bsi['strmtyp'] == 2) { //  if bit stream converted from AC-3
+				if ($thisfile_ac3_raw_bsi['numblkscod'] != 3) { // 6 blocks per syncframe
+					$thisfile_ac3_raw_bsi['flags']['blkid']  = 1;
+				} else {
+					$thisfile_ac3_raw_bsi['flags']['blkid']  = (bool) $this->readHeaderBSI(1);
+				}
+				if ($thisfile_ac3_raw_bsi['flags']['blkid']) {
+					$thisfile_ac3_raw_bsi['frmsizecod']  =        $this->readHeaderBSI(6);
+				}
+			}
+			$thisfile_ac3_raw_bsi['flags']['addbsi']  = (bool) $this->readHeaderBSI(1);
+			if ($thisfile_ac3_raw_bsi['flags']['addbsi']) {
+				$thisfile_ac3_raw_bsi['addbsil']  =        $this->readHeaderBSI(6);
+				$thisfile_ac3_raw_bsi['addbsi']   =        $this->readHeaderBSI(($thisfile_ac3_raw_bsi['addbsil'] + 1) * 8);
+			}
+
+		} else {
+
+			$this->error('Bit stream identification is version '.$thisfile_ac3_raw_bsi['bsid'].', but getID3() only understands up to version 16. Please submit a support ticket with a sample file.');
+			unset($info['ac3']);
+			return false;
+
 		}
 
-		$thisfile_ac3['frame_length'] = self::frameSizeLookup($thisfile_ac3_raw['synchinfo']['frmsizecod'], $thisfile_ac3_raw['synchinfo']['fscod']);
-		$thisfile_ac3['bitrate']      = self::bitrateLookup($thisfile_ac3_raw['synchinfo']['frmsizecod']);
+		if (isset($thisfile_ac3_raw_bsi['fscod2'])) {
+			$thisfile_ac3['sample_rate'] = self::sampleRateCodeLookup2($thisfile_ac3_raw_bsi['fscod2']);
+		} else {
+			$thisfile_ac3['sample_rate'] = self::sampleRateCodeLookup($thisfile_ac3_raw_bsi['fscod']);
+		}
+		if ($thisfile_ac3_raw_bsi['fscod'] <= 3) {
+			$info['audio']['sample_rate'] = $thisfile_ac3['sample_rate'];
+		} else {
+			$this->warning('Unexpected ac3.bsi.fscod value: '.$thisfile_ac3_raw_bsi['fscod']);
+		}
+		if (isset($thisfile_ac3_raw_bsi['frmsizecod'])) {
+			$thisfile_ac3['frame_length'] = self::frameSizeLookup($thisfile_ac3_raw_bsi['frmsizecod'], $thisfile_ac3_raw_bsi['fscod']);
+			$thisfile_ac3['bitrate']      = self::bitrateLookup($thisfile_ac3_raw_bsi['frmsizecod']);
+		} elseif (!empty($thisfile_ac3_raw_bsi['frmsiz'])) {
+			// this isn't right, but it's (usually) close, roughly 5% less than it should be.
+			// but WHERE is the actual bitrate value stored in EAC3?? email info@getid3.org if you know!
+			$thisfile_ac3['bitrate']      = ($thisfile_ac3_raw_bsi['frmsiz'] + 1) * 16 * 30; // The frmsiz field shall contain a value one less than the overall size of the coded syncframe in 16-bit words. That is, this field may assume a value ranging from 0 to 2047, and these values correspond to syncframe sizes ranging from 1 to 2048.
+			// kludge-fix to make it approximately the expected value, still not "right":
+			$thisfile_ac3['bitrate'] = round(($thisfile_ac3['bitrate'] * 1.05) / 16000) * 16000;
+		}
 		$info['audio']['bitrate'] = $thisfile_ac3['bitrate'];
 
-		$this->AC3header['bsi'] = getid3_lib::BigEndian2Bin($this->fread(15));
-		$ac3_bsi_offset = 0;
-
-		$thisfile_ac3_raw_bsi['bsid'] = $this->readHeaderBSI(5);
-		if ($thisfile_ac3_raw_bsi['bsid'] > 8) {
-			// Decoders which can decode version 8 will thus be able to decode version numbers less than 8.
-			// If this standard is extended by the addition of additional elements or features, a value of bsid greater than 8 will be used.
-			// Decoders built to this version of the standard will not be able to decode versions with bsid greater than 8.
-			$this->error('Bit stream identification is version '.$thisfile_ac3_raw_bsi['bsid'].', but getID3() only understands up to version 8');
-		    unset($info['ac3']);
-			return false;
+		if (isset($thisfile_ac3_raw_bsi['bsmod']) && isset($thisfile_ac3_raw_bsi['acmod'])) {
+			$thisfile_ac3['service_type'] = self::serviceTypeLookup($thisfile_ac3_raw_bsi['bsmod'], $thisfile_ac3_raw_bsi['acmod']);
 		}
-
-		$thisfile_ac3_raw_bsi['bsmod'] = $this->readHeaderBSI(3);
-		$thisfile_ac3_raw_bsi['acmod'] = $this->readHeaderBSI(3);
-
-		$thisfile_ac3['service_type'] = self::serviceTypeLookup($thisfile_ac3_raw_bsi['bsmod'], $thisfile_ac3_raw_bsi['acmod']);
 		$ac3_coding_mode = self::audioCodingModeLookup($thisfile_ac3_raw_bsi['acmod']);
 		foreach($ac3_coding_mode as $key => $value) {
 			$thisfile_ac3[$key] = $value;
@@ -122,117 +474,22 @@ class getid3_ac3 extends getid3_handler
 		}
 		$info['audio']['channels'] = $thisfile_ac3['num_channels'];
 
-		if ($thisfile_ac3_raw_bsi['acmod'] & 0x01) {
-			// If the lsb of acmod is a 1, center channel is in use and cmixlev follows in the bit stream.
-			$thisfile_ac3_raw_bsi['cmixlev'] = $this->readHeaderBSI(2);
-			$thisfile_ac3['center_mix_level'] = self::centerMixLevelLookup($thisfile_ac3_raw_bsi['cmixlev']);
-		}
-
-		if ($thisfile_ac3_raw_bsi['acmod'] & 0x04) {
-			// If the msb of acmod is a 1, surround channels are in use and surmixlev follows in the bit stream.
-			$thisfile_ac3_raw_bsi['surmixlev'] = $this->readHeaderBSI(2);
-			$thisfile_ac3['surround_mix_level'] = self::surroundMixLevelLookup($thisfile_ac3_raw_bsi['surmixlev']);
-		}
-
-		if ($thisfile_ac3_raw_bsi['acmod'] == 0x02) {
-			// When operating in the two channel mode, this 2-bit code indicates whether or not the program has been encoded in Dolby Surround.
-			$thisfile_ac3_raw_bsi['dsurmod'] = $this->readHeaderBSI(2);
-			$thisfile_ac3['dolby_surround_mode'] = self::dolbySurroundModeLookup($thisfile_ac3_raw_bsi['dsurmod']);
-		}
-
-		$thisfile_ac3_raw_bsi['lfeon'] = (bool) $this->readHeaderBSI(1);
-		$thisfile_ac3['lfe_enabled'] = $thisfile_ac3_raw_bsi['lfeon'];
-		if ($thisfile_ac3_raw_bsi['lfeon']) {
-			//$info['audio']['channels']++;
+		$thisfile_ac3['lfe_enabled'] = $thisfile_ac3_raw_bsi['flags']['lfeon'];
+		if ($thisfile_ac3_raw_bsi['flags']['lfeon']) {
 			$info['audio']['channels'] .= '.1';
 		}
 
-		$thisfile_ac3['channels_enabled'] = self::channelsEnabledLookup($thisfile_ac3_raw_bsi['acmod'], $thisfile_ac3_raw_bsi['lfeon']);
-
-		// This indicates how far the average dialogue level is below digital 100 percent. Valid values are 1-31.
-		// The value of 0 is reserved. The values of 1 to 31 are interpreted as -1 dB to -31 dB with respect to digital 100 percent.
-		$thisfile_ac3_raw_bsi['dialnorm'] = $this->readHeaderBSI(5);
+		$thisfile_ac3['channels_enabled'] = self::channelsEnabledLookup($thisfile_ac3_raw_bsi['acmod'], $thisfile_ac3_raw_bsi['flags']['lfeon']);
 		$thisfile_ac3['dialogue_normalization'] = '-'.$thisfile_ac3_raw_bsi['dialnorm'].'dB';
-
-		$thisfile_ac3_raw_bsi['compre_flag'] = (bool) $this->readHeaderBSI(1);
-		if ($thisfile_ac3_raw_bsi['compre_flag']) {
-			$thisfile_ac3_raw_bsi['compr'] = $this->readHeaderBSI(8);
-			$thisfile_ac3['heavy_compression'] = self::heavyCompression($thisfile_ac3_raw_bsi['compr']);
-		}
-
-		$thisfile_ac3_raw_bsi['langcode_flag'] = (bool) $this->readHeaderBSI(1);
-		if ($thisfile_ac3_raw_bsi['langcode_flag']) {
-			$thisfile_ac3_raw_bsi['langcod'] = $this->readHeaderBSI(8);
-		}
-
-		$thisfile_ac3_raw_bsi['audprodie'] = (bool) $this->readHeaderBSI(1);
-		if ($thisfile_ac3_raw_bsi['audprodie']) {
-			$thisfile_ac3_raw_bsi['mixlevel'] = $this->readHeaderBSI(5);
-			$thisfile_ac3_raw_bsi['roomtyp']  = $this->readHeaderBSI(2);
-
-			$thisfile_ac3['mixing_level'] = (80 + $thisfile_ac3_raw_bsi['mixlevel']).'dB';
-			$thisfile_ac3['room_type']    = self::roomTypeLookup($thisfile_ac3_raw_bsi['roomtyp']);
-		}
-
-		if ($thisfile_ac3_raw_bsi['acmod'] == 0x00) {
-			// If acmod is 0, then two completely independent program channels (dual mono)
-			// are encoded into the bit stream, and are referenced as Ch1, Ch2. In this case,
-			// a number of additional items are present in BSI or audblk to fully describe Ch2.
-
-			// This indicates how far the average dialogue level is below digital 100 percent. Valid values are 1-31.
-			// The value of 0 is reserved. The values of 1 to 31 are interpreted as -1 dB to -31 dB with respect to digital 100 percent.
-			$thisfile_ac3_raw_bsi['dialnorm2'] = $this->readHeaderBSI(5);
-			$thisfile_ac3['dialogue_normalization2'] = '-'.$thisfile_ac3_raw_bsi['dialnorm2'].'dB';
-
-			$thisfile_ac3_raw_bsi['compre_flag2'] = (bool) $this->readHeaderBSI(1);
-			if ($thisfile_ac3_raw_bsi['compre_flag2']) {
-				$thisfile_ac3_raw_bsi['compr2'] = $this->readHeaderBSI(8);
-				$thisfile_ac3['heavy_compression2'] = self::heavyCompression($thisfile_ac3_raw_bsi['compr2']);
-			}
-
-			$thisfile_ac3_raw_bsi['langcode_flag2'] = (bool) $this->readHeaderBSI(1);
-			if ($thisfile_ac3_raw_bsi['langcode_flag2']) {
-				$thisfile_ac3_raw_bsi['langcod2'] = $this->readHeaderBSI(8);
-			}
-
-			$thisfile_ac3_raw_bsi['audprodie2'] = (bool) $this->readHeaderBSI(1);
-			if ($thisfile_ac3_raw_bsi['audprodie2']) {
-				$thisfile_ac3_raw_bsi['mixlevel2'] = $this->readHeaderBSI(5);
-				$thisfile_ac3_raw_bsi['roomtyp2']  = $this->readHeaderBSI(2);
-
-				$thisfile_ac3['mixing_level2'] = (80 + $thisfile_ac3_raw_bsi['mixlevel2']).'dB';
-				$thisfile_ac3['room_type2']    = self::roomTypeLookup($thisfile_ac3_raw_bsi['roomtyp2']);
-			}
-
-		}
-
-		$thisfile_ac3_raw_bsi['copyright'] = (bool) $this->readHeaderBSI(1);
-
-		$thisfile_ac3_raw_bsi['original']  = (bool) $this->readHeaderBSI(1);
-
-		$thisfile_ac3_raw_bsi['timecode1_flag'] = (bool) $this->readHeaderBSI(1);
-		if ($thisfile_ac3_raw_bsi['timecode1_flag']) {
-			$thisfile_ac3_raw_bsi['timecode1'] = $this->readHeaderBSI(14);
-		}
-
-		$thisfile_ac3_raw_bsi['timecode2_flag'] = (bool) $this->readHeaderBSI(1);
-		if ($thisfile_ac3_raw_bsi['timecode2_flag']) {
-			$thisfile_ac3_raw_bsi['timecode2'] = $this->readHeaderBSI(14);
-		}
-
-		$thisfile_ac3_raw_bsi['addbsi_flag'] = (bool) $this->readHeaderBSI(1);
-		if ($thisfile_ac3_raw_bsi['addbsi_flag']) {
-			$thisfile_ac3_raw_bsi['addbsi_length'] = $this->readHeaderBSI(6);
-
-			$this->AC3header['bsi'] .= getid3_lib::BigEndian2Bin($this->fread($thisfile_ac3_raw_bsi['addbsi_length']));
-
-			$thisfile_ac3_raw_bsi['addbsi_data'] = substr($this->AC3header['bsi'], $this->BSIoffset, $thisfile_ac3_raw_bsi['addbsi_length'] * 8);
-			$this->BSIoffset += $thisfile_ac3_raw_bsi['addbsi_length'] * 8;
-		}
 
 		return true;
 	}
 
+	/**
+	 * @param int $length
+	 *
+	 * @return int
+	 */
 	private function readHeaderBSI($length) {
 		$data = substr($this->AC3header['bsi'], $this->BSIoffset, $length);
 		$this->BSIoffset += $length;
@@ -240,6 +497,11 @@ class getid3_ac3 extends getid3_handler
 		return bindec($data);
 	}
 
+	/**
+	 * @param int $fscod
+	 *
+	 * @return int|string|false
+	 */
 	public static function sampleRateCodeLookup($fscod) {
 		static $sampleRateCodeLookup = array(
 			0 => 48000,
@@ -250,6 +512,27 @@ class getid3_ac3 extends getid3_handler
 		return (isset($sampleRateCodeLookup[$fscod]) ? $sampleRateCodeLookup[$fscod] : false);
 	}
 
+	/**
+	 * @param int $fscod2
+	 *
+	 * @return int|string|false
+	 */
+	public static function sampleRateCodeLookup2($fscod2) {
+		static $sampleRateCodeLookup2 = array(
+			0 => 24000,
+			1 => 22050,
+			2 => 16000,
+			3 => 'reserved' // If the reserved code is indicated, the decoder should not attempt to decode audio and should mute.
+		);
+		return (isset($sampleRateCodeLookup2[$fscod2]) ? $sampleRateCodeLookup2[$fscod2] : false);
+	}
+
+	/**
+	 * @param int $bsmod
+	 * @param int $acmod
+	 *
+	 * @return string|false
+	 */
 	public static function serviceTypeLookup($bsmod, $acmod) {
 		static $serviceTypeLookup = array();
 		if (empty($serviceTypeLookup)) {
@@ -271,24 +554,31 @@ class getid3_ac3 extends getid3_handler
 		return (isset($serviceTypeLookup[$bsmod][$acmod]) ? $serviceTypeLookup[$bsmod][$acmod] : false);
 	}
 
+	/**
+	 * @param int $acmod
+	 *
+	 * @return array|false
+	 */
 	public static function audioCodingModeLookup($acmod) {
-		static $audioCodingModeLookup = array();
-		if (empty($audioCodingModeLookup)) {
-			// array(channel configuration, # channels (not incl LFE), channel order)
-			$audioCodingModeLookup = array (
-				0 => array('channel_config'=>'1+1', 'num_channels'=>2, 'channel_order'=>'Ch1,Ch2'),
-				1 => array('channel_config'=>'1/0', 'num_channels'=>1, 'channel_order'=>'C'),
-				2 => array('channel_config'=>'2/0', 'num_channels'=>2, 'channel_order'=>'L,R'),
-				3 => array('channel_config'=>'3/0', 'num_channels'=>3, 'channel_order'=>'L,C,R'),
-				4 => array('channel_config'=>'2/1', 'num_channels'=>3, 'channel_order'=>'L,R,S'),
-				5 => array('channel_config'=>'3/1', 'num_channels'=>4, 'channel_order'=>'L,C,R,S'),
-				6 => array('channel_config'=>'2/2', 'num_channels'=>4, 'channel_order'=>'L,R,SL,SR'),
-				7 => array('channel_config'=>'3/2', 'num_channels'=>5, 'channel_order'=>'L,C,R,SL,SR')
-			);
-		}
+		// array(channel configuration, # channels (not incl LFE), channel order)
+		static $audioCodingModeLookup = array (
+			0 => array('channel_config'=>'1+1', 'num_channels'=>2, 'channel_order'=>'Ch1,Ch2'),
+			1 => array('channel_config'=>'1/0', 'num_channels'=>1, 'channel_order'=>'C'),
+			2 => array('channel_config'=>'2/0', 'num_channels'=>2, 'channel_order'=>'L,R'),
+			3 => array('channel_config'=>'3/0', 'num_channels'=>3, 'channel_order'=>'L,C,R'),
+			4 => array('channel_config'=>'2/1', 'num_channels'=>3, 'channel_order'=>'L,R,S'),
+			5 => array('channel_config'=>'3/1', 'num_channels'=>4, 'channel_order'=>'L,C,R,S'),
+			6 => array('channel_config'=>'2/2', 'num_channels'=>4, 'channel_order'=>'L,R,SL,SR'),
+			7 => array('channel_config'=>'3/2', 'num_channels'=>5, 'channel_order'=>'L,C,R,SL,SR'),
+		);
 		return (isset($audioCodingModeLookup[$acmod]) ? $audioCodingModeLookup[$acmod] : false);
 	}
 
+	/**
+	 * @param int $cmixlev
+	 *
+	 * @return int|float|string|false
+	 */
 	public static function centerMixLevelLookup($cmixlev) {
 		static $centerMixLevelLookup;
 		if (empty($centerMixLevelLookup)) {
@@ -302,6 +592,11 @@ class getid3_ac3 extends getid3_handler
 		return (isset($centerMixLevelLookup[$cmixlev]) ? $centerMixLevelLookup[$cmixlev] : false);
 	}
 
+	/**
+	 * @param int $surmixlev
+	 *
+	 * @return int|float|string|false
+	 */
 	public static function surroundMixLevelLookup($surmixlev) {
 		static $surroundMixLevelLookup;
 		if (empty($surroundMixLevelLookup)) {
@@ -315,6 +610,11 @@ class getid3_ac3 extends getid3_handler
 		return (isset($surroundMixLevelLookup[$surmixlev]) ? $surroundMixLevelLookup[$surmixlev] : false);
 	}
 
+	/**
+	 * @param int $dsurmod
+	 *
+	 * @return string|false
+	 */
 	public static function dolbySurroundModeLookup($dsurmod) {
 		static $dolbySurroundModeLookup = array(
 			0 => 'not indicated',
@@ -325,12 +625,18 @@ class getid3_ac3 extends getid3_handler
 		return (isset($dolbySurroundModeLookup[$dsurmod]) ? $dolbySurroundModeLookup[$dsurmod] : false);
 	}
 
+	/**
+	 * @param int  $acmod
+	 * @param bool $lfeon
+	 *
+	 * @return array
+	 */
 	public static function channelsEnabledLookup($acmod, $lfeon) {
-		$channelsEnabledLookup = array(
-			'ch1'=>(bool) ($acmod == 0),
-			'ch2'=>(bool) ($acmod == 0),
-			'left'=>(bool) ($acmod > 1),
-			'right'=>(bool) ($acmod > 1),
+		$lookup = array(
+			'ch1'=>($acmod == 0),
+			'ch2'=>($acmod == 0),
+			'left'=>($acmod > 1),
+			'right'=>($acmod > 1),
 			'center'=>(bool) ($acmod & 0x01),
 			'surround_mono'=>false,
 			'surround_left'=>false,
@@ -339,17 +645,22 @@ class getid3_ac3 extends getid3_handler
 		switch ($acmod) {
 			case 4:
 			case 5:
-				$channelsEnabledLookup['surround_mono']  = true;
+				$lookup['surround_mono']  = true;
 				break;
 			case 6:
 			case 7:
-				$channelsEnabledLookup['surround_left']  = true;
-				$channelsEnabledLookup['surround_right'] = true;
+				$lookup['surround_left']  = true;
+				$lookup['surround_right'] = true;
 				break;
 		}
-		return $channelsEnabledLookup;
+		return $lookup;
 	}
 
+	/**
+	 * @param int $compre
+	 *
+	 * @return float|int
+	 */
 	public static function heavyCompression($compre) {
 		// The first four bits indicate gain changes in 6.02dB increments which can be
 		// implemented with an arithmetic shift operation. The following four bits
@@ -379,7 +690,7 @@ class getid3_ac3 extends getid3_handler
 		// -8    -42.14 dB
 
 		$fourbit = str_pad(decbin(($compre & 0xF0) >> 4), 4, '0', STR_PAD_LEFT);
-		if ($fourbit{0} == '1') {
+		if ($fourbit[0] == '1') {
 			$log_gain = -8 + bindec(substr($fourbit, 1));
 		} else {
 			$log_gain = bindec(substr($fourbit, 1));
@@ -400,6 +711,11 @@ class getid3_ac3 extends getid3_handler
 		return $log_gain - $lin_gain;
 	}
 
+	/**
+	 * @param int $roomtyp
+	 *
+	 * @return string|false
+	 */
 	public static function roomTypeLookup($roomtyp) {
 		static $roomTypeLookup = array(
 			0 => 'not indicated',
@@ -410,55 +726,71 @@ class getid3_ac3 extends getid3_handler
 		return (isset($roomTypeLookup[$roomtyp]) ? $roomTypeLookup[$roomtyp] : false);
 	}
 
+	/**
+	 * @param int $frmsizecod
+	 * @param int $fscod
+	 *
+	 * @return int|false
+	 */
 	public static function frameSizeLookup($frmsizecod, $fscod) {
-		$padding     = (bool) ($frmsizecod % 2);
-		$framesizeid =   floor($frmsizecod / 2);
+		// LSB is whether padding is used or not
+		$padding     = (bool) ($frmsizecod & 0x01);
+		$framesizeid =        ($frmsizecod & 0x3E) >> 1;
 
 		static $frameSizeLookup = array();
 		if (empty($frameSizeLookup)) {
 			$frameSizeLookup = array (
-				0  => array(128, 138, 192),
-				1  => array(40, 160, 174, 240),
-				2  => array(48, 192, 208, 288),
-				3  => array(56, 224, 242, 336),
-				4  => array(64, 256, 278, 384),
-				5  => array(80, 320, 348, 480),
-				6  => array(96, 384, 416, 576),
-				7  => array(112, 448, 486, 672),
-				8  => array(128, 512, 556, 768),
-				9  => array(160, 640, 696, 960),
-				10 => array(192, 768, 834, 1152),
-				11 => array(224, 896, 974, 1344),
-				12 => array(256, 1024, 1114, 1536),
-				13 => array(320, 1280, 1392, 1920),
-				14 => array(384, 1536, 1670, 2304),
-				15 => array(448, 1792, 1950, 2688),
-				16 => array(512, 2048, 2228, 3072),
-				17 => array(576, 2304, 2506, 3456),
-				18 => array(640, 2560, 2786, 3840)
+				0  => array( 128,  138,  192),  //  32 kbps
+				1  => array( 160,  174,  240),  //  40 kbps
+				2  => array( 192,  208,  288),  //  48 kbps
+				3  => array( 224,  242,  336),  //  56 kbps
+				4  => array( 256,  278,  384),  //  64 kbps
+				5  => array( 320,  348,  480),  //  80 kbps
+				6  => array( 384,  416,  576),  //  96 kbps
+				7  => array( 448,  486,  672),  // 112 kbps
+				8  => array( 512,  556,  768),  // 128 kbps
+				9  => array( 640,  696,  960),  // 160 kbps
+				10 => array( 768,  834, 1152),  // 192 kbps
+				11 => array( 896,  974, 1344),  // 224 kbps
+				12 => array(1024, 1114, 1536),  // 256 kbps
+				13 => array(1280, 1392, 1920),  // 320 kbps
+				14 => array(1536, 1670, 2304),  // 384 kbps
+				15 => array(1792, 1950, 2688),  // 448 kbps
+				16 => array(2048, 2228, 3072),  // 512 kbps
+				17 => array(2304, 2506, 3456),  // 576 kbps
+				18 => array(2560, 2786, 3840)   // 640 kbps
 			);
 		}
+		$paddingBytes = 0;
 		if (($fscod == 1) && $padding) {
 			// frame lengths are padded by 1 word (16 bits) at 44100
-			$frameSizeLookup[$frmsizecod] += 2;
+			// (fscode==1) means 44100Hz (see sampleRateCodeLookup)
+			$paddingBytes = 2;
 		}
-		return (isset($frameSizeLookup[$framesizeid][$fscod]) ? $frameSizeLookup[$framesizeid][$fscod] : false);
+		return (isset($frameSizeLookup[$framesizeid][$fscod]) ? $frameSizeLookup[$framesizeid][$fscod] + $paddingBytes : false);
 	}
 
+	/**
+	 * @param int $frmsizecod
+	 *
+	 * @return int|false
+	 */
 	public static function bitrateLookup($frmsizecod) {
-		$framesizeid =   floor($frmsizecod / 2);
+		// LSB is whether padding is used or not
+		$padding     = (bool) ($frmsizecod & 0x01);
+		$framesizeid =        ($frmsizecod & 0x3E) >> 1;
 
 		static $bitrateLookup = array(
-			0  => 32000,
-			1  => 40000,
-			2  => 48000,
-			3  => 56000,
-			4  => 64000,
-			5  => 80000,
-			6  => 96000,
-			7  => 112000,
-			8  => 128000,
-			9  => 160000,
+			 0 =>  32000,
+			 1 =>  40000,
+			 2 =>  48000,
+			 3 =>  56000,
+			 4 =>  64000,
+			 5 =>  80000,
+			 6 =>  96000,
+			 7 => 112000,
+			 8 => 128000,
+			 9 => 160000,
 			10 => 192000,
 			11 => 224000,
 			12 => 256000,
@@ -467,9 +799,24 @@ class getid3_ac3 extends getid3_handler
 			15 => 448000,
 			16 => 512000,
 			17 => 576000,
-			18 => 640000
+			18 => 640000,
 		);
 		return (isset($bitrateLookup[$framesizeid]) ? $bitrateLookup[$framesizeid] : false);
+	}
+
+	/**
+	 * @param int $numblkscod
+	 *
+	 * @return int|false
+	 */
+	public static function blocksPerSyncFrame($numblkscod) {
+		static $blocksPerSyncFrameLookup = array(
+			0 => 1,
+			1 => 2,
+			2 => 3,
+			3 => 6,
+		);
+		return (isset($blocksPerSyncFrameLookup[$numblkscod]) ? $blocksPerSyncFrameLookup[$numblkscod] : false);
 	}
 
 

--- a/application/libraries/getid3/module.audio.amr.php
+++ b/application/libraries/getid3/module.audio.amr.php
@@ -1,0 +1,110 @@
+<?php
+
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// module.audio.aa.php                                         //
+// module for analyzing Audible Audiobook files                //
+// dependencies: NONE                                          //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+
+class getid3_amr extends getid3_handler
+{
+	/**
+	 * @return bool
+	 */
+	public function Analyze() {
+		$info = &$this->getid3->info;
+
+		$this->fseek($info['avdataoffset']);
+		$AMRheader = $this->fread(6);
+
+		$magic = '#!AMR'."\x0A";
+		if (substr($AMRheader, 0, 6) != $magic) {
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($AMRheader, 0, 6)).'"');
+			return false;
+		}
+
+		// shortcut
+		$info['amr'] = array();
+		$thisfile_amr = &$info['amr'];
+
+		$info['fileformat']               = 'amr';
+		$info['audio']['dataformat']      = 'amr';
+		$info['audio']['bitrate_mode']    = 'vbr';   // within a small predefined range: 4.75kbps to 12.2kbps
+		$info['audio']['bits_per_sample'] =    13;   // http://en.wikipedia.org/wiki/Adaptive_Multi-Rate_audio_codec: "Sampling frequency 8 kHz/13-bit (160 samples for 20 ms frames), filtered to 200–3400 Hz"
+		$info['audio']['sample_rate']     =  8000;   // http://en.wikipedia.org/wiki/Adaptive_Multi-Rate_audio_codec: "Sampling frequency 8 kHz/13-bit (160 samples for 20 ms frames), filtered to 200–3400 Hz"
+		$info['audio']['channels']        =     1;
+		$thisfile_amr['frame_mode_count'] = array(0=>0, 1=>0, 2=>0, 3=>0, 4=>0, 5=>0, 6=>0, 7=>0);
+
+		$buffer = '';
+		do {
+			if ((strlen($buffer) < $this->getid3->fread_buffer_size()) && !feof($this->getid3->fp)) {
+				$buffer .= $this->fread($this->getid3->fread_buffer_size() * 2);
+			}
+			$AMR_frame_header = ord(substr($buffer, 0, 1));
+			$codec_mode_request = ($AMR_frame_header & 0x78) >> 3; // The 2nd bit through 5th bit (counting the most significant bit as the first bit) comprise the CMR (Codec Mode Request), values 0-7 being valid for AMR. The top bit of the CMR can actually be ignored, though it is used when AMR forms RTP payloads. The lower 3-bits of the header are reserved and are not used. Viewing the header from most significant bit to least significant bit, the encoding is XCCCCXXX, where Xs are reserved (typically 0) and the Cs are the CMR.
+			if ($codec_mode_request > 7) {
+				break;
+			}
+			$thisfile_amr['frame_mode_count'][$codec_mode_request]++;
+			$buffer = substr($buffer, $this->amr_mode_bytes_per_frame($codec_mode_request));
+		} while (strlen($buffer) > 0);
+
+		$info['playtime_seconds'] = array_sum($thisfile_amr['frame_mode_count']) * 0.020; // each frame contain 160 samples and is 20 milliseconds long
+		$info['audio']['bitrate'] = (8 * ($info['avdataend'] - $info['avdataoffset'])) / $info['playtime_seconds']; // bitrate could be calculated from average bitrate by distributation of frame types. That would give effective audio bitrate, this gives overall file bitrate which will be a little bit higher since every frame will waste 8 bits for header, plus a few bits for octet padding
+		$info['bitrate'] = $info['audio']['bitrate'];
+
+		return true;
+	}
+
+	/**
+	 * @param int $key
+	 *
+	 * @return int|false
+	 */
+	public function amr_mode_bitrate($key) {
+		static $amr_mode_bitrate = array(
+			0 =>  4750,
+			1 =>  5150,
+			2 =>  5900,
+			3 =>  6700,
+			4 =>  7400,
+			5 =>  7950,
+			6 => 10200,
+			7 => 12200,
+		);
+		return (isset($amr_mode_bitrate[$key]) ? $amr_mode_bitrate[$key] : false);
+	}
+
+	/**
+	 * @param int $key
+	 *
+	 * @return int|false
+	 */
+	public function amr_mode_bytes_per_frame($key) {
+		static $amr_mode_bitrate = array(
+			0 =>  13, // 1-byte frame header +  95 bits [padded to: 12 bytes] audio data
+			1 =>  14, // 1-byte frame header + 103 bits [padded to: 13 bytes] audio data
+			2 =>  16, // 1-byte frame header + 118 bits [padded to: 15 bytes] audio data
+			3 =>  18, // 1-byte frame header + 134 bits [padded to: 17 bytes] audio data
+			4 =>  20, // 1-byte frame header + 148 bits [padded to: 19 bytes] audio data
+			5 =>  21, // 1-byte frame header + 159 bits [padded to: 20 bytes] audio data
+			6 =>  27, // 1-byte frame header + 204 bits [padded to: 26 bytes] audio data
+			7 =>  32, // 1-byte frame header + 244 bits [padded to: 31 bytes] audio data
+		);
+		return (isset($amr_mode_bitrate[$key]) ? $amr_mode_bitrate[$key] : false);
+	}
+
+
+}

--- a/application/libraries/getid3/module.audio.avr.php
+++ b/application/libraries/getid3/module.audio.avr.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.avr.php                                        //
@@ -13,10 +14,15 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_avr extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -62,13 +68,13 @@ class getid3_avr extends getid3_handler
 
 		$info['fileformat'] = 'avr';
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$AVRheader = fread($this->getid3->fp, 128);
+		$this->fseek($info['avdataoffset']);
+		$AVRheader = $this->fread(128);
 
 		$info['avr']['raw']['magic'] = substr($AVRheader,  0,  4);
 		$magic = '2BIT';
 		if ($info['avr']['raw']['magic'] != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['avr']['raw']['magic']).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['avr']['raw']['magic']).'"');
 			unset($info['fileformat']);
 			unset($info['avr']);
 			return false;
@@ -105,7 +111,7 @@ class getid3_avr extends getid3_handler
 		}
 
 		if (($info['avdataend'] - $info['avdataoffset']) != ($info['avr']['sample_length'] * (($info['avr']['bits_per_sample'] == 8) ? 1 : 2))) {
-			$info['warning'][] = 'Probable truncated file: expecting '.($info['avr']['sample_length'] * (($info['avr']['bits_per_sample'] == 8) ? 1 : 2)).' bytes of audio data, found '.($info['avdataend'] - $info['avdataoffset']);
+			$this->warning('Probable truncated file: expecting '.($info['avr']['sample_length'] * (($info['avr']['bits_per_sample'] == 8) ? 1 : 2)).' bytes of audio data, found '.($info['avdataend'] - $info['avdataoffset']));
 		}
 
 		$info['audio']['dataformat']      = 'avr';

--- a/application/libraries/getid3/module.audio.dsdiff.php
+++ b/application/libraries/getid3/module.audio.dsdiff.php
@@ -1,0 +1,310 @@
+<?php
+
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// module.audio.dsdiff.php                                     //
+// module for analyzing Direct Stream Digital Interchange      //
+// File Format (DSDIFF) files                                  //
+// dependencies: NONE                                          //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+
+class getid3_dsdiff extends getid3_handler
+{
+	/**
+	 * @return bool
+	 */
+	public function Analyze() {
+		$info = &$this->getid3->info;
+
+		$this->fseek($info['avdataoffset']);
+		$DSDIFFheader = $this->fread(4);
+
+		// https://dsd-guide.com/sites/default/files/white-papers/DSDIFF_1.5_Spec.pdf
+		if (substr($DSDIFFheader, 0, 4) != 'FRM8') {
+			$this->error('Expecting "FRM8" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($DSDIFFheader, 0, 4)).'"');
+			return false;
+		}
+		unset($DSDIFFheader);
+		$this->fseek($info['avdataoffset']);
+
+		$info['encoding']                 = 'ISO-8859-1'; // not certain, but assumed
+		$info['fileformat']               = 'dsdiff';
+		$info['mime_type']                = 'audio/dsd';
+		$info['audio']['dataformat']      = 'dsdiff';
+		$info['audio']['bitrate_mode']    = 'cbr';
+		$info['audio']['bits_per_sample'] = 1;
+
+		$info['dsdiff'] = array();
+		while (!$this->feof() && ($ChunkHeader = $this->fread(12))) {
+			if (strlen($ChunkHeader) < 12) {
+				$this->error('Expecting chunk header at offset '.$thisChunk['offset'].', found insufficient data in file, aborting parsing');
+				break;
+			}
+			$thisChunk = array();
+			$thisChunk['offset'] = $this->ftell() - 12;
+			$thisChunk['name'] = substr($ChunkHeader, 0, 4);
+			if (!preg_match('#^[\\x21-\\x7E]+ *$#', $thisChunk['name'])) {
+				// "a concatenation of four printable ASCII characters in the range ' ' (space, 0x20) through '~'(0x7E). Space (0x20) cannot precede printing characters; trailing spaces are allowed."
+				$this->error('Invalid chunk name "'.$thisChunk['name'].'" ('.getid3_lib::PrintHexBytes($thisChunk['name']).') at offset '.$thisChunk['offset'].', aborting parsing');
+			}
+			$thisChunk['size'] = getid3_lib::BigEndian2Int(substr($ChunkHeader, 4, 8));
+			$datasize = $thisChunk['size'] + ($thisChunk['size'] % 2); // "If the data is an odd number of bytes in length, a pad byte must be added at the end. The pad byte is not included in ckDataSize."
+
+			switch ($thisChunk['name']) {
+				case 'FRM8':
+					$thisChunk['form_type'] = $this->fread(4);
+					if ($thisChunk['form_type'] != 'DSD ') {
+						$this->error('Expecting "DSD " at offset '.($this->ftell() - 4).', found "'.getid3_lib::PrintHexBytes($thisChunk['form_type']).'", aborting parsing');
+						break 2;
+					}
+					// do nothing further, prevent skipping subchunks
+					break;
+				case 'PROP': // PROPerty chunk
+					$thisChunk['prop_type'] = $this->fread(4);
+					if ($thisChunk['prop_type'] != 'SND ') {
+						$this->error('Expecting "SND " at offset '.($this->ftell() - 4).', found "'.getid3_lib::PrintHexBytes($thisChunk['prop_type']).'", aborting parsing');
+						break 2;
+					}
+					// do nothing further, prevent skipping subchunks
+					break;
+				case 'DIIN': // eDIted master INformation chunk
+					// do nothing, just prevent skipping subchunks
+					break;
+
+				case 'FVER': // Format VERsion chunk
+					if ($thisChunk['size'] == 4) {
+						$FVER = $this->fread(4);
+						$info['dsdiff']['format_version'] = ord($FVER[0]).'.'.ord($FVER[1]).'.'.ord($FVER[2]).'.'.ord($FVER[3]);
+						unset($FVER);
+					} else {
+						$this->warning('Expecting "FVER" chunk to be 4 bytes, found '.$thisChunk['size'].' bytes, skipping chunk');
+						$this->fseek($datasize, SEEK_CUR);
+					}
+					break;
+				case 'FS  ': // sample rate chunk
+					if ($thisChunk['size'] == 4) {
+						$info['dsdiff']['sample_rate'] = getid3_lib::BigEndian2Int($this->fread(4));
+						$info['audio']['sample_rate'] = $info['dsdiff']['sample_rate'];
+					} else {
+						$this->warning('Expecting "FVER" chunk to be 4 bytes, found '.$thisChunk['size'].' bytes, skipping chunk');
+						$this->fseek($datasize, SEEK_CUR);
+					}
+					break;
+				case 'CHNL': // CHaNneLs chunk
+					$thisChunk['num_channels'] = getid3_lib::BigEndian2Int($this->fread(2));
+					if ($thisChunk['num_channels'] == 0) {
+						$this->warning('channel count should be greater than zero, skipping chunk');
+						$this->fseek($datasize - 2, SEEK_CUR);
+					}
+					for ($i = 0; $i < $thisChunk['num_channels']; $i++) {
+						$thisChunk['channels'][$i] = $this->fread(4);
+					}
+					$info['audio']['channels'] = $thisChunk['num_channels'];
+					break;
+				case 'CMPR': // CoMPRession type chunk
+					$thisChunk['compression_type'] = $this->fread(4);
+					$info['audio']['dataformat'] = trim($thisChunk['compression_type']);
+					$humanReadableByteLength = getid3_lib::BigEndian2Int($this->fread(1));
+					$thisChunk['compression_name'] = $this->fread($humanReadableByteLength);
+					if (($humanReadableByteLength % 2) == 0) {
+						// need to seek to multiple of 2 bytes, human-readable string length is only one byte long so if the string is an even number of bytes we need to seek past a padding byte after the string
+						$this->fseek(1, SEEK_CUR);
+					}
+					unset($humanReadableByteLength);
+					break;
+				case 'ABSS': // ABSolute Start time chunk
+					$ABSS = $this->fread(8);
+					$info['dsdiff']['absolute_start_time']['hours']   = getid3_lib::BigEndian2Int(substr($ABSS, 0, 2));
+					$info['dsdiff']['absolute_start_time']['minutes'] = getid3_lib::BigEndian2Int(substr($ABSS, 2, 1));
+					$info['dsdiff']['absolute_start_time']['seconds'] = getid3_lib::BigEndian2Int(substr($ABSS, 3, 1));
+					$info['dsdiff']['absolute_start_time']['samples'] = getid3_lib::BigEndian2Int(substr($ABSS, 4, 4));
+					unset($ABSS);
+					break;
+				case 'LSCO': // LoudSpeaker COnfiguration chunk
+					// 0 = 2-channel stereo set-up
+					// 3 = 5-channel set-up according to ITU-R BS.775-1 [ITU]
+					// 4 = 6-channel set-up, 5-channel set-up according to ITU-R BS.775-1 [ITU], plus additional Low Frequency Enhancement (LFE) loudspeaker. Also known as "5.1 configuration"
+					// 65535 = Undefined channel set-up
+					$thisChunk['loundspeaker_config_id'] = getid3_lib::BigEndian2Int($this->fread(2));
+					break;
+				case 'COMT': // COMmenTs chunk
+					$thisChunk['num_comments'] = getid3_lib::BigEndian2Int($this->fread(2));
+					for ($i = 0; $i < $thisChunk['num_comments']; $i++) {
+						$thisComment = array();
+						$COMT = $this->fread(14);
+						$thisComment['creation_year']   = getid3_lib::BigEndian2Int(substr($COMT,  0, 2));
+						$thisComment['creation_month']  = getid3_lib::BigEndian2Int(substr($COMT,  2, 1));
+						$thisComment['creation_day']    = getid3_lib::BigEndian2Int(substr($COMT,  3, 1));
+						$thisComment['creation_hour']   = getid3_lib::BigEndian2Int(substr($COMT,  4, 1));
+						$thisComment['creation_minute'] = getid3_lib::BigEndian2Int(substr($COMT,  5, 1));
+						$thisComment['comment_type_id'] = getid3_lib::BigEndian2Int(substr($COMT,  6, 2));
+						$thisComment['comment_ref_id']  = getid3_lib::BigEndian2Int(substr($COMT,  8, 2));
+						$thisComment['string_length']   = getid3_lib::BigEndian2Int(substr($COMT, 10, 4));
+						$thisComment['comment_text'] = $this->fread($thisComment['string_length']);
+						if ($thisComment['string_length'] % 2) {
+							// commentText[] is the description of the Comment. This text must be padded with a byte at the end, if needed, to make it an even number of bytes long. This pad byte, if present, is not included in count.
+							$this->fseek(1, SEEK_CUR);
+						}
+						$thisComment['comment_type']      = $this->DSDIFFcmtType($thisComment['comment_type_id']);
+						$thisComment['comment_reference'] = $this->DSDIFFcmtRef($thisComment['comment_type_id'], $thisComment['comment_ref_id']);
+						$thisComment['creation_unix'] = mktime($thisComment['creation_hour'], $thisComment['creation_minute'], 0, $thisComment['creation_month'], $thisComment['creation_day'], $thisComment['creation_year']);
+						$thisChunk['comments'][$i] = $thisComment;
+
+						$commentkey = ($thisComment['comment_reference'] ?: 'comment');
+						$info['dsdiff']['comments'][$commentkey][] = $thisComment['comment_text'];
+						unset($thisComment);
+					}
+					break;
+				case 'MARK': // MARKer chunk
+					$MARK = $this->fread(22);
+					$thisChunk['marker_hours']   = getid3_lib::BigEndian2Int(substr($MARK,  0, 2));
+					$thisChunk['marker_minutes'] = getid3_lib::BigEndian2Int(substr($MARK,  2, 1));
+					$thisChunk['marker_seconds'] = getid3_lib::BigEndian2Int(substr($MARK,  3, 1));
+					$thisChunk['marker_samples'] = getid3_lib::BigEndian2Int(substr($MARK,  4, 4));
+					$thisChunk['marker_offset']  = getid3_lib::BigEndian2Int(substr($MARK,  8, 4));
+					$thisChunk['marker_type_id'] = getid3_lib::BigEndian2Int(substr($MARK, 12, 2));
+					$thisChunk['marker_channel'] = getid3_lib::BigEndian2Int(substr($MARK, 14, 2));
+					$thisChunk['marker_flagraw'] = getid3_lib::BigEndian2Int(substr($MARK, 16, 2));
+					$thisChunk['string_length']  = getid3_lib::BigEndian2Int(substr($MARK, 18, 4));
+					$thisChunk['description'] = ($thisChunk['string_length'] ? $this->fread($thisChunk['string_length']) : '');
+					if ($thisChunk['string_length'] % 2) {
+						// markerText[] is the description of the marker. This text must be padded with a byte at the end, if needed, to make it an even number of bytes long. This pad byte, if present, is not included in count.
+						$this->fseek(1, SEEK_CUR);
+					}
+					$thisChunk['marker_type'] = $this->DSDIFFmarkType($thisChunk['marker_type_id']);
+					unset($MARK);
+					break;
+				case 'DIAR': // artist chunk
+				case 'DITI': // title chunk
+					$thisChunk['string_length']  = getid3_lib::BigEndian2Int($this->fread(4));
+					$thisChunk['description'] = ($thisChunk['string_length'] ? $this->fread($thisChunk['string_length']) : '');
+					if ($thisChunk['string_length'] % 2) {
+						// This text must be padded with a byte at the end, if needed, to make it an even number of bytes long. This pad byte, if present, is not included in count.
+						$this->fseek(1, SEEK_CUR);
+					}
+
+					if ($commentkey = (($thisChunk['name'] == 'DIAR') ? 'artist' : (($thisChunk['name'] == 'DITI') ? 'title' : ''))) {
+						@$info['dsdiff']['comments'][$commentkey][] = $thisChunk['description'];
+					}
+					break;
+				case 'EMID': // Edited Master ID chunk
+					if ($thisChunk['size']) {
+						$thisChunk['identifier'] = $this->fread($thisChunk['size']);
+					}
+					break;
+
+				case 'ID3 ':
+					$endOfID3v2 = $this->ftell() + $datasize; // we will need to reset the filepointer after parsing ID3v2
+
+					getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.id3v2.php', __FILE__, true);
+					$getid3_temp = new getID3();
+					$getid3_temp->openfile($this->getid3->filename, null, $this->getid3->fp);
+					$getid3_id3v2 = new getid3_id3v2($getid3_temp);
+					$getid3_id3v2->StartingOffset = $this->ftell();
+					if ($thisChunk['valid'] = $getid3_id3v2->Analyze()) {
+						$info['id3v2'] = $getid3_temp->info['id3v2'];
+					}
+					unset($getid3_temp, $getid3_id3v2);
+
+					$this->fseek($endOfID3v2);
+					break;
+
+				case 'DSD ': // DSD sound data chunk
+				case 'DST ': // DST sound data chunk
+					// actual audio data, we're not interested, skip
+					$this->fseek($datasize, SEEK_CUR);
+					break;
+				default:
+					$this->warning('Unhandled chunk "'.$thisChunk['name'].'"');
+					$this->fseek($datasize, SEEK_CUR);
+					break;
+			}
+
+			@$info['dsdiff']['chunks'][] = $thisChunk;
+			//break;
+		}
+		if (empty($info['audio']['bitrate']) && !empty($info['audio']['channels']) && !empty($info['audio']['sample_rate']) && !empty($info['audio']['bits_per_sample'])) {
+			$info['audio']['bitrate'] = $info['audio']['bits_per_sample'] * $info['audio']['sample_rate'] * $info['audio']['channels'];
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param int $cmtType
+	 *
+	 * @return string
+	 */
+	public static function DSDIFFcmtType($cmtType) {
+		static $DSDIFFcmtType = array(
+			0 => 'General (album) Comment',
+			1 => 'Channel Comment',
+			2 => 'Sound Source',
+			3 => 'File History',
+		);
+		return (isset($DSDIFFcmtType[$cmtType]) ? $DSDIFFcmtType[$cmtType] : 'reserved');
+	}
+
+	/**
+	 * @param int $cmtType
+	 * @param int $cmtRef
+	 *
+	 * @return string
+	 */
+	public static function DSDIFFcmtRef($cmtType, $cmtRef) {
+		static $DSDIFFcmtRef = array(
+			2 => array(  // Sound Source
+				0 => 'DSD recording',
+				1 => 'Analogue recording',
+				2 => 'PCM recording',
+			),
+			3 => array( // File History
+				0 => 'comment',   // General Remark
+				1 => 'encodeby',  // Name of the operator
+				2 => 'encoder',   // Name or type of the creating machine
+				3 => 'timezone',  // Time zone information
+				4 => 'revision',  // Revision of the file
+			),
+		);
+		switch ($cmtType) {
+			case 0:
+				// If the comment type is General Comment the comment reference must be 0
+				return '';
+			case 1:
+				// If the comment type is Channel Comment, the comment reference defines the channel number to which the comment belongs
+				return ($cmtRef ? 'channel '.$cmtRef : 'all channels');
+			case 2:
+			case 3:
+				return (isset($DSDIFFcmtRef[$cmtType][$cmtRef]) ? $DSDIFFcmtRef[$cmtType][$cmtRef] : 'reserved');
+		}
+		return 'unsupported $cmtType='.$cmtType;
+	}
+
+	/**
+	 * @param int $cmtType
+	 *
+	 * @return string
+	 */
+	public static function DSDIFFmarkType($markType) {
+		static $DSDIFFmarkType = array(
+			0 => 'TrackStart',   // Entry point for a Track start
+			1 => 'TrackStop',    // Entry point for ending a Track
+			2 => 'ProgramStart', // Start point of 2-channel or multi-channel area
+			3 => 'Obsolete',     //
+			4 => 'Index',        // Entry point of an Index
+		);
+		return (isset($DSDIFFmarkType[$markType]) ? $DSDIFFmarkType[$markType] : 'reserved');
+	}
+
+}

--- a/application/libraries/getid3/module.audio.dsf.php
+++ b/application/libraries/getid3/module.audio.dsf.php
@@ -1,0 +1,142 @@
+<?php
+
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// module.audio.dsf.php                                        //
+// module for analyzing dsf/DSF Audio files                    //
+// dependencies: module.tag.id3v2.php                          //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.id3v2.php', __FILE__, true);
+
+class getid3_dsf extends getid3_handler
+{
+	/**
+	 * @return bool
+	 */
+	public function Analyze() {
+		$info = &$this->getid3->info;
+
+		$info['fileformat']            = 'dsf';
+		$info['audio']['dataformat']   = 'dsf';
+		$info['audio']['lossless']     = true;
+		$info['audio']['bitrate_mode'] = 'cbr';
+
+		$this->fseek($info['avdataoffset']);
+		$dsfheader = $this->fread(28 + 12);
+
+		$headeroffset = 0;
+		$info['dsf']['dsd']['magic'] = substr($dsfheader, $headeroffset, 4);
+		$headeroffset += 4;
+		$magic = 'DSD ';
+		if ($info['dsf']['dsd']['magic'] != $magic) {
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['dsf']['dsd']['magic']).'"');
+			unset($info['fileformat']);
+			unset($info['audio']);
+			unset($info['dsf']);
+			return false;
+		}
+		$info['dsf']['dsd']['dsd_chunk_size']     = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8)); // should be 28
+		$headeroffset += 8;
+		$info['dsf']['dsd']['dsf_file_size']      = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));
+		$headeroffset += 8;
+		$info['dsf']['dsd']['meta_chunk_offset']  = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));
+		$headeroffset += 8;
+
+
+		$info['dsf']['fmt']['magic'] = substr($dsfheader, $headeroffset, 4);
+		$headeroffset += 4;
+		$magic = 'fmt ';
+		if ($info['dsf']['fmt']['magic'] != $magic) {
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$headeroffset.', found "'.getid3_lib::PrintHexBytes($info['dsf']['fmt']['magic']).'"');
+			return false;
+		}
+		$info['dsf']['fmt']['fmt_chunk_size']     = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));  // usually 52 bytes
+		$headeroffset += 8;
+		$dsfheader .= $this->fread($info['dsf']['fmt']['fmt_chunk_size'] - 12 + 12);  // we have already read the entire DSD chunk, plus 12 bytes of FMT. We now want to read the size of FMT, plus 12 bytes into the next chunk to get magic and size.
+		if (strlen($dsfheader) != ($info['dsf']['dsd']['dsd_chunk_size'] + $info['dsf']['fmt']['fmt_chunk_size'] + 12)) {
+			$this->error('Expecting '.($info['dsf']['dsd']['dsd_chunk_size'] + $info['dsf']['fmt']['fmt_chunk_size']).' bytes header, found '.strlen($dsfheader).' bytes');
+			return false;
+		}
+		$info['dsf']['fmt']['format_version']     = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));  // usually "1"
+		$headeroffset += 4;
+		$info['dsf']['fmt']['format_id']          = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));  // usually "0" = "DSD Raw"
+		$headeroffset += 4;
+		$info['dsf']['fmt']['channel_type_id']    = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['channels']           = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['sample_rate']        = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['bits_per_sample']    = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['sample_count']       = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));
+		$headeroffset += 8;
+		$info['dsf']['fmt']['channel_block_size'] = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['reserved']           = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4)); // zero-filled
+		$headeroffset += 4;
+
+
+		$info['dsf']['data']['magic'] = substr($dsfheader, $headeroffset, 4);
+		$headeroffset += 4;
+		$magic = 'data';
+		if ($info['dsf']['data']['magic'] != $magic) {
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$headeroffset.', found "'.getid3_lib::PrintHexBytes($info['dsf']['data']['magic']).'"');
+			return false;
+		}
+		$info['dsf']['data']['data_chunk_size']    = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));
+		$headeroffset += 8;
+		$info['avdataoffset'] = $headeroffset;
+		$info['avdataend']    = $info['avdataoffset'] + $info['dsf']['data']['data_chunk_size'];
+
+
+		if ($info['dsf']['dsd']['meta_chunk_offset'] > 0) {
+			$getid3_id3v2 = new getid3_id3v2($this->getid3);
+			$getid3_id3v2->StartingOffset = $info['dsf']['dsd']['meta_chunk_offset'];
+			$getid3_id3v2->Analyze();
+			unset($getid3_id3v2);
+		}
+
+
+		$info['dsf']['fmt']['channel_type'] = $this->DSFchannelTypeLookup($info['dsf']['fmt']['channel_type_id']);
+		$info['audio']['channelmode']       = $info['dsf']['fmt']['channel_type'];
+		$info['audio']['bits_per_sample']   = $info['dsf']['fmt']['bits_per_sample'];
+		$info['audio']['sample_rate']       = $info['dsf']['fmt']['sample_rate'];
+		$info['audio']['channels']          = $info['dsf']['fmt']['channels'];
+		$info['audio']['bitrate']           = $info['audio']['bits_per_sample'] * $info['audio']['sample_rate'] * $info['audio']['channels'];
+		$info['playtime_seconds']           = ($info['dsf']['data']['data_chunk_size'] * 8) / $info['audio']['bitrate'];
+
+		return true;
+	}
+
+	/**
+	 * @param int $channel_type_id
+	 *
+	 * @return string
+	 */
+	public static function DSFchannelTypeLookup($channel_type_id) {
+		static $DSFchannelTypeLookup = array(
+			                  // interleaving order:
+			1 => 'mono',      // 1: Mono
+			2 => 'stereo',    // 1: Front-Left; 2: Front-Right
+			3 => '3-channel', // 1: Front-Left; 2: Front-Right; 3: Center
+			4 => 'quad',      // 1: Front-Left; 2: Front-Right; 3: Back-Left; 4: Back-Right
+			5 => '4-channel', // 1: Front-Left; 2: Front-Right; 3: Center;    4: Low-Frequency
+			6 => '5-channel', // 1: Front-Left; 2: Front-Right; 3: Center;    4: Back-Left      5: Back-Right
+			7 => '5.1',       // 1: Front-Left; 2: Front-Right; 3: Center;    4: Low-Frequency; 5: Back-Left;  6: Back-Right
+		);
+		return (isset($DSFchannelTypeLookup[$channel_type_id]) ? $DSFchannelTypeLookup[$channel_type_id] : '');
+	}
+
+}

--- a/application/libraries/getid3/module.audio.dts.php
+++ b/application/libraries/getid3/module.audio.dts.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.dts.php                                        //
@@ -13,65 +14,112 @@
 //                                                             //
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
+/**
+* @tutorial http://wiki.multimedia.cx/index.php?title=DTS
+*/
 class getid3_dts extends getid3_handler
 {
-    const syncword = "\x7F\xFE\x80\x01";
+	/**
+	 * Default DTS syncword used in native .cpt or .dts formats.
+	 */
+	const syncword = "\x7F\xFE\x80\x01";
 
+	/**
+	 * @var int
+	 */
+	private $readBinDataOffset = 0;
+
+	/**
+	 * Possible syncwords indicating bitstream encoding.
+	 */
+	public static $syncwords = array(
+		0 => "\x7F\xFE\x80\x01",  // raw big-endian
+		1 => "\xFE\x7F\x01\x80",  // raw little-endian
+		2 => "\x1F\xFF\xE8\x00",  // 14-bit big-endian
+		3 => "\xFF\x1F\x00\xE8"); // 14-bit little-endian
+
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
-
-		// Specs taken from "DTS Coherent Acoustics;Core and Extensions,  ETSI TS 102 114 V1.2.1 (2002-12)"
-		// (http://pda.etsi.org/pda/queryform.asp)
-		// With thanks to Gambit <macteam@users.sourceforge.net> http://mac.sourceforge.net/atl/
-
 		$info['fileformat'] = 'dts';
 
 		$this->fseek($info['avdataoffset']);
-		$DTSheader = $this->fread(16);
+		$DTSheader = $this->fread(20); // we only need 2 words magic + 6 words frame header, but these words may be normal 16-bit words OR 14-bit words with 2 highest bits set to zero, so 8 words can be either 8*16/8 = 16 bytes OR 8*16*(16/14)/8 = 18.3 bytes
 
-		if (strpos($DTSheader, self::syncword) === 0) {
-			$info['dts']['raw']['magic'] = self::syncword;
-			$offset = 4;
+		// check syncword
+		$sync = substr($DTSheader, 0, 4);
+		if (($encoding = array_search($sync, self::$syncwords)) !== false) {
+
+			$info['dts']['raw']['magic'] = $sync;
+			$this->readBinDataOffset = 32;
+
+		} elseif ($this->isDependencyFor('matroska')) {
+
+			// Matroska contains DTS without syncword encoded as raw big-endian format
+			$encoding = 0;
+			$this->readBinDataOffset = 0;
+
 		} else {
-			if (!$this->isDependencyFor('matroska')) {
-				unset($info['fileformat']);
-				return $this->error('Expecting "'.getid3_lib::PrintHexBytes(self::syncword).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($DTSheader, 0, 4)).'"');
-			}
-			$offset = 0;
+
+			unset($info['fileformat']);
+			return $this->error('Expecting "'.implode('| ', array_map('getid3_lib::PrintHexBytes', self::$syncwords)).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($sync).'"');
+
 		}
 
-		$fhBS = getid3_lib::BigEndian2Bin(substr($DTSheader, $offset,  12));
-		$bsOffset = 0;
-		$info['dts']['raw']['frame_type']             =        $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['raw']['deficit_samples']        =        $this->readBinData($fhBS, $bsOffset,  5);
-		$info['dts']['flags']['crc_present']          = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['raw']['pcm_sample_blocks']      =        $this->readBinData($fhBS, $bsOffset,  7);
-		$info['dts']['raw']['frame_byte_size']        =        $this->readBinData($fhBS, $bsOffset, 14);
-		$info['dts']['raw']['channel_arrangement']    =        $this->readBinData($fhBS, $bsOffset,  6);
-		$info['dts']['raw']['sample_frequency']       =        $this->readBinData($fhBS, $bsOffset,  4);
-		$info['dts']['raw']['bitrate']                =        $this->readBinData($fhBS, $bsOffset,  5);
-		$info['dts']['flags']['embedded_downmix']     = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['flags']['dynamicrange']         = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['flags']['timestamp']            = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['flags']['auxdata']              = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['flags']['hdcd']                 = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['raw']['extension_audio']        =        $this->readBinData($fhBS, $bsOffset,  3);
-		$info['dts']['flags']['extended_coding']      = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['flags']['audio_sync_insertion'] = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['raw']['lfe_effects']            =        $this->readBinData($fhBS, $bsOffset,  2);
-		$info['dts']['flags']['predictor_history']    = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		if ($info['dts']['flags']['crc_present']) {
-			$info['dts']['raw']['crc16']              =        $this->readBinData($fhBS, $bsOffset, 16);
+		// decode header
+		$fhBS = '';
+		for ($word_offset = 0; $word_offset <= strlen($DTSheader); $word_offset += 2) {
+			switch ($encoding) {
+				case 0: // raw big-endian
+					$fhBS .=        getid3_lib::BigEndian2Bin(       substr($DTSheader, $word_offset, 2) );
+					break;
+				case 1: // raw little-endian
+					$fhBS .=        getid3_lib::BigEndian2Bin(strrev(substr($DTSheader, $word_offset, 2)));
+					break;
+				case 2: // 14-bit big-endian
+					$fhBS .= substr(getid3_lib::BigEndian2Bin(       substr($DTSheader, $word_offset, 2) ), 2, 14);
+					break;
+				case 3: // 14-bit little-endian
+					$fhBS .= substr(getid3_lib::BigEndian2Bin(strrev(substr($DTSheader, $word_offset, 2))), 2, 14);
+					break;
+			}
 		}
-		$info['dts']['flags']['mri_perfect_reconst']  = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['raw']['encoder_soft_version']   =        $this->readBinData($fhBS, $bsOffset,  4);
-		$info['dts']['raw']['copy_history']           =        $this->readBinData($fhBS, $bsOffset,  2);
-		$info['dts']['raw']['bits_per_sample']        =        $this->readBinData($fhBS, $bsOffset,  2);
-		$info['dts']['flags']['surround_es']          = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['flags']['front_sum_diff']       = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['flags']['surround_sum_diff']    = (bool) $this->readBinData($fhBS, $bsOffset,  1);
-		$info['dts']['raw']['dialog_normalization']   =        $this->readBinData($fhBS, $bsOffset,  4);
+
+		$info['dts']['raw']['frame_type']             =        $this->readBinData($fhBS,  1);
+		$info['dts']['raw']['deficit_samples']        =        $this->readBinData($fhBS,  5);
+		$info['dts']['flags']['crc_present']          = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['raw']['pcm_sample_blocks']      =        $this->readBinData($fhBS,  7);
+		$info['dts']['raw']['frame_byte_size']        =        $this->readBinData($fhBS, 14);
+		$info['dts']['raw']['channel_arrangement']    =        $this->readBinData($fhBS,  6);
+		$info['dts']['raw']['sample_frequency']       =        $this->readBinData($fhBS,  4);
+		$info['dts']['raw']['bitrate']                =        $this->readBinData($fhBS,  5);
+		$info['dts']['flags']['embedded_downmix']     = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['flags']['dynamicrange']         = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['flags']['timestamp']            = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['flags']['auxdata']              = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['flags']['hdcd']                 = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['raw']['extension_audio']        =        $this->readBinData($fhBS,  3);
+		$info['dts']['flags']['extended_coding']      = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['flags']['audio_sync_insertion'] = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['raw']['lfe_effects']            =        $this->readBinData($fhBS,  2);
+		$info['dts']['flags']['predictor_history']    = (bool) $this->readBinData($fhBS,  1);
+		if ($info['dts']['flags']['crc_present']) {
+			$info['dts']['raw']['crc16']              =        $this->readBinData($fhBS, 16);
+		}
+		$info['dts']['flags']['mri_perfect_reconst']  = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['raw']['encoder_soft_version']   =        $this->readBinData($fhBS,  4);
+		$info['dts']['raw']['copy_history']           =        $this->readBinData($fhBS,  2);
+		$info['dts']['raw']['bits_per_sample']        =        $this->readBinData($fhBS,  2);
+		$info['dts']['flags']['surround_es']          = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['flags']['front_sum_diff']       = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['flags']['surround_sum_diff']    = (bool) $this->readBinData($fhBS,  1);
+		$info['dts']['raw']['dialog_normalization']   =        $this->readBinData($fhBS,  4);
 
 
 		$info['dts']['bitrate']              = self::bitrateLookup($info['dts']['raw']['bitrate']);
@@ -90,19 +138,34 @@ class getid3_dts extends getid3_handler
 		$info['audio']['sample_rate']         = $info['dts']['sample_rate'];
 		$info['audio']['channels']            = $info['dts']['channels'];
 		$info['audio']['bitrate']             = $info['dts']['bitrate'];
-		if (isset($info['avdataend'])) {
+		if (isset($info['avdataend']) && !empty($info['dts']['bitrate']) && is_numeric($info['dts']['bitrate'])) {
 			$info['playtime_seconds']         = ($info['avdataend'] - $info['avdataoffset']) / ($info['dts']['bitrate'] / 8);
+			if (($encoding == 2) || ($encoding == 3)) {
+				// 14-bit data packed into 16-bit words, so the playtime is wrong because only (14/16) of the bytes in the data portion of the file are used at the specified bitrate
+				$info['playtime_seconds'] *= (14 / 16);
+			}
 		}
-
 		return true;
 	}
 
-	private function readBinData($bin, &$offset, $length) {
-		$data = substr($bin, $offset, $length);
-		$offset += $length;
+	/**
+	 * @param string $bin
+	 * @param int $length
+	 *
+	 * @return int
+	 */
+	private function readBinData($bin, $length) {
+		$data = substr($bin, $this->readBinDataOffset, $length);
+		$this->readBinDataOffset += $length;
+
 		return bindec($data);
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return int|string|false
+	 */
 	public static function bitrateLookup($index) {
 		static $lookup = array(
 			0  => 32000,
@@ -141,6 +204,11 @@ class getid3_dts extends getid3_handler
 		return (isset($lookup[$index]) ? $lookup[$index] : false);
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return int|string|false
+	 */
 	public static function sampleRateLookup($index) {
 		static $lookup = array(
 			0  => 'invalid',
@@ -163,6 +231,11 @@ class getid3_dts extends getid3_handler
 		return (isset($lookup[$index]) ? $lookup[$index] : false);
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return int|false
+	 */
 	public static function bitPerSampleLookup($index) {
 		static $lookup = array(
 			0  => 16,
@@ -173,44 +246,46 @@ class getid3_dts extends getid3_handler
 		return (isset($lookup[$index]) ? $lookup[$index] : false);
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return int|false
+	 */
 	public static function numChannelsLookup($index) {
 		switch ($index) {
 			case 0:
 				return 1;
-				break;
 			case 1:
 			case 2:
 			case 3:
 			case 4:
 				return 2;
-				break;
 			case 5:
 			case 6:
 				return 3;
-				break;
 			case 7:
 			case 8:
 				return 4;
-				break;
 			case 9:
 				return 5;
-				break;
 			case 10:
 			case 11:
 			case 12:
 				return 6;
-				break;
 			case 13:
 				return 7;
-				break;
 			case 14:
 			case 15:
 				return 8;
-				break;
 		}
 		return false;
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public static function channelArrangementLookup($index) {
 		static $lookup = array(
 			0  => 'A',
@@ -233,14 +308,18 @@ class getid3_dts extends getid3_handler
 		return (isset($lookup[$index]) ? $lookup[$index] : 'user-defined');
 	}
 
+	/**
+	 * @param int $index
+	 * @param int $version
+	 *
+	 * @return int|false
+	 */
 	public static function dialogNormalization($index, $version) {
 		switch ($version) {
 			case 7:
 				return 0 - $index;
-				break;
 			case 6:
 				return 0 - 16 - $index;
-				break;
 		}
 		return false;
 	}

--- a/application/libraries/getid3/module.audio.flac.php
+++ b/application/libraries/getid3/module.audio.flac.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.flac.php                                       //
@@ -13,17 +14,23 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
-
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.ogg.php', __FILE__, true);
 
+/**
+* @tutorial http://flac.sourceforge.net/format.html
+*/
 class getid3_flac extends getid3_handler
 {
 	const syncword = 'fLaC';
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
-
-		// http://flac.sourceforge.net/format.html
 
 		$this->fseek($info['avdataoffset']);
 		$StreamMarker = $this->fread(4);
@@ -39,22 +46,30 @@ class getid3_flac extends getid3_handler
 		return $this->parseMETAdata();
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function parseMETAdata() {
 		$info = &$this->getid3->info;
 		do {
 			$BlockOffset   = $this->ftell();
 			$BlockHeader   = $this->fread(4);
-			$LBFBT         = getid3_lib::BigEndian2Int(substr($BlockHeader, 0, 1));
+			$LBFBT         = getid3_lib::BigEndian2Int(substr($BlockHeader, 0, 1));  // LBFBT = LastBlockFlag + BlockType
 			$LastBlockFlag = (bool) ($LBFBT & 0x80);
 			$BlockType     =        ($LBFBT & 0x7F);
 			$BlockLength   = getid3_lib::BigEndian2Int(substr($BlockHeader, 1, 3));
 			$BlockTypeText = self::metaBlockTypeLookup($BlockType);
 
 			if (($BlockOffset + 4 + $BlockLength) > $info['avdataend']) {
-				$this->error('METADATA_BLOCK_HEADER.BLOCK_TYPE ('.$BlockTypeText.') at offset '.$BlockOffset.' extends beyond end of file');
+				$this->warning('METADATA_BLOCK_HEADER.BLOCK_TYPE ('.$BlockTypeText.') at offset '.$BlockOffset.' extends beyond end of file');
 				break;
 			}
 			if ($BlockLength < 1) {
+				if ($BlockTypeText != 'reserved') {
+					// probably supposed to be zero-length
+					$this->warning('METADATA_BLOCK_HEADER.BLOCK_LENGTH ('.$BlockTypeText.') at offset '.$BlockOffset.' is zero bytes');
+					continue;
+				}
 				$this->error('METADATA_BLOCK_HEADER.BLOCK_LENGTH ('.$BlockLength.') at offset '.$BlockOffset.' is invalid');
 				break;
 			}
@@ -133,7 +148,17 @@ class getid3_flac extends getid3_handler
 		if (isset($info['flac']['PICTURE']) && ($this->getid3->option_save_attachments !== getID3::ATTACHMENTS_NONE)) {
 			foreach ($info['flac']['PICTURE'] as $entry) {
 				if (!empty($entry['data'])) {
-					$info['flac']['comments']['picture'][] = array('image_mime'=>$entry['image_mime'], 'data'=>$entry['data']);
+					if (!isset($info['flac']['comments']['picture'])) {
+						$info['flac']['comments']['picture'] = array();
+					}
+					$comments_picture_data = array();
+					foreach (array('data', 'image_mime', 'image_width', 'image_height', 'imagetype', 'picturetype', 'description', 'datalength') as $picture_key) {
+						if (isset($entry[$picture_key])) {
+							$comments_picture_data[$picture_key] = $entry[$picture_key];
+						}
+					}
+					$info['flac']['comments']['picture'][] = $comments_picture_data;
+					unset($comments_picture_data);
 				}
 			}
 		}
@@ -146,7 +171,7 @@ class getid3_flac extends getid3_handler
 			if ($info['flac']['uncompressed_audio_bytes'] == 0) {
 				return $this->error('Corrupt FLAC file: uncompressed_audio_bytes == zero');
 			}
-			if (!$this->isDependencyFor('matroska')) {
+			if (!empty($info['flac']['compressed_audio_bytes'])) {
 				$info['flac']['compression_ratio'] = $info['flac']['compressed_audio_bytes'] / $info['flac']['uncompressed_audio_bytes'];
 			}
 		}
@@ -155,7 +180,7 @@ class getid3_flac extends getid3_handler
 		if (isset($info['flac']['STREAMINFO']['audio_signature'])) {
 
 			if ($info['flac']['STREAMINFO']['audio_signature'] === str_repeat("\x00", 16)) {
-                $this->warning('FLAC STREAMINFO.audio_signature is null (known issue with libOggFLAC)');
+				$this->warning('FLAC STREAMINFO.audio_signature is null (known issue with libOggFLAC)');
 			}
 			else {
 				$info['md5_data_source'] = '';
@@ -182,12 +207,14 @@ class getid3_flac extends getid3_handler
 		return true;
 	}
 
-	private function parseSTREAMINFO($BlockData) {
-		$info = &$this->getid3->info;
 
-		$info['flac']['STREAMINFO'] = array();
-		$streaminfo = &$info['flac']['STREAMINFO'];
-
+	/**
+	 * @param string $BlockData
+	 *
+	 * @return array
+	 */
+	public static function parseSTREAMINFOdata($BlockData) {
+		$streaminfo = array();
 		$streaminfo['min_block_size']  = getid3_lib::BigEndian2Int(substr($BlockData, 0, 2));
 		$streaminfo['max_block_size']  = getid3_lib::BigEndian2Int(substr($BlockData, 2, 2));
 		$streaminfo['min_frame_size']  = getid3_lib::BigEndian2Int(substr($BlockData, 4, 3));
@@ -199,15 +226,28 @@ class getid3_flac extends getid3_handler
 		$streaminfo['bits_per_sample'] = getid3_lib::Bin2Dec(substr($SRCSBSS, 23,  5)) + 1;
 		$streaminfo['samples_stream']  = getid3_lib::Bin2Dec(substr($SRCSBSS, 28, 36));
 
-		$streaminfo['audio_signature'] = substr($BlockData, 18, 16);
+		$streaminfo['audio_signature'] =                           substr($BlockData, 18, 16);
 
-		if (!empty($streaminfo['sample_rate'])) {
+		return $streaminfo;
+	}
+
+	/**
+	 * @param string $BlockData
+	 *
+	 * @return bool
+	 */
+	private function parseSTREAMINFO($BlockData) {
+		$info = &$this->getid3->info;
+
+		$info['flac']['STREAMINFO'] = self::parseSTREAMINFOdata($BlockData);
+
+		if (!empty($info['flac']['STREAMINFO']['sample_rate'])) {
 
 			$info['audio']['bitrate_mode']    = 'vbr';
-			$info['audio']['sample_rate']     = $streaminfo['sample_rate'];
-			$info['audio']['channels']        = $streaminfo['channels'];
-			$info['audio']['bits_per_sample'] = $streaminfo['bits_per_sample'];
-			$info['playtime_seconds']         = $streaminfo['samples_stream'] / $streaminfo['sample_rate'];
+			$info['audio']['sample_rate']     = $info['flac']['STREAMINFO']['sample_rate'];
+			$info['audio']['channels']        = $info['flac']['STREAMINFO']['channels'];
+			$info['audio']['bits_per_sample'] = $info['flac']['STREAMINFO']['bits_per_sample'];
+			$info['playtime_seconds']         = $info['flac']['STREAMINFO']['samples_stream'] / $info['flac']['STREAMINFO']['sample_rate'];
 			if ($info['playtime_seconds'] > 0) {
 				if (!$this->isDependencyFor('matroska')) {
 					$info['audio']['bitrate'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
@@ -224,6 +264,11 @@ class getid3_flac extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $BlockData
+	 *
+	 * @return bool
+	 */
 	private function parseAPPLICATION($BlockData) {
 		$info = &$this->getid3->info;
 
@@ -234,6 +279,11 @@ class getid3_flac extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $BlockData
+	 *
+	 * @return bool
+	 */
 	private function parseSEEKTABLE($BlockData) {
 		$info = &$this->getid3->info;
 
@@ -263,6 +313,11 @@ class getid3_flac extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $BlockData
+	 *
+	 * @return bool
+	 */
 	private function parseVORBIS_COMMENT($BlockData) {
 		$info = &$this->getid3->info;
 
@@ -282,6 +337,11 @@ class getid3_flac extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $BlockData
+	 *
+	 * @return bool
+	 */
 	private function parseCUESHEET($BlockData) {
 		$info = &$this->getid3->info;
 		$offset = 0;
@@ -334,32 +394,34 @@ class getid3_flac extends getid3_handler
 	}
 
 	/**
-	* Parse METADATA_BLOCK_PICTURE flac structure and extract attachment
-	* External usage: audio.ogg
-	*/
+	 * Parse METADATA_BLOCK_PICTURE flac structure and extract attachment
+	 * External usage: audio.ogg
+	 *
+	 * @return bool
+	 */
 	public function parsePICTURE() {
 		$info = &$this->getid3->info;
 
 		$picture['typeid']         = getid3_lib::BigEndian2Int($this->fread(4));
-		$picture['type']           = self::pictureTypeLookup($picture['typeid']);
+		$picture['picturetype']    = self::pictureTypeLookup($picture['typeid']);
 		$picture['image_mime']     = $this->fread(getid3_lib::BigEndian2Int($this->fread(4)));
 		$descr_length              = getid3_lib::BigEndian2Int($this->fread(4));
 		if ($descr_length) {
 			$picture['description'] = $this->fread($descr_length);
 		}
-		$picture['width']          = getid3_lib::BigEndian2Int($this->fread(4));
-		$picture['height']         = getid3_lib::BigEndian2Int($this->fread(4));
+		$picture['image_width']    = getid3_lib::BigEndian2Int($this->fread(4));
+		$picture['image_height']   = getid3_lib::BigEndian2Int($this->fread(4));
 		$picture['color_depth']    = getid3_lib::BigEndian2Int($this->fread(4));
 		$picture['colors_indexed'] = getid3_lib::BigEndian2Int($this->fread(4));
-		$data_length               = getid3_lib::BigEndian2Int($this->fread(4));
+		$picture['datalength']     = getid3_lib::BigEndian2Int($this->fread(4));
 
 		if ($picture['image_mime'] == '-->') {
-			$picture['data'] = $this->fread($data_length);
+			$picture['data'] = $this->fread($picture['datalength']);
 		} else {
 			$picture['data'] = $this->saveAttachment(
-				$picture['type'].'_'.$this->ftell(),
+				str_replace('/', '_', $picture['picturetype']).'_'.$this->ftell(),
 				$this->ftell(),
-				$data_length,
+				$picture['datalength'],
 				$picture['image_mime']);
 		}
 
@@ -368,6 +430,11 @@ class getid3_flac extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int $blocktype
+	 *
+	 * @return string
+	 */
 	public static function metaBlockTypeLookup($blocktype) {
 		static $lookup = array(
 			0 => 'STREAMINFO',
@@ -381,6 +448,11 @@ class getid3_flac extends getid3_handler
 		return (isset($lookup[$blocktype]) ? $lookup[$blocktype] : 'reserved');
 	}
 
+	/**
+	 * @param int $applicationid
+	 *
+	 * @return string
+	 */
 	public static function applicationIDLookup($applicationid) {
 		// http://flac.sourceforge.net/id.html
 		static $lookup = array(
@@ -411,6 +483,11 @@ class getid3_flac extends getid3_handler
 		return (isset($lookup[$applicationid]) ? $lookup[$applicationid] : 'reserved');
 	}
 
+	/**
+	 * @param int $type_id
+	 *
+	 * @return string
+	 */
 	public static function pictureTypeLookup($type_id) {
 		static $lookup = array (
 			 0 => 'Other',

--- a/application/libraries/getid3/module.audio.la.php
+++ b/application/libraries/getid3/module.audio.la.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.la.php                                         //
@@ -13,17 +14,22 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio-video.riff.php', __FILE__, true);
 
 class getid3_la extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
 		$offset = 0;
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$rawdata = fread($this->getid3->fp, $this->getid3->fread_buffer_size());
+		$this->fseek($info['avdataoffset']);
+		$rawdata = $this->fread($this->getid3->fread_buffer_size());
 
 		switch (substr($rawdata, $offset, 4)) {
 			case 'LA02':
@@ -41,13 +47,13 @@ class getid3_la extends getid3_handler
 				$info['la']['uncompressed_size'] = getid3_lib::LittleEndian2Int(substr($rawdata, $offset, 4));
 				$offset += 4;
 				if ($info['la']['uncompressed_size'] == 0) {
-					$info['error'][] = 'Corrupt LA file: uncompressed_size == zero';
+					$this->error('Corrupt LA file: uncompressed_size == zero');
 					return false;
 				}
 
 				$WAVEchunk = substr($rawdata, $offset, 4);
 				if ($WAVEchunk !== 'WAVE') {
-					$info['error'][] = 'Expected "WAVE" ('.getid3_lib::PrintHexBytes('WAVE').') at offset '.$offset.', found "'.$WAVEchunk.'" ('.getid3_lib::PrintHexBytes($WAVEchunk).') instead.';
+					$this->error('Expected "WAVE" ('.getid3_lib::PrintHexBytes('WAVE').') at offset '.$offset.', found "'.$WAVEchunk.'" ('.getid3_lib::PrintHexBytes($WAVEchunk).') instead.');
 					return false;
 				}
 				$offset += 4;
@@ -68,7 +74,7 @@ class getid3_la extends getid3_handler
 
 				$fmt_chunk = substr($rawdata, $offset, 4);
 				if ($fmt_chunk !== 'fmt ') {
-					$info['error'][] = 'Expected "fmt " ('.getid3_lib::PrintHexBytes('fmt ').') at offset '.$offset.', found "'.$fmt_chunk.'" ('.getid3_lib::PrintHexBytes($fmt_chunk).') instead.';
+					$this->error('Expected "fmt " ('.getid3_lib::PrintHexBytes('fmt ').') at offset '.$offset.', found "'.$fmt_chunk.'" ('.getid3_lib::PrintHexBytes($fmt_chunk).') instead.');
 					return false;
 				}
 				$offset += 4;
@@ -81,14 +87,14 @@ class getid3_la extends getid3_handler
 				$info['la']['channels']       = getid3_lib::LittleEndian2Int(substr($rawdata, $offset, 2));
 				$offset += 2;
 				if ($info['la']['channels'] == 0) {
-					$info['error'][] = 'Corrupt LA file: channels == zero';
+					$this->error('Corrupt LA file: channels == zero');
 						return false;
 				}
 
 				$info['la']['sample_rate'] = getid3_lib::LittleEndian2Int(substr($rawdata, $offset, 4));
 				$offset += 4;
 				if ($info['la']['sample_rate'] == 0) {
-					$info['error'][] = 'Corrupt LA file: sample_rate == zero';
+					$this->error('Corrupt LA file: sample_rate == zero');
 						return false;
 				}
 
@@ -112,7 +118,7 @@ class getid3_la extends getid3_handler
 				$info['la']['original_crc']         = getid3_lib::LittleEndian2Int(substr($rawdata, $offset, 4));
 				$offset += 4;
 
-				// mikeØbevin*de
+				// mikeÃ˜bevin*de
 				// Basically, the blocksize/seekevery are 61440/19 in La0.4 and 73728/16
 				// in earlier versions. A seekpoint is added every blocksize * seekevery
 				// samples, so 4 * int(totalSamples / (blockSize * seekEvery)) should
@@ -145,7 +151,7 @@ class getid3_la extends getid3_handler
 					$offset += 4;
 
 					if ($info['la']['footerstart'] > $info['filesize']) {
-						$info['warning'][] = 'FooterStart value points to offset '.$info['la']['footerstart'].' which is beyond end-of-file ('.$info['filesize'].')';
+						$this->warning('FooterStart value points to offset '.$info['la']['footerstart'].' which is beyond end-of-file ('.$info['filesize'].')');
 						$info['la']['footerstart'] = $info['filesize'];
 					}
 
@@ -166,8 +172,8 @@ class getid3_la extends getid3_handler
 								$RIFFdata .= substr($rawdata, 16, 24);
 							}
 							if ($info['la']['footerstart'] < $info['avdataend']) {
-								fseek($this->getid3->fp, $info['la']['footerstart'], SEEK_SET);
-								$RIFFdata .= fread($this->getid3->fp, $info['avdataend'] - $info['la']['footerstart']);
+								$this->fseek($info['la']['footerstart']);
+								$RIFFdata .= $this->fread($info['avdataend'] - $info['la']['footerstart']);
 							}
 							$RIFFdata = 'RIFF'.getid3_lib::LittleEndian2String(strlen($RIFFdata), 4, false).$RIFFdata;
 							fwrite($RIFF_fp, $RIFFdata, strlen($RIFFdata));
@@ -181,7 +187,7 @@ class getid3_la extends getid3_handler
 							if (empty($getid3_temp->info['error'])) {
 								$info['riff'] = $getid3_temp->info['riff'];
 							} else {
-								$info['warning'][] = 'Error parsing RIFF portion of La file: '.implode($getid3_temp->info['error']);
+								$this->warning('Error parsing RIFF portion of La file: '.implode($getid3_temp->info['error']));
 							}
 							unset($getid3_temp, $getid3_riff);
 						}
@@ -196,7 +202,7 @@ class getid3_la extends getid3_handler
 				$info['la']['compression_ratio']    = (float) (($info['avdataend'] - $info['avdataoffset']) / $info['la']['uncompressed_size']);
 				$info['playtime_seconds']           = (float) ($info['la']['samples'] / $info['la']['sample_rate']) / $info['la']['channels'];
 				if ($info['playtime_seconds'] == 0) {
-					$info['error'][] = 'Corrupt LA file: playtime_seconds == zero';
+					$this->error('Corrupt LA file: playtime_seconds == zero');
 					return false;
 				}
 
@@ -207,12 +213,11 @@ class getid3_la extends getid3_handler
 
 			default:
 				if (substr($rawdata, $offset, 2) == 'LA') {
-					$info['error'][] = 'This version of getID3() ['.$this->getid3->version().'] does not support LA version '.substr($rawdata, $offset + 2, 1).'.'.substr($rawdata, $offset + 3, 1).' which this appears to be - check http://getid3.sourceforge.net for updates.';
+					$this->error('This version of getID3() ['.$this->getid3->version().'] does not support LA version '.substr($rawdata, $offset + 2, 1).'.'.substr($rawdata, $offset + 3, 1).' which this appears to be - check http://getid3.sourceforge.net for updates.');
 				} else {
-					$info['error'][] = 'Not a LA (Lossless-Audio) file';
+					$this->error('Not a LA (Lossless-Audio) file');
 				}
 				return false;
-				break;
 		}
 
 		$info['audio']['channels']    = $info['la']['channels'];

--- a/application/libraries/getid3/module.audio.lpac.php
+++ b/application/libraries/getid3/module.audio.lpac.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.lpac.php                                       //
@@ -13,18 +14,24 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio-video.riff.php', __FILE__, true);
 
 class getid3_lpac extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$LPACheader = fread($this->getid3->fp, 14);
-		if (substr($LPACheader, 0, 4) != 'LPAC') {
-			$info['error'][] = 'Expected "LPAC" at offset '.$info['avdataoffset'].', found "'.$StreamMarker.'"';
+		$this->fseek($info['avdataoffset']);
+		$LPACheader = $this->fread(14);
+		$StreamMarker = substr($LPACheader, 0, 4);
+		if ($StreamMarker != 'LPAC') {
+			$this->error('Expected "LPAC" at offset '.$info['avdataoffset'].', found "'.$StreamMarker.'"');
 			return false;
 		}
 		$info['avdataoffset'] += 14;
@@ -45,7 +52,7 @@ class getid3_lpac extends getid3_handler
 		$info['lpac']['flags']['16_bit']  = (bool) ($flags['audio_type'] & 0x01);
 
 		if ($info['lpac']['flags']['24_bit'] && $info['lpac']['flags']['16_bit']) {
-			$info['warning'][] = '24-bit and 16-bit flags cannot both be set';
+			$this->warning('24-bit and 16-bit flags cannot both be set');
 		}
 
 		$info['lpac']['flags']['fast_compress']             =  (bool) ($flags['parameters'] & 0x40000000);
@@ -58,25 +65,25 @@ class getid3_lpac extends getid3_handler
 		$info['lpac']['max_prediction_order']               =         ($flags['parameters'] & 0x0000003F);
 
 		if ($info['lpac']['flags']['fast_compress'] && ($info['lpac']['max_prediction_order'] != 3)) {
-			$info['warning'][] = 'max_prediction_order expected to be "3" if fast_compress is true, actual value is "'.$info['lpac']['max_prediction_order'].'"';
+			$this->warning('max_prediction_order expected to be "3" if fast_compress is true, actual value is "'.$info['lpac']['max_prediction_order'].'"');
 		}
 		switch ($info['lpac']['file_version']) {
 			case 6:
 				if ($info['lpac']['flags']['adaptive_quantization']) {
-					$info['warning'][] = 'adaptive_quantization expected to be false in LPAC file stucture v6, actually true';
+					$this->warning('adaptive_quantization expected to be false in LPAC file stucture v6, actually true');
 				}
 				if ($info['lpac']['quantization'] != 20) {
-					$info['warning'][] = 'Quantization expected to be 20 in LPAC file stucture v6, actually '.$info['lpac']['flags']['Q'];
+					$this->warning('Quantization expected to be 20 in LPAC file stucture v6, actually '.$info['lpac']['flags']['Q']);
 				}
 				break;
 
 			default:
-				//$info['warning'][] = 'This version of getID3() ['.$this->getid3->version().'] only supports LPAC file format version 6, this file is version '.$info['lpac']['file_version'].' - please report to info@getid3.org';
+				//$this->warning('This version of getID3() ['.$this->getid3->version().'] only supports LPAC file format version 6, this file is version '.$info['lpac']['file_version'].' - please report to info@getid3.org');
 				break;
 		}
 
 		$getid3_temp = new getID3();
-		$getid3_temp->openfile($this->getid3->filename);
+		$getid3_temp->openfile($this->getid3->filename, $this->getid3->info['filesize'], $this->getid3->fp);
 		$getid3_temp->info = $info;
 		$getid3_riff = new getid3_riff($getid3_temp);
 		$getid3_riff->Analyze();

--- a/application/libraries/getid3/module.audio.midi.php
+++ b/application/libraries/getid3/module.audio.midi.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.midi.php                                       //
@@ -13,13 +14,23 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+
 define('GETID3_MIDI_MAGIC_MTHD', 'MThd'); // MIDI file header magic
 define('GETID3_MIDI_MAGIC_MTRK', 'MTrk'); // MIDI track header magic
 
 class getid3_midi extends getid3_handler
 {
+	/**
+	 * @var bool
+	 */
 	public $scanwholefile = true;
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -31,12 +42,12 @@ class getid3_midi extends getid3_handler
 		$info['fileformat']          = 'midi';
 		$info['audio']['dataformat'] = 'midi';
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$MIDIdata = fread($this->getid3->fp, $this->getid3->fread_buffer_size());
+		$this->fseek($info['avdataoffset']);
+		$MIDIdata = $this->fread($this->getid3->fread_buffer_size());
 		$offset = 0;
 		$MIDIheaderID = substr($MIDIdata, $offset, 4); // 'MThd'
 		if ($MIDIheaderID != GETID3_MIDI_MAGIC_MTHD) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes(GETID3_MIDI_MAGIC_MTHD).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($MIDIheaderID).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes(GETID3_MIDI_MAGIC_MTHD).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($MIDIheaderID).'"');
 			unset($info['fileformat']);
 			return false;
 		}
@@ -52,24 +63,30 @@ class getid3_midi extends getid3_handler
 
 		for ($i = 0; $i < $thisfile_midi_raw['tracks']; $i++) {
 			while ((strlen($MIDIdata) - $offset) < 8) {
-				$MIDIdata .= fread($this->getid3->fp, $this->getid3->fread_buffer_size());
+				if ($buffer = $this->fread($this->getid3->fread_buffer_size())) {
+					$MIDIdata .= $buffer;
+				} else {
+					$this->warning('only processed '.($i - 1).' of '.$thisfile_midi_raw['tracks'].' tracks');
+					$this->error('Unabled to read more file data at '.$this->ftell().' (trying to seek to : '.$offset.'), was expecting at least 8 more bytes');
+					return false;
+				}
 			}
 			$trackID = substr($MIDIdata, $offset, 4);
 			$offset += 4;
 			if ($trackID == GETID3_MIDI_MAGIC_MTRK) {
 				$tracksize = getid3_lib::BigEndian2Int(substr($MIDIdata, $offset, 4));
 				$offset += 4;
-				// $thisfile_midi['tracks'][$i]['size'] = $tracksize;
+				//$thisfile_midi['tracks'][$i]['size'] = $tracksize;
 				$trackdataarray[$i] = substr($MIDIdata, $offset, $tracksize);
 				$offset += $tracksize;
 			} else {
-				$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes(GETID3_MIDI_MAGIC_MTRK).'" at '.($offset - 4).', found "'.getid3_lib::PrintHexBytes($trackID).'" instead';
+				$this->error('Expecting "'.getid3_lib::PrintHexBytes(GETID3_MIDI_MAGIC_MTRK).'" at '.($offset - 4).', found "'.getid3_lib::PrintHexBytes($trackID).'" instead');
 				return false;
 			}
 		}
 
 		if (!isset($trackdataarray) || !is_array($trackdataarray)) {
-			$info['error'][] = 'Cannot find MIDI track information';
+			$this->error('Cannot find MIDI track information');
 			unset($thisfile_midi);
 			unset($info['fileformat']);
 			return false;
@@ -81,6 +98,7 @@ class getid3_midi extends getid3_handler
 			$CurrentMicroSecondsPerBeat       = 500000; // 120 beats per minute;  60,000,000 microseconds per minute -> 500,000 microseconds per beat
 			$CurrentBeatsPerMinute            = 120;    // 120 beats per minute;  60,000,000 microseconds per minute -> 500,000 microseconds per beat
 			$MicroSecondsPerQuarterNoteAfter  = array ();
+			$MIDIevents                       = array();
 
 			foreach ($trackdataarray as $tracknumber => $trackdata) {
 
@@ -219,7 +237,7 @@ class getid3_midi extends getid3_handler
 							case 0x51: // Tempo: microseconds / quarter note
 								$CurrentMicroSecondsPerBeat = getid3_lib::BigEndian2Int(substr($METAeventData, 0, $METAeventLength));
 								if ($CurrentMicroSecondsPerBeat == 0) {
-									$info['error'][] = 'Corrupt MIDI file: CurrentMicroSecondsPerBeat == zero';
+									$this->error('Corrupt MIDI file: CurrentMicroSecondsPerBeat == zero');
 									return false;
 								}
 								$thisfile_midi_raw['events'][$tracknumber][$CumulativeDeltaTime]['us_qnote'] = $CurrentMicroSecondsPerBeat;
@@ -229,9 +247,9 @@ class getid3_midi extends getid3_handler
 								break;
 
 							case 0x58: // Time signature
-								$timesig_numerator   = getid3_lib::BigEndian2Int($METAeventData{0});
-								$timesig_denominator = pow(2, getid3_lib::BigEndian2Int($METAeventData{1})); // $02 -> x/4, $03 -> x/8, etc
-								$timesig_32inqnote   = getid3_lib::BigEndian2Int($METAeventData{2});         // number of 32nd notes to the quarter note
+								$timesig_numerator   = getid3_lib::BigEndian2Int($METAeventData[0]);
+								$timesig_denominator = pow(2, getid3_lib::BigEndian2Int($METAeventData[1])); // $02 -> x/4, $03 -> x/8, etc
+								$timesig_32inqnote   = getid3_lib::BigEndian2Int($METAeventData[2]);         // number of 32nd notes to the quarter note
 								//$thisfile_midi_raw['events'][$tracknumber][$eventid]['timesig_32inqnote']   = $timesig_32inqnote;
 								//$thisfile_midi_raw['events'][$tracknumber][$eventid]['timesig_numerator']   = $timesig_numerator;
 								//$thisfile_midi_raw['events'][$tracknumber][$eventid]['timesig_denominator'] = $timesig_denominator;
@@ -240,13 +258,13 @@ class getid3_midi extends getid3_handler
 								break;
 
 							case 0x59: // Keysignature
-								$keysig_sharpsflats = getid3_lib::BigEndian2Int($METAeventData{0});
+								$keysig_sharpsflats = getid3_lib::BigEndian2Int($METAeventData[0]);
 								if ($keysig_sharpsflats & 0x80) {
 									// (-7 -> 7 flats, 0 ->key of C, 7 -> 7 sharps)
 									$keysig_sharpsflats -= 256;
 								}
 
-								$keysig_majorminor  = getid3_lib::BigEndian2Int($METAeventData{1}); // 0 -> major, 1 -> minor
+								$keysig_majorminor  = getid3_lib::BigEndian2Int($METAeventData[1]); // 0 -> major, 1 -> minor
 								$keysigs = array(-7=>'Cb', -6=>'Gb', -5=>'Db', -4=>'Ab', -3=>'Eb', -2=>'Bb', -1=>'F', 0=>'C', 1=>'G', 2=>'D', 3=>'A', 4=>'E', 5=>'B', 6=>'F#', 7=>'C#');
 								//$thisfile_midi_raw['events'][$tracknumber][$eventid]['keysig_sharps'] = (($keysig_sharpsflats > 0) ? abs($keysig_sharpsflats) : 0);
 								//$thisfile_midi_raw['events'][$tracknumber][$eventid]['keysig_flats']  = (($keysig_sharpsflats < 0) ? abs($keysig_sharpsflats) : 0);
@@ -262,13 +280,13 @@ class getid3_midi extends getid3_handler
 								break;
 
 							default:
-								$info['warning'][] = 'Unhandled META Event Command: '.$METAeventCommand;
+								$this->warning('Unhandled META Event Command: '.$METAeventCommand);
 								break;
 						}
 
 					} else {
 
-						$info['warning'][] = 'Unhandled MIDI Event ID: '.$MIDIevents[$tracknumber][$eventid]['eventid'].' + Channel ID: '.$MIDIevents[$tracknumber][$eventid]['channel'];
+						$this->warning('Unhandled MIDI Event ID: '.$MIDIevents[$tracknumber][$eventid]['eventid'].' + Channel ID: '.$MIDIevents[$tracknumber][$eventid]['channel']);
 
 					}
 				}
@@ -276,7 +294,8 @@ class getid3_midi extends getid3_handler
 					$thisfile_midi['totalticks'] = max($thisfile_midi['totalticks'], $CumulativeDeltaTime);
 				}
 			}
-			$previoustickoffset = null;
+			$previoustickoffset      = null;
+			$prevmicrosecondsperbeat = null;
 
 			ksort($MicroSecondsPerQuarterNoteAfter);
 			foreach ($MicroSecondsPerQuarterNoteAfter as $tickoffset => $microsecondsperbeat) {
@@ -288,7 +307,7 @@ class getid3_midi extends getid3_handler
 				if ($thisfile_midi['totalticks'] > $tickoffset) {
 
 					if ($thisfile_midi_raw['ticksperqnote'] == 0) {
-						$info['error'][] = 'Corrupt MIDI file: ticksperqnote == zero';
+						$this->error('Corrupt MIDI file: ticksperqnote == zero');
 						return false;
 					}
 
@@ -301,11 +320,11 @@ class getid3_midi extends getid3_handler
 			if ($thisfile_midi['totalticks'] > $previoustickoffset) {
 
 				if ($thisfile_midi_raw['ticksperqnote'] == 0) {
-					$info['error'][] = 'Corrupt MIDI file: ticksperqnote == zero';
+					$this->error('Corrupt MIDI file: ticksperqnote == zero');
 					return false;
 				}
 
-				$info['playtime_seconds'] += (($thisfile_midi['totalticks'] - $previoustickoffset) / $thisfile_midi_raw['ticksperqnote']) * ($microsecondsperbeat / 1000000);
+				$info['playtime_seconds'] += (($thisfile_midi['totalticks'] - $previoustickoffset) / $thisfile_midi_raw['ticksperqnote']) * ($prevmicrosecondsperbeat / 1000000);
 
 			}
 		}
@@ -322,6 +341,11 @@ class getid3_midi extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int $instrumentid
+	 *
+	 * @return string
+	 */
 	public function GeneralMIDIinstrumentLookup($instrumentid) {
 
 		$begin = __LINE__;
@@ -462,6 +486,11 @@ class getid3_midi extends getid3_handler
 		return getid3_lib::EmbeddedLookup($instrumentid, $begin, __LINE__, __FILE__, 'GeneralMIDIinstrument');
 	}
 
+	/**
+	 * @param int $instrumentid
+	 *
+	 * @return string
+	 */
 	public function GeneralMIDIpercussionLookup($instrumentid) {
 
 		$begin = __LINE__;

--- a/application/libraries/getid3/module.audio.mod.php
+++ b/application/libraries/getid3/module.audio.mod.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.mod.php                                        //
@@ -13,14 +14,19 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_mod extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$fileheader = fread($this->getid3->fp, 1088);
+		$this->fseek($info['avdataoffset']);
+		$fileheader = $this->fread(1088);
 		if (preg_match('#^IMPM#', $fileheader)) {
 			return $this->getITheaderFilepointer();
 		} elseif (preg_match('#^Extended Module#', $fileheader)) {
@@ -30,68 +36,79 @@ class getid3_mod extends getid3_handler
 		} elseif (preg_match('#^.{1080}(M\\.K\\.|M!K!|FLT4|FLT8|[5-9]CHN|[1-3][0-9]CH)#', $fileheader)) {
 			return $this->getMODheaderFilepointer();
 		}
-		$info['error'][] = 'This is not a known type of MOD file';
+		$this->error('This is not a known type of MOD file');
 		return false;
 	}
 
-
+	/**
+	 * @return bool
+	 */
 	public function getMODheaderFilepointer() {
 		$info = &$this->getid3->info;
-		fseek($this->getid3->fp, $info['avdataoffset'] + 1080);
-		$FormatID = fread($this->getid3->fp, 4);
+		$this->fseek($info['avdataoffset'] + 1080);
+		$FormatID = $this->fread(4);
 		if (!preg_match('#^(M.K.|[5-9]CHN|[1-3][0-9]CH)$#', $FormatID)) {
-			$info['error'][] = 'This is not a known type of MOD file';
+			$this->error('This is not a known type of MOD file');
 			return false;
 		}
 
 		$info['fileformat'] = 'mod';
 
-		$info['error'][] = 'MOD parsing not enabled in this version of getID3() ['.$this->getid3->version().']';
+		$this->error('MOD parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
 		return false;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function getXMheaderFilepointer() {
 		$info = &$this->getid3->info;
-		fseek($this->getid3->fp, $info['avdataoffset']);
-		$FormatID = fread($this->getid3->fp, 15);
+		$this->fseek($info['avdataoffset']);
+		$FormatID = $this->fread(15);
 		if (!preg_match('#^Extended Module$#', $FormatID)) {
-			$info['error'][] = 'This is not a known type of XM-MOD file';
+			$this->error('This is not a known type of XM-MOD file');
 			return false;
 		}
 
 		$info['fileformat'] = 'xm';
 
-		$info['error'][] = 'XM-MOD parsing not enabled in this version of getID3() ['.$this->getid3->version().']';
+		$this->error('XM-MOD parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
 		return false;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function getS3MheaderFilepointer() {
 		$info = &$this->getid3->info;
-		fseek($this->getid3->fp, $info['avdataoffset'] + 44);
-		$FormatID = fread($this->getid3->fp, 4);
+		$this->fseek($info['avdataoffset'] + 44);
+		$FormatID = $this->fread(4);
 		if (!preg_match('#^SCRM$#', $FormatID)) {
-			$info['error'][] = 'This is not a ScreamTracker MOD file';
+			$this->error('This is not a ScreamTracker MOD file');
 			return false;
 		}
 
 		$info['fileformat'] = 's3m';
 
-		$info['error'][] = 'ScreamTracker parsing not enabled in this version of getID3() ['.$this->getid3->version().']';
+		$this->error('ScreamTracker parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
 		return false;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function getITheaderFilepointer() {
 		$info = &$this->getid3->info;
-		fseek($this->getid3->fp, $info['avdataoffset']);
-		$FormatID = fread($this->getid3->fp, 4);
+		$this->fseek($info['avdataoffset']);
+		$FormatID = $this->fread(4);
 		if (!preg_match('#^IMPM$#', $FormatID)) {
-			$info['error'][] = 'This is not an ImpulseTracker MOD file';
+			$this->error('This is not an ImpulseTracker MOD file');
 			return false;
 		}
 
 		$info['fileformat'] = 'it';
 
-		$info['error'][] = 'ImpulseTracker parsing not enabled in this version of getID3() ['.$this->getid3->version().']';
+		$this->error('ImpulseTracker parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
 		return false;
 	}
 

--- a/application/libraries/getid3/module.audio.monkey.php
+++ b/application/libraries/getid3/module.audio.monkey.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.monkey.php                                     //
@@ -13,14 +14,19 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_monkey extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		// based loosely on code from TMonkey by Jurgen Faul <jfaulØgmx*de>
+		// based loosely on code from TMonkey by Jurgen Faul <jfaulÃ˜gmx*de>
 		// http://jfaul.de/atl  or  http://j-faul.virtualave.net/atl/atl.html
 
 		$info['fileformat']            = 'mac';
@@ -32,13 +38,13 @@ class getid3_monkey extends getid3_handler
 		$thisfile_monkeysaudio                = &$info['monkeys_audio'];
 		$thisfile_monkeysaudio_raw            = &$thisfile_monkeysaudio['raw'];
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$MACheaderData = fread($this->getid3->fp, 74);
+		$this->fseek($info['avdataoffset']);
+		$MACheaderData = $this->fread(74);
 
 		$thisfile_monkeysaudio_raw['magic'] = substr($MACheaderData, 0, 4);
 		$magic = 'MAC ';
 		if ($thisfile_monkeysaudio_raw['magic'] != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($thisfile_monkeysaudio_raw['magic']).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($thisfile_monkeysaudio_raw['magic']).'"');
 			unset($info['fileformat']);
 			return false;
 		}
@@ -111,7 +117,7 @@ class getid3_monkey extends getid3_handler
 		$info['audio']['channels']               = $thisfile_monkeysaudio['channels'];
 		$thisfile_monkeysaudio['sample_rate']            = $thisfile_monkeysaudio_raw['nSampleRate'];
 		if ($thisfile_monkeysaudio['sample_rate'] == 0) {
-			$info['error'][] = 'Corrupt MAC file: frequency == zero';
+			$this->error('Corrupt MAC file: frequency == zero');
 			return false;
 		}
 		$info['audio']['sample_rate']            = $thisfile_monkeysaudio['sample_rate'];
@@ -126,14 +132,14 @@ class getid3_monkey extends getid3_handler
 		}
 		$thisfile_monkeysaudio['playtime']               = $thisfile_monkeysaudio['samples'] / $thisfile_monkeysaudio['sample_rate'];
 		if ($thisfile_monkeysaudio['playtime'] == 0) {
-			$info['error'][] = 'Corrupt MAC file: playtime == zero';
+			$this->error('Corrupt MAC file: playtime == zero');
 			return false;
 		}
 		$info['playtime_seconds']                = $thisfile_monkeysaudio['playtime'];
 		$thisfile_monkeysaudio['compressed_size']        = $info['avdataend'] - $info['avdataoffset'];
 		$thisfile_monkeysaudio['uncompressed_size']      = $thisfile_monkeysaudio['samples'] * $thisfile_monkeysaudio['channels'] * ($thisfile_monkeysaudio['bits_per_sample'] / 8);
 		if ($thisfile_monkeysaudio['uncompressed_size'] == 0) {
-			$info['error'][] = 'Corrupt MAC file: uncompressed_size == zero';
+			$this->error('Corrupt MAC file: uncompressed_size == zero');
 			return false;
 		}
 		$thisfile_monkeysaudio['compression_ratio']      = $thisfile_monkeysaudio['compressed_size'] / ($thisfile_monkeysaudio['uncompressed_size'] + $thisfile_monkeysaudio_raw['nHeaderDataBytes']);
@@ -154,12 +160,12 @@ class getid3_monkey extends getid3_handler
 
 		if ($thisfile_monkeysaudio_raw['nVersion'] >= 3980) {
 			if ($thisfile_monkeysaudio_raw['cFileMD5'] === str_repeat("\x00", 16)) {
-				//$info['warning'][] = 'cFileMD5 is null';
+				//$this->warning('cFileMD5 is null');
 			} else {
 				$info['md5_data_source'] = '';
 				$md5 = $thisfile_monkeysaudio_raw['cFileMD5'];
 				for ($i = 0; $i < strlen($md5); $i++) {
-					$info['md5_data_source'] .= str_pad(dechex(ord($md5{$i})), 2, '00', STR_PAD_LEFT);
+					$info['md5_data_source'] .= str_pad(dechex(ord($md5[$i])), 2, '00', STR_PAD_LEFT);
 				}
 				if (!preg_match('/^[0-9a-f]{32}$/', $info['md5_data_source'])) {
 					unset($info['md5_data_source']);
@@ -176,6 +182,11 @@ class getid3_monkey extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int $compressionlevel
+	 *
+	 * @return string
+	 */
 	public function MonkeyCompressionLevelNameLookup($compressionlevel) {
 		static $MonkeyCompressionLevelNameLookup = array(
 			0     => 'unknown',
@@ -188,6 +199,12 @@ class getid3_monkey extends getid3_handler
 		return (isset($MonkeyCompressionLevelNameLookup[$compressionlevel]) ? $MonkeyCompressionLevelNameLookup[$compressionlevel] : 'invalid');
 	}
 
+	/**
+	 * @param int $versionid
+	 * @param int $compressionlevel
+	 *
+	 * @return int
+	 */
 	public function MonkeySamplesPerFrame($versionid, $compressionlevel) {
 		if ($versionid >= 3950) {
 			return 73728 * 4;

--- a/application/libraries/getid3/module.audio.mp3.php
+++ b/application/libraries/getid3/module.audio.mp3.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.mp3.php                                        //
@@ -13,6 +14,9 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 // number of frames to scan to determine if MPEG-audio sequence is valid
 // Lower this number to 5-20 for faster scanning
@@ -23,9 +27,17 @@ define('GETID3_MP3_VALID_CHECK_FRAMES', 35);
 
 class getid3_mp3 extends getid3_handler
 {
+	/**
+	 * Forces getID3() to scan the file byte-by-byte and log all the valid audio frame headers - extremely slow,
+	 * unrecommended, but may provide data from otherwise-unusable files.
+	 *
+	 * @var bool
+	 */
+	public $allow_bruteforce = false;
 
-	public $allow_bruteforce = false; // forces getID3() to scan the file byte-by-byte and log all the valid audio frame headers - extremely slow, unrecommended, but may provide data from otherwise-unusuable files
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -33,8 +45,8 @@ class getid3_mp3 extends getid3_handler
 
 		if (!$this->getOnlyMPEGaudioInfo($info['avdataoffset'])) {
 			if ($this->allow_bruteforce) {
-				$info['error'][] = 'Rescanning file in BruteForce mode';
-				$this->getOnlyMPEGaudioInfoBruteForce($this->getid3->fp, $info);
+				$this->error('Rescanning file in BruteForce mode');
+				$this->getOnlyMPEGaudioInfoBruteForce();
 			}
 		}
 
@@ -71,7 +83,7 @@ class getid3_mp3 extends getid3_handler
 				}
 
 			}
-			$info['warning'][] = $synchoffsetwarning;
+			$this->warning($synchoffsetwarning);
 
 		}
 
@@ -95,8 +107,8 @@ class getid3_mp3 extends getid3_handler
 
 			// Not sure what version of LAME this is - look in padding of last frame for longer version string
 			$PossibleLAMEversionStringOffset = $info['avdataend'] - $PossiblyLongerLAMEversion_FrameLength;
-			fseek($this->getid3->fp, $PossibleLAMEversionStringOffset);
-			$PossiblyLongerLAMEversion_Data = fread($this->getid3->fp, $PossiblyLongerLAMEversion_FrameLength);
+			$this->fseek($PossibleLAMEversionStringOffset);
+			$PossiblyLongerLAMEversion_Data = $this->fread($PossiblyLongerLAMEversion_FrameLength);
 			switch (substr($CurrentDataLAMEversionString, -1)) {
 				case 'a':
 				case 'b':
@@ -133,7 +145,7 @@ class getid3_mp3 extends getid3_handler
 					break;
 
 				default:
-					$info['warning'][] = 'Expecting [audio][dataformat] to be mp1/mp2/mp3 when fileformat == mp3, [audio][dataformat] actually "'.$info['audio']['dataformat'].'"';
+					$this->warning('Expecting [audio][dataformat] to be mp1/mp2/mp3 when fileformat == mp3, [audio][dataformat] actually "'.$info['audio']['dataformat'].'"');
 					break;
 			}
 		}
@@ -151,7 +163,11 @@ class getid3_mp3 extends getid3_handler
 
 		// Calculate playtime
 		if (!isset($info['playtime_seconds']) && isset($info['audio']['bitrate']) && ($info['audio']['bitrate'] > 0)) {
-			$info['playtime_seconds'] = ($info['avdataend'] - $info['avdataoffset']) * 8 / $info['audio']['bitrate'];
+			// https://github.com/JamesHeinrich/getID3/issues/161
+			// VBR header frame contains ~0.026s of silent audio data, but is not actually part of the original encoding and should be ignored
+			$xingVBRheaderFrameLength = ((isset($info['mpeg']['audio']['VBR_frames']) && isset($info['mpeg']['audio']['framelength'])) ? $info['mpeg']['audio']['framelength'] : 0);
+
+			$info['playtime_seconds'] = ($info['avdataend'] - $info['avdataoffset'] - $xingVBRheaderFrameLength) * 8 / $info['audio']['bitrate'];
 		}
 
 		$info['audio']['encoder_options'] = $this->GuessEncoderOptions();
@@ -159,10 +175,14 @@ class getid3_mp3 extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @return string
+	 */
 	public function GuessEncoderOptions() {
 		// shortcuts
 		$info = &$this->getid3->info;
+		$thisfile_mpeg_audio = array();
+		$thisfile_mpeg_audio_lame = array();
 		if (!empty($info['mpeg']['audio'])) {
 			$thisfile_mpeg_audio = &$info['mpeg']['audio'];
 			if (!empty($thisfile_mpeg_audio['LAME'])) {
@@ -177,7 +197,7 @@ class getid3_mp3 extends getid3_handler
 
 			$encoder_options = 'VBR q'.$thisfile_mpeg_audio['VBR_quality'];
 
-		} elseif (!empty($thisfile_mpeg_audio_lame['preset_used']) && (!in_array($thisfile_mpeg_audio_lame['preset_used_id'], $NamedPresetBitrates))) {
+		} elseif (!empty($thisfile_mpeg_audio_lame['preset_used']) && isset($thisfile_mpeg_audio_lame['preset_used_id']) && (!in_array($thisfile_mpeg_audio_lame['preset_used_id'], $NamedPresetBitrates))) {
 
 			$encoder_options = $thisfile_mpeg_audio_lame['preset_used'];
 
@@ -403,7 +423,15 @@ class getid3_mp3 extends getid3_handler
 		return $encoder_options;
 	}
 
-
+	/**
+	 * @param int   $offset
+	 * @param array $info
+	 * @param bool  $recursivesearch
+	 * @param bool  $ScanAsCBR
+	 * @param bool  $FastMPEGheaderScan
+	 *
+	 * @return bool
+	 */
 	public function decodeMPEGaudioHeader($offset, &$info, $recursivesearch=true, $ScanAsCBR=false, $FastMPEGheaderScan=false) {
 		static $MPEGaudioVersionLookup;
 		static $MPEGaudioLayerLookup;
@@ -422,12 +450,12 @@ class getid3_mp3 extends getid3_handler
 			$MPEGaudioEmphasisLookup      = self::MPEGaudioEmphasisArray();
 		}
 
-		if (fseek($this->getid3->fp, $offset, SEEK_SET) != 0) {
-			$info['error'][] = 'decodeMPEGaudioHeader() failed to seek to next offset at '.$offset;
+		if ($this->fseek($offset) != 0) {
+			$this->error('decodeMPEGaudioHeader() failed to seek to next offset at '.$offset);
 			return false;
 		}
-		//$headerstring = fread($this->getid3->fp, 1441); // worst-case max length = 32kHz @ 320kbps layer 3 = 1441 bytes/frame
-		$headerstring = fread($this->getid3->fp, 226); // LAME header at offset 36 + 190 bytes of Xing/LAME data
+		//$headerstring = $this->fread(1441); // worst-case max length = 32kHz @ 320kbps layer 3 = 1441 bytes/frame
+		$headerstring = $this->fread(226); // LAME header at offset 36 + 190 bytes of Xing/LAME data
 
 		// MP3 audio frame structure:
 		// $aa $aa $aa $aa [$bb $bb] $cc...
@@ -436,19 +464,19 @@ class getid3_mp3 extends getid3_handler
 		// and $cc... is the audio data
 
 		$head4 = substr($headerstring, 0, 4);
-
+		$head4_key = getid3_lib::PrintHexBytes($head4, true, false, false);
 		static $MPEGaudioHeaderDecodeCache = array();
-		if (isset($MPEGaudioHeaderDecodeCache[$head4])) {
-			$MPEGheaderRawArray = $MPEGaudioHeaderDecodeCache[$head4];
+		if (isset($MPEGaudioHeaderDecodeCache[$head4_key])) {
+			$MPEGheaderRawArray = $MPEGaudioHeaderDecodeCache[$head4_key];
 		} else {
 			$MPEGheaderRawArray = self::MPEGaudioHeaderDecode($head4);
-			$MPEGaudioHeaderDecodeCache[$head4] = $MPEGheaderRawArray;
+			$MPEGaudioHeaderDecodeCache[$head4_key] = $MPEGheaderRawArray;
 		}
 
 		static $MPEGaudioHeaderValidCache = array();
-		if (!isset($MPEGaudioHeaderValidCache[$head4])) { // Not in cache
-			//$MPEGaudioHeaderValidCache[$head4] = self::MPEGaudioHeaderValid($MPEGheaderRawArray, false, true);  // allow badly-formatted freeformat (from LAME 3.90 - 3.93.1)
-			$MPEGaudioHeaderValidCache[$head4] = self::MPEGaudioHeaderValid($MPEGheaderRawArray, false, false);
+		if (!isset($MPEGaudioHeaderValidCache[$head4_key])) { // Not in cache
+			//$MPEGaudioHeaderValidCache[$head4_key] = self::MPEGaudioHeaderValid($MPEGheaderRawArray, false, true);  // allow badly-formatted freeformat (from LAME 3.90 - 3.93.1)
+			$MPEGaudioHeaderValidCache[$head4_key] = self::MPEGaudioHeaderValid($MPEGheaderRawArray, false, false);
 		}
 
 		// shortcut
@@ -457,11 +485,10 @@ class getid3_mp3 extends getid3_handler
 		}
 		$thisfile_mpeg_audio = &$info['mpeg']['audio'];
 
-
-		if ($MPEGaudioHeaderValidCache[$head4]) {
+		if ($MPEGaudioHeaderValidCache[$head4_key]) {
 			$thisfile_mpeg_audio['raw'] = $MPEGheaderRawArray;
 		} else {
-			$info['error'][] = 'Invalid MPEG audio header ('.getid3_lib::PrintHexBytes($head4).') at offset '.$offset;
+			$this->error('Invalid MPEG audio header ('.getid3_lib::PrintHexBytes($head4).') at offset '.$offset);
 			return false;
 		}
 
@@ -489,7 +516,7 @@ class getid3_mp3 extends getid3_handler
 
 		if ($thisfile_mpeg_audio['raw']['bitrate'] == 15) {
 			// http://www.hydrogenaudio.org/?act=ST&f=16&t=9682&st=0
-			$info['warning'][] = 'Invalid bitrate index (15), this is a known bug in free-format MP3s encoded by LAME v3.90 - 3.93.1';
+			$this->warning('Invalid bitrate index (15), this is a known bug in free-format MP3s encoded by LAME v3.90 - 3.93.1');
 			$thisfile_mpeg_audio['raw']['bitrate'] = 0;
 		}
 		$thisfile_mpeg_audio['padding'] = (bool) $thisfile_mpeg_audio['raw']['padding'];
@@ -511,7 +538,7 @@ class getid3_mp3 extends getid3_handler
 					if (($thisfile_mpeg_audio['bitrate'] == 'free') || ($thisfile_mpeg_audio['bitrate'] <= 192000)) {
 						// these are ok
 					} else {
-						$info['error'][] = $thisfile_mpeg_audio['bitrate'].'kbps not allowed in Layer 2, '.$thisfile_mpeg_audio['channelmode'].'.';
+						$this->error($thisfile_mpeg_audio['bitrate'].'kbps not allowed in Layer 2, '.$thisfile_mpeg_audio['channelmode'].'.');
 						return false;
 					}
 					break;
@@ -522,7 +549,7 @@ class getid3_mp3 extends getid3_handler
 					if (($thisfile_mpeg_audio['bitrate'] == 'free') || ($thisfile_mpeg_audio['bitrate'] == 64000) || ($thisfile_mpeg_audio['bitrate'] >= 96000)) {
 						// these are ok
 					} else {
-						$info['error'][] = intval(round($thisfile_mpeg_audio['bitrate'] / 1000)).'kbps not allowed in Layer 2, '.$thisfile_mpeg_audio['channelmode'].'.';
+						$this->error(intval(round($thisfile_mpeg_audio['bitrate'] / 1000)).'kbps not allowed in Layer 2, '.$thisfile_mpeg_audio['channelmode'].'.');
 						return false;
 					}
 					break;
@@ -544,7 +571,7 @@ class getid3_mp3 extends getid3_handler
 			if (isset($thisfile_mpeg_audio['framelength'])) {
 				$nextframetestoffset = $offset + $thisfile_mpeg_audio['framelength'];
 			} else {
-				$info['error'][] = 'Frame at offset('.$offset.') is has an invalid frame length.';
+				$this->error('Frame at offset('.$offset.') is has an invalid frame length.');
 				return false;
 			}
 
@@ -561,7 +588,7 @@ class getid3_mp3 extends getid3_handler
 
 			$thisfile_mpeg_audio['bitrate_mode'] = 'vbr';
 			$thisfile_mpeg_audio['VBR_method']   = 'Fraunhofer';
-			$info['audio']['codec']                = 'Fraunhofer';
+			$info['audio']['codec']              = 'Fraunhofer';
 
 			$SideInfoData = substr($headerstring, 4 + 2, 32);
 
@@ -647,9 +674,20 @@ class getid3_mp3 extends getid3_handler
 				}
 
 				//if (($thisfile_mpeg_audio['bitrate'] == 'free') && !empty($thisfile_mpeg_audio['VBR_frames']) && !empty($thisfile_mpeg_audio['VBR_bytes'])) {
-				if (!empty($thisfile_mpeg_audio['VBR_frames']) && !empty($thisfile_mpeg_audio['VBR_bytes'])) {
+				//if (!empty($thisfile_mpeg_audio['VBR_frames']) && !empty($thisfile_mpeg_audio['VBR_bytes'])) {
+				if (!empty($thisfile_mpeg_audio['VBR_frames'])) {
+					$used_filesize  = 0;
+					if (!empty($thisfile_mpeg_audio['VBR_bytes'])) {
+						$used_filesize = $thisfile_mpeg_audio['VBR_bytes'];
+					} elseif (!empty($info['filesize'])) {
+						$used_filesize  = $info['filesize'];
+						$used_filesize -= (isset($info['id3v2']['headerlength']) ? intval($info['id3v2']['headerlength']) : 0);
+						$used_filesize -= (isset($info['id3v1']) ? 128 : 0);
+						$used_filesize -= (isset($info['tag_offset_end']) ? $info['tag_offset_end'] - $info['tag_offset_start'] : 0);
+						$this->warning('MP3.Xing header missing VBR_bytes, assuming MPEG audio portion of file is '.number_format($used_filesize).' bytes');
+					}
 
-					$framelengthfloat = $thisfile_mpeg_audio['VBR_bytes'] / $thisfile_mpeg_audio['VBR_frames'];
+					$framelengthfloat = $used_filesize / $thisfile_mpeg_audio['VBR_frames'];
 
 					if ($thisfile_mpeg_audio['layer'] == '1') {
 						// BitRate = (((FrameLengthInBytes / 4) - Padding) * SampleRate) / 12
@@ -666,7 +704,7 @@ class getid3_mp3 extends getid3_handler
 				if ($thisfile_mpeg_audio['xing_flags']['toc']) {
 					$LAMEtocData = substr($headerstring, $VBRidOffset + 16, 100);
 					for ($i = 0; $i < 100; $i++) {
-						$thisfile_mpeg_audio['toc'][$i] = ord($LAMEtocData{$i});
+						$thisfile_mpeg_audio['toc'][$i] = ord($LAMEtocData[$i]);
 					}
 				}
 				if ($thisfile_mpeg_audio['xing_flags']['vbr_scale']) {
@@ -684,8 +722,17 @@ class getid3_mp3 extends getid3_handler
 
 					$thisfile_mpeg_audio_lame['long_version']  = substr($headerstring, $VBRidOffset + 120, 20);
 					$thisfile_mpeg_audio_lame['short_version'] = substr($thisfile_mpeg_audio_lame['long_version'], 0, 9);
+					$thisfile_mpeg_audio_lame['numeric_version'] = str_replace('LAME', '', $thisfile_mpeg_audio_lame['short_version']);
+					if (preg_match('#^LAME([0-9\\.a-z]+)#', $thisfile_mpeg_audio_lame['long_version'], $matches)) {
+						$thisfile_mpeg_audio_lame['short_version']   = $matches[0];
+						$thisfile_mpeg_audio_lame['numeric_version'] = $matches[1];
+					}
+					foreach (explode('.', $thisfile_mpeg_audio_lame['numeric_version']) as $key => $number) {
+						$thisfile_mpeg_audio_lame['integer_version'][$key] = intval($number);
+					}
 
-					if ($thisfile_mpeg_audio_lame['short_version'] >= 'LAME3.90') {
+					//if ($thisfile_mpeg_audio_lame['short_version'] >= 'LAME3.90') {
+					if ((($thisfile_mpeg_audio_lame['integer_version'][0] * 1000) + $thisfile_mpeg_audio_lame['integer_version'][1]) >= 3090) { // cannot use string version compare, may have "LAME3.90" or "LAME3.100" -- see https://github.com/JamesHeinrich/getID3/issues/207
 
 						// extra 11 chars are not part of version string when LAMEtag present
 						unset($thisfile_mpeg_audio_lame['long_version']);
@@ -836,7 +883,7 @@ class getid3_mp3 extends getid3_handler
 						$thisfile_mpeg_audio_lame['preset_used_id']    = ($PresetSurroundBytes & 0x07FF);
 						$thisfile_mpeg_audio_lame['preset_used']       = self::LAMEpresetUsedLookup($thisfile_mpeg_audio_lame);
 						if (!empty($thisfile_mpeg_audio_lame['preset_used_id']) && empty($thisfile_mpeg_audio_lame['preset_used'])) {
-							$info['warning'][] = 'Unknown LAME preset used ('.$thisfile_mpeg_audio_lame['preset_used_id'].') - please report to info@getid3.org';
+							$this->warning('Unknown LAME preset used ('.$thisfile_mpeg_audio_lame['preset_used_id'].') - please report to info@getid3.org');
 						}
 						if (($thisfile_mpeg_audio_lame['short_version'] == 'LAME3.90.') && !empty($thisfile_mpeg_audio_lame['preset_used_id'])) {
 							// this may change if 3.90.4 ever comes out
@@ -880,7 +927,7 @@ class getid3_mp3 extends getid3_handler
 						$thisfile_mpeg_audio['bitrate_mode'] = 'cbr';
 					}
 					if ($thisfile_mpeg_audio['bitrate_mode'] == 'vbr') {
-						$info['warning'][] = 'VBR file with no VBR header. Bitrate values calculated from actual frame bitrates.';
+						$this->warning('VBR file with no VBR header. Bitrate values calculated from actual frame bitrates.');
 					}
 				}
 
@@ -890,27 +937,29 @@ class getid3_mp3 extends getid3_handler
 
 		if (($ExpectedNumberOfAudioBytes > 0) && ($ExpectedNumberOfAudioBytes != ($info['avdataend'] - $info['avdataoffset']))) {
 			if ($ExpectedNumberOfAudioBytes > ($info['avdataend'] - $info['avdataoffset'])) {
-				if (isset($info['fileformat']) && ($info['fileformat'] == 'riff')) {
+				if ($this->isDependencyFor('matroska') || $this->isDependencyFor('riff')) {
 					// ignore, audio data is broken into chunks so will always be data "missing"
-				} elseif (($ExpectedNumberOfAudioBytes - ($info['avdataend'] - $info['avdataoffset'])) == 1) {
-					$info['warning'][] = 'Last byte of data truncated (this is a known bug in Meracl ID3 Tag Writer before v1.3.5)';
-				} else {
-					$info['warning'][] = 'Probable truncated file: expecting '.$ExpectedNumberOfAudioBytes.' bytes of audio data, only found '.($info['avdataend'] - $info['avdataoffset']).' (short by '.($ExpectedNumberOfAudioBytes - ($info['avdataend'] - $info['avdataoffset'])).' bytes)';
+				}
+				elseif (($ExpectedNumberOfAudioBytes - ($info['avdataend'] - $info['avdataoffset'])) == 1) {
+					$this->warning('Last byte of data truncated (this is a known bug in Meracl ID3 Tag Writer before v1.3.5)');
+				}
+				else {
+					$this->warning('Probable truncated file: expecting '.$ExpectedNumberOfAudioBytes.' bytes of audio data, only found '.($info['avdataend'] - $info['avdataoffset']).' (short by '.($ExpectedNumberOfAudioBytes - ($info['avdataend'] - $info['avdataoffset'])).' bytes)');
 				}
 			} else {
 				if ((($info['avdataend'] - $info['avdataoffset']) - $ExpectedNumberOfAudioBytes) == 1) {
-				//	$prenullbytefileoffset = ftell($this->getid3->fp);
-				//	fseek($this->getid3->fp, $info['avdataend'], SEEK_SET);
-				//	$PossibleNullByte = fread($this->getid3->fp, 1);
-				//	fseek($this->getid3->fp, $prenullbytefileoffset, SEEK_SET);
+				//	$prenullbytefileoffset = $this->ftell();
+				//	$this->fseek($info['avdataend']);
+				//	$PossibleNullByte = $this->fread(1);
+				//	$this->fseek($prenullbytefileoffset);
 				//	if ($PossibleNullByte === "\x00") {
 						$info['avdataend']--;
-				//		$info['warning'][] = 'Extra null byte at end of MP3 data assumed to be RIFF padding and therefore ignored';
+				//		$this->warning('Extra null byte at end of MP3 data assumed to be RIFF padding and therefore ignored');
 				//	} else {
-				//		$info['warning'][] = 'Too much data in file: expecting '.$ExpectedNumberOfAudioBytes.' bytes of audio data, found '.($info['avdataend'] - $info['avdataoffset']).' ('.(($info['avdataend'] - $info['avdataoffset']) - $ExpectedNumberOfAudioBytes).' bytes too many)';
+				//		$this->warning('Too much data in file: expecting '.$ExpectedNumberOfAudioBytes.' bytes of audio data, found '.($info['avdataend'] - $info['avdataoffset']).' ('.(($info['avdataend'] - $info['avdataoffset']) - $ExpectedNumberOfAudioBytes).' bytes too many)');
 				//	}
 				} else {
-					$info['warning'][] = 'Too much data in file: expecting '.$ExpectedNumberOfAudioBytes.' bytes of audio data, found '.($info['avdataend'] - $info['avdataoffset']).' ('.(($info['avdataend'] - $info['avdataoffset']) - $ExpectedNumberOfAudioBytes).' bytes too many)';
+					$this->warning('Too much data in file: expecting '.$ExpectedNumberOfAudioBytes.' bytes of audio data, found '.($info['avdataend'] - $info['avdataoffset']).' ('.(($info['avdataend'] - $info['avdataoffset']) - $ExpectedNumberOfAudioBytes).' bytes too many)');
 				}
 			}
 		}
@@ -928,7 +977,7 @@ class getid3_mp3 extends getid3_handler
 						$info['audio']['bitrate'] = (($framebytelength - intval($thisfile_mpeg_audio['padding'])) * $thisfile_mpeg_audio['sample_rate']) / 144;
 					}
 				} else {
-					$info['error'][] = 'Error calculating frame length of free-format MP3 without Xing/LAME header';
+					$this->error('Error calculating frame length of free-format MP3 without Xing/LAME header');
 				}
 			}
 		}
@@ -945,7 +994,7 @@ class getid3_mp3 extends getid3_handler
 					}
 					$thisfile_mpeg_audio['VBR_bitrate'] = (isset($thisfile_mpeg_audio['VBR_bytes']) ? (($thisfile_mpeg_audio['VBR_bytes'] / $thisfile_mpeg_audio['VBR_frames']) * 8) * ($info['audio']['sample_rate'] / $bytes_per_frame) : 0);
 					if ($thisfile_mpeg_audio['VBR_bitrate'] > 0) {
-						$info['audio']['bitrate']         = $thisfile_mpeg_audio['VBR_bitrate'];
+						$info['audio']['bitrate']       = $thisfile_mpeg_audio['VBR_bitrate'];
 						$thisfile_mpeg_audio['bitrate'] = $thisfile_mpeg_audio['VBR_bitrate']; // to avoid confusion
 					}
 					break;
@@ -1069,9 +1118,16 @@ class getid3_mp3 extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int $offset
+	 * @param int $nextframetestoffset
+	 * @param bool $ScanAsCBR
+	 *
+	 * @return bool
+	 */
 	public function RecursiveFrameScanning(&$offset, &$nextframetestoffset, $ScanAsCBR) {
 		$info = &$this->getid3->info;
-		$firstframetestarray = array('error'=>'', 'warning'=>'', 'avdataend'=>$info['avdataend'], 'avdataoffset'=>$info['avdataoffset']);
+		$firstframetestarray = array('error' => array(), 'warning'=> array(), 'avdataend' => $info['avdataend'], 'avdataoffset' => $info['avdataoffset']);
 		$this->decodeMPEGaudioHeader($offset, $firstframetestarray, false);
 
 		for ($i = 0; $i < GETID3_MP3_VALID_CHECK_FRAMES; $i++) {
@@ -1081,7 +1137,7 @@ class getid3_mp3 extends getid3_handler
 				return true;
 			}
 
-			$nextframetestarray = array('error'=>'', 'warning'=>'', 'avdataend'=>$info['avdataend'], 'avdataoffset'=>$info['avdataoffset']);
+			$nextframetestarray = array('error' => array(), 'warning' => array(), 'avdataend' => $info['avdataend'], 'avdataoffset'=>$info['avdataoffset']);
 			if ($this->decodeMPEGaudioHeader($nextframetestoffset, $nextframetestarray, false)) {
 				if ($ScanAsCBR) {
 					// force CBR mode, used for trying to pick out invalid audio streams with valid(?) VBR headers, or VBR streams with no VBR header
@@ -1095,7 +1151,7 @@ class getid3_mp3 extends getid3_handler
 				if (isset($nextframetestarray['mpeg']['audio']['framelength']) && ($nextframetestarray['mpeg']['audio']['framelength'] > 0)) {
 					$nextframetestoffset += $nextframetestarray['mpeg']['audio']['framelength'];
 				} else {
-					$info['error'][] = 'Frame at offset ('.$offset.') is has an invalid frame length.';
+					$this->error('Frame at offset ('.$offset.') is has an invalid frame length.');
 					return false;
 				}
 
@@ -1107,7 +1163,7 @@ class getid3_mp3 extends getid3_handler
 			} else {
 
 				// next frame is not valid, note the error and fail, so scanning can contiue for a valid frame sequence
-				$info['warning'][] = 'Frame at offset ('.$offset.') is valid, but the next one at ('.$nextframetestoffset.') is not.';
+				$this->warning('Frame at offset ('.$offset.') is valid, but the next one at ('.$nextframetestoffset.') is not.');
 
 				return false;
 			}
@@ -1115,17 +1171,23 @@ class getid3_mp3 extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int  $offset
+	 * @param bool $deepscan
+	 *
+	 * @return int|false
+	 */
 	public function FreeFormatFrameLength($offset, $deepscan=false) {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $offset, SEEK_SET);
-		$MPEGaudioData = fread($this->getid3->fp, 32768);
+		$this->fseek($offset);
+		$MPEGaudioData = $this->fread(32768);
 
 		$SyncPattern1 = substr($MPEGaudioData, 0, 4);
 		// may be different pattern due to padding
-		$SyncPattern2 = $SyncPattern1{0}.$SyncPattern1{1}.chr(ord($SyncPattern1{2}) | 0x02).$SyncPattern1{3};
+		$SyncPattern2 = $SyncPattern1[0].$SyncPattern1[1].chr(ord($SyncPattern1[2]) | 0x02).$SyncPattern1[3];
 		if ($SyncPattern2 === $SyncPattern1) {
-			$SyncPattern2 = $SyncPattern1{0}.$SyncPattern1{1}.chr(ord($SyncPattern1{2}) & 0xFD).$SyncPattern1{3};
+			$SyncPattern2 = $SyncPattern1[0].$SyncPattern1[1].chr(ord($SyncPattern1[2]) & 0xFD).$SyncPattern1[3];
 		}
 
 		$framelength = false;
@@ -1150,10 +1212,10 @@ class getid3_mp3 extends getid3_handler
 				$framelength = $framelength2;
 			}
 			if (!$framelength) {
-				$info['error'][] = 'Cannot find next free-format synch pattern ('.getid3_lib::PrintHexBytes($SyncPattern1).' or '.getid3_lib::PrintHexBytes($SyncPattern2).') after offset '.$offset;
+				$this->error('Cannot find next free-format synch pattern ('.getid3_lib::PrintHexBytes($SyncPattern1).' or '.getid3_lib::PrintHexBytes($SyncPattern2).') after offset '.$offset);
 				return false;
 			} else {
-				$info['warning'][] = 'ModeExtension varies between first frame and other frames (known free-format issue in LAME 3.88)';
+				$this->warning('ModeExtension varies between first frame and other frames (known free-format issue in LAME 3.88)');
 				$info['audio']['codec']   = 'LAME';
 				$info['audio']['encoder'] = 'LAME3.88';
 				$SyncPattern1 = substr($SyncPattern1, 0, 3);
@@ -1166,8 +1228,8 @@ class getid3_mp3 extends getid3_handler
 			$ActualFrameLengthValues = array();
 			$nextoffset = $offset + $framelength;
 			while ($nextoffset < ($info['avdataend'] - 6)) {
-				fseek($this->getid3->fp, $nextoffset - 1, SEEK_SET);
-				$NextSyncPattern = fread($this->getid3->fp, 6);
+				$this->fseek($nextoffset - 1);
+				$NextSyncPattern = $this->fread(6);
 				if ((substr($NextSyncPattern, 1, strlen($SyncPattern1)) == $SyncPattern1) || (substr($NextSyncPattern, 1, strlen($SyncPattern2)) == $SyncPattern2)) {
 					// good - found where expected
 					$ActualFrameLengthValues[] = $framelength;
@@ -1180,7 +1242,7 @@ class getid3_mp3 extends getid3_handler
 					$ActualFrameLengthValues[] = ($framelength + 1);
 					$nextoffset++;
 				} else {
-					$info['error'][] = 'Did not find expected free-format sync pattern at offset '.$nextoffset;
+					$this->error('Did not find expected free-format sync pattern at offset '.$nextoffset);
 					return false;
 				}
 				$nextoffset += $framelength;
@@ -1192,6 +1254,9 @@ class getid3_mp3 extends getid3_handler
 		return $framelength;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function getOnlyMPEGaudioInfoBruteForce() {
 		$MPEGaudioHeaderDecodeCache   = array();
 		$MPEGaudioHeaderValidCache    = array();
@@ -1215,22 +1280,22 @@ class getid3_mp3 extends getid3_handler
 		$Distribution['padding']      = array();
 
 		$info = &$this->getid3->info;
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+		$this->fseek($info['avdataoffset']);
 
 		$max_frames_scan = 5000;
 		$frames_scanned  = 0;
 
 		$previousvalidframe = $info['avdataoffset'];
-		while (ftell($this->getid3->fp) < $info['avdataend']) {
+		while ($this->ftell() < $info['avdataend']) {
 			set_time_limit(30);
-			$head4 = fread($this->getid3->fp, 4);
+			$head4 = $this->fread(4);
 			if (strlen($head4) < 4) {
 				break;
 			}
-			if ($head4{0} != "\xFF") {
+			if ($head4[0] != "\xFF") {
 				for ($i = 1; $i < 4; $i++) {
-					if ($head4{$i} == "\xFF") {
-						fseek($this->getid3->fp, $i - 4, SEEK_CUR);
+					if ($head4[$i] == "\xFF") {
+						$this->fseek($i - 4, SEEK_CUR);
 						continue 2;
 					}
 				}
@@ -1258,10 +1323,10 @@ class getid3_mp3 extends getid3_handler
 						$LongMPEGfrequencyLookup[$head4]);
 				}
 				if ($MPEGaudioHeaderLengthCache[$head4] > 4) {
-					$WhereWeWere = ftell($this->getid3->fp);
-					fseek($this->getid3->fp, $MPEGaudioHeaderLengthCache[$head4] - 4, SEEK_CUR);
-					$next4 = fread($this->getid3->fp, 4);
-					if ($next4{0} == "\xFF") {
+					$WhereWeWere = $this->ftell();
+					$this->fseek($MPEGaudioHeaderLengthCache[$head4] - 4, SEEK_CUR);
+					$next4 = $this->fread(4);
+					if ($next4[0] == "\xFF") {
 						if (!isset($MPEGaudioHeaderDecodeCache[$next4])) {
 							$MPEGaudioHeaderDecodeCache[$next4] = self::MPEGaudioHeaderDecode($next4);
 						}
@@ -1269,16 +1334,16 @@ class getid3_mp3 extends getid3_handler
 							$MPEGaudioHeaderValidCache[$next4] = self::MPEGaudioHeaderValid($MPEGaudioHeaderDecodeCache[$next4], false, false);
 						}
 						if ($MPEGaudioHeaderValidCache[$next4]) {
-							fseek($this->getid3->fp, -4, SEEK_CUR);
+							$this->fseek(-4, SEEK_CUR);
 
-							getid3_lib::safe_inc($Distribution['bitrate'][$LongMPEGbitrateLookup[$head4]]);
-							getid3_lib::safe_inc($Distribution['layer'][$LongMPEGlayerLookup[$head4]]);
-							getid3_lib::safe_inc($Distribution['version'][$LongMPEGversionLookup[$head4]]);
-							getid3_lib::safe_inc($Distribution['padding'][intval($LongMPEGpaddingLookup[$head4])]);
-							getid3_lib::safe_inc($Distribution['frequency'][$LongMPEGfrequencyLookup[$head4]]);
-							if ($max_frames_scan && (++$frames_scanned >= $max_frames_scan)) {
-								$pct_data_scanned = (ftell($this->getid3->fp) - $info['avdataoffset']) / ($info['avdataend'] - $info['avdataoffset']);
-								$info['warning'][] = 'too many MPEG audio frames to scan, only scanned first '.$max_frames_scan.' frames ('.number_format($pct_data_scanned * 100, 1).'% of file) and extrapolated distribution, playtime and bitrate may be incorrect.';
+							$Distribution['bitrate'][$LongMPEGbitrateLookup[$head4]] = isset($Distribution['bitrate'][$LongMPEGbitrateLookup[$head4]]) ? ++$Distribution['bitrate'][$LongMPEGbitrateLookup[$head4]] : 1;
+							$Distribution['layer'][$LongMPEGlayerLookup[$head4]] = isset($Distribution['layer'][$LongMPEGlayerLookup[$head4]]) ? ++$Distribution['layer'][$LongMPEGlayerLookup[$head4]] : 1;
+							$Distribution['version'][$LongMPEGversionLookup[$head4]] = isset($Distribution['version'][$LongMPEGversionLookup[$head4]]) ? ++$Distribution['version'][$LongMPEGversionLookup[$head4]] : 1;
+							$Distribution['padding'][intval($LongMPEGpaddingLookup[$head4])] = isset($Distribution['padding'][intval($LongMPEGpaddingLookup[$head4])]) ? ++$Distribution['padding'][intval($LongMPEGpaddingLookup[$head4])] : 1;
+							$Distribution['frequency'][$LongMPEGfrequencyLookup[$head4]] = isset($Distribution['frequency'][$LongMPEGfrequencyLookup[$head4]]) ? ++$Distribution['frequency'][$LongMPEGfrequencyLookup[$head4]] : 1;
+							if (++$frames_scanned >= $max_frames_scan) {
+								$pct_data_scanned = ($this->ftell() - $info['avdataoffset']) / ($info['avdataend'] - $info['avdataoffset']);
+								$this->warning('too many MPEG audio frames to scan, only scanned first '.$max_frames_scan.' frames ('.number_format($pct_data_scanned * 100, 1).'% of file) and extrapolated distribution, playtime and bitrate may be incorrect.');
 								foreach ($Distribution as $key1 => $value1) {
 									foreach ($value1 as $key2 => $value2) {
 										$Distribution[$key1][$key2] = round($value2 / $pct_data_scanned);
@@ -1290,7 +1355,7 @@ class getid3_mp3 extends getid3_handler
 						}
 					}
 					unset($next4);
-					fseek($this->getid3->fp, $WhereWeWere - 3, SEEK_SET);
+					$this->fseek($WhereWeWere - 3);
 				}
 
 			}
@@ -1305,13 +1370,13 @@ class getid3_mp3 extends getid3_handler
 		$info['mpeg']['audio']['version_distribution']   = $Distribution['version'];
 		$info['mpeg']['audio']['padding_distribution']   = $Distribution['padding'];
 		if (count($Distribution['version']) > 1) {
-			$info['error'][] = 'Corrupt file - more than one MPEG version detected';
+			$this->error('Corrupt file - more than one MPEG version detected');
 		}
 		if (count($Distribution['layer']) > 1) {
-			$info['error'][] = 'Corrupt file - more than one MPEG layer detected';
+			$this->error('Corrupt file - more than one MPEG layer detected');
 		}
 		if (count($Distribution['frequency']) > 1) {
-			$info['error'][] = 'Corrupt file - more than one MPEG sample rate detected';
+			$this->error('Corrupt file - more than one MPEG sample rate detected');
 		}
 
 
@@ -1323,7 +1388,7 @@ class getid3_mp3 extends getid3_handler
 		}
 		$info['mpeg']['audio']['frame_count']  = array_sum($Distribution['bitrate']);
 		if ($info['mpeg']['audio']['frame_count'] == 0) {
-			$info['error'][] = 'no MPEG audio frames found';
+			$this->error('no MPEG audio frames found');
 			return false;
 		}
 		$info['mpeg']['audio']['bitrate']      = ($bittotal / $info['mpeg']['audio']['frame_count']);
@@ -1339,7 +1404,12 @@ class getid3_mp3 extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @param int  $avdataoffset
+	 * @param bool $BitrateHistogram
+	 *
+	 * @return bool
+	 */
 	public function getOnlyMPEGaudioInfo($avdataoffset, $BitrateHistogram=false) {
 		// looks for synch, decodes MPEG audio header
 
@@ -1349,19 +1419,18 @@ class getid3_mp3 extends getid3_handler
 		static $MPEGaudioLayerLookup;
 		static $MPEGaudioBitrateLookup;
 		if (empty($MPEGaudioVersionLookup)) {
-		   $MPEGaudioVersionLookup = self::MPEGaudioVersionArray();
-		   $MPEGaudioLayerLookup   = self::MPEGaudioLayerArray();
-		   $MPEGaudioBitrateLookup = self::MPEGaudioBitrateArray();
-
+			$MPEGaudioVersionLookup = self::MPEGaudioVersionArray();
+			$MPEGaudioLayerLookup   = self::MPEGaudioLayerArray();
+			$MPEGaudioBitrateLookup = self::MPEGaudioBitrateArray();
 		}
 
-		fseek($this->getid3->fp, $avdataoffset, SEEK_SET);
+		$this->fseek($avdataoffset);
 		$sync_seek_buffer_size = min(128 * 1024, $info['avdataend'] - $avdataoffset);
 		if ($sync_seek_buffer_size <= 0) {
-			$info['error'][] = 'Invalid $sync_seek_buffer_size at offset '.$avdataoffset;
+			$this->error('Invalid $sync_seek_buffer_size at offset '.$avdataoffset);
 			return false;
 		}
-		$header = fread($this->getid3->fp, $sync_seek_buffer_size);
+		$header = $this->fread($sync_seek_buffer_size);
 		$sync_seek_buffer_size = strlen($header);
 		$SynchSeekOffset = 0;
 		while ($SynchSeekOffset < $sync_seek_buffer_size) {
@@ -1369,7 +1438,7 @@ class getid3_mp3 extends getid3_handler
 
 				if ($SynchSeekOffset > $sync_seek_buffer_size) {
 					// if a synch's not found within the first 128k bytes, then give up
-					$info['error'][] = 'Could not find valid MPEG audio synch within the first '.round($sync_seek_buffer_size / 1024).'kB';
+					$this->error('Could not find valid MPEG audio synch within the first '.round($sync_seek_buffer_size / 1024).'kB');
 					if (isset($info['audio']['bitrate'])) {
 						unset($info['audio']['bitrate']);
 					}
@@ -1383,7 +1452,7 @@ class getid3_mp3 extends getid3_handler
 
 				} elseif (feof($this->getid3->fp)) {
 
-					$info['error'][] = 'Could not find valid MPEG audio synch before end of file';
+					$this->error('Could not find valid MPEG audio synch before end of file');
 					if (isset($info['audio']['bitrate'])) {
 						unset($info['audio']['bitrate']);
 					}
@@ -1398,11 +1467,12 @@ class getid3_mp3 extends getid3_handler
 			}
 
 			if (($SynchSeekOffset + 1) >= strlen($header)) {
-				$info['error'][] = 'Could not find valid MPEG synch before end of file';
+				$this->error('Could not find valid MPEG synch before end of file');
 				return false;
 			}
 
-			if (($header{$SynchSeekOffset} == "\xFF") && ($header{($SynchSeekOffset + 1)} > "\xE0")) { // synch detected
+			if (($header[$SynchSeekOffset] == "\xFF") && ($header[($SynchSeekOffset + 1)] > "\xE0")) { // synch detected
+				$FirstFrameAVDataOffset = null;
 				if (!isset($FirstFrameThisfileInfo) && !isset($info['mpeg']['audio'])) {
 					$FirstFrameThisfileInfo = $info;
 					$FirstFrameAVDataOffset = $avdataoffset + $SynchSeekOffset;
@@ -1426,7 +1496,7 @@ class getid3_mp3 extends getid3_handler
 							$info['audio']['dataformat'] = 'mp3';
 							break;
 					}
-					if (isset($FirstFrameThisfileInfo['mpeg']['audio']['bitrate_mode']) && ($FirstFrameThisfileInfo['mpeg']['audio']['bitrate_mode'] == 'vbr')) {
+					if (isset($FirstFrameThisfileInfo) && isset($FirstFrameThisfileInfo['mpeg']['audio']['bitrate_mode']) && ($FirstFrameThisfileInfo['mpeg']['audio']['bitrate_mode'] == 'vbr')) {
 						if (!(abs($info['audio']['bitrate'] - $FirstFrameThisfileInfo['audio']['bitrate']) <= 1)) {
 							// If there is garbage data between a valid VBR header frame and a sequence
 							// of valid MPEG-audio frames the VBR data is no longer discarded.
@@ -1441,9 +1511,9 @@ class getid3_mp3 extends getid3_handler
 							if ($this->decodeMPEGaudioHeader($GarbageOffsetEnd, $dummy, true, true)) {
 								$info = $dummy;
 								$info['avdataoffset'] = $GarbageOffsetEnd;
-								$info['warning'][] = 'apparently-valid VBR header not used because could not find '.GETID3_MP3_VALID_CHECK_FRAMES.' consecutive MPEG-audio frames immediately after VBR header (garbage data for '.($GarbageOffsetEnd - $GarbageOffsetStart).' bytes between '.$GarbageOffsetStart.' and '.$GarbageOffsetEnd.'), but did find valid CBR stream starting at '.$GarbageOffsetEnd;
+								$this->warning('apparently-valid VBR header not used because could not find '.GETID3_MP3_VALID_CHECK_FRAMES.' consecutive MPEG-audio frames immediately after VBR header (garbage data for '.($GarbageOffsetEnd - $GarbageOffsetStart).' bytes between '.$GarbageOffsetStart.' and '.$GarbageOffsetEnd.'), but did find valid CBR stream starting at '.$GarbageOffsetEnd);
 							} else {
-								$info['warning'][] = 'using data from VBR header even though could not find '.GETID3_MP3_VALID_CHECK_FRAMES.' consecutive MPEG-audio frames immediately after VBR header (garbage data for '.($GarbageOffsetEnd - $GarbageOffsetStart).' bytes between '.$GarbageOffsetStart.' and '.$GarbageOffsetEnd.')';
+								$this->warning('using data from VBR header even though could not find '.GETID3_MP3_VALID_CHECK_FRAMES.' consecutive MPEG-audio frames immediately after VBR header (garbage data for '.($GarbageOffsetEnd - $GarbageOffsetStart).' bytes between '.$GarbageOffsetStart.' and '.$GarbageOffsetEnd.')');
 							}
 						}
 					}
@@ -1473,7 +1543,7 @@ class getid3_mp3 extends getid3_handler
 
 						$dummy = array('error'=>$info['error'], 'warning'=>$info['warning'], 'avdataend'=>$info['avdataend'], 'avdataoffset'=>$info['avdataoffset']);
 						$synchstartoffset = $info['avdataoffset'];
-						fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+						$this->fseek($info['avdataoffset']);
 
 						// you can play with these numbers:
 						$max_frames_scan  = 50000;
@@ -1488,15 +1558,15 @@ class getid3_mp3 extends getid3_handler
 						$pct_data_scanned = 0;
 						for ($current_segment = 0; $current_segment < $max_scan_segments; $current_segment++) {
 							$frames_scanned_this_segment = 0;
-							if (ftell($this->getid3->fp) >= $info['avdataend']) {
+							if ($this->ftell() >= $info['avdataend']) {
 								break;
 							}
-							$scan_start_offset[$current_segment] = max(ftell($this->getid3->fp), $info['avdataoffset'] + round($current_segment * (($info['avdataend'] - $info['avdataoffset']) / $max_scan_segments)));
+							$scan_start_offset[$current_segment] = max($this->ftell(), $info['avdataoffset'] + round($current_segment * (($info['avdataend'] - $info['avdataoffset']) / $max_scan_segments)));
 							if ($current_segment > 0) {
-								fseek($this->getid3->fp, $scan_start_offset[$current_segment], SEEK_SET);
-								$buffer_4k = fread($this->getid3->fp, 4096);
+								$this->fseek($scan_start_offset[$current_segment]);
+								$buffer_4k = $this->fread(4096);
 								for ($j = 0; $j < (strlen($buffer_4k) - 4); $j++) {
-									if (($buffer_4k{$j} == "\xFF") && ($buffer_4k{($j + 1)} > "\xE0")) { // synch detected
+									if (($buffer_4k[$j] == "\xFF") && ($buffer_4k[($j + 1)] > "\xE0")) { // synch detected
 										if ($this->decodeMPEGaudioHeader($scan_start_offset[$current_segment] + $j, $dummy, false, false, $FastMode)) {
 											$calculated_next_offset = $scan_start_offset[$current_segment] + $j + $dummy['mpeg']['audio']['framelength'];
 											if ($this->decodeMPEGaudioHeader($calculated_next_offset, $dummy, false, false, $FastMode)) {
@@ -1508,7 +1578,7 @@ class getid3_mp3 extends getid3_handler
 								}
 							}
 							$synchstartoffset = $scan_start_offset[$current_segment];
-							while ($this->decodeMPEGaudioHeader($synchstartoffset, $dummy, false, false, $FastMode)) {
+							while (($synchstartoffset < $info['avdataend']) && $this->decodeMPEGaudioHeader($synchstartoffset, $dummy, false, false, $FastMode)) {
 								$FastMode = true;
 								$thisframebitrate = $MPEGaudioBitrateLookup[$MPEGaudioVersionLookup[$dummy['mpeg']['audio']['raw']['version']]][$MPEGaudioLayerLookup[$dummy['mpeg']['audio']['raw']['layer']]][$dummy['mpeg']['audio']['raw']['bitrate']];
 
@@ -1523,7 +1593,7 @@ class getid3_mp3 extends getid3_handler
 								}
 								$frames_scanned++;
 								if ($frames_scan_per_segment && (++$frames_scanned_this_segment >= $frames_scan_per_segment)) {
-									$this_pct_scanned = (ftell($this->getid3->fp) - $scan_start_offset[$current_segment]) / ($info['avdataend'] - $info['avdataoffset']);
+									$this_pct_scanned = ($this->ftell() - $scan_start_offset[$current_segment]) / ($info['avdataend'] - $info['avdataoffset']);
 									if (($current_segment == 0) && (($this_pct_scanned * $max_scan_segments) >= 1)) {
 										// file likely contains < $max_frames_scan, just scan as one segment
 										$max_scan_segments = 1;
@@ -1536,7 +1606,7 @@ class getid3_mp3 extends getid3_handler
 							}
 						}
 						if ($pct_data_scanned > 0) {
-							$info['warning'][] = 'too many MPEG audio frames to scan, only scanned '.$frames_scanned.' frames in '.$max_scan_segments.' segments ('.number_format($pct_data_scanned * 100, 1).'% of file) and extrapolated distribution, playtime and bitrate may be incorrect.';
+							$this->warning('too many MPEG audio frames to scan, only scanned '.$frames_scanned.' frames in '.$max_scan_segments.' segments ('.number_format($pct_data_scanned * 100, 1).'% of file) and extrapolated distribution, playtime and bitrate may be incorrect.');
 							foreach ($info['mpeg']['audio'] as $key1 => $value1) {
 								if (!preg_match('#_distribution$#i', $key1)) {
 									continue;
@@ -1548,7 +1618,7 @@ class getid3_mp3 extends getid3_handler
 						}
 
 						if ($SynchErrorsFound > 0) {
-							$info['warning'][] = 'Found '.$SynchErrorsFound.' synch errors in histogram analysis';
+							$this->warning('Found '.$SynchErrorsFound.' synch errors in histogram analysis');
 							//return false;
 						}
 
@@ -1561,7 +1631,7 @@ class getid3_mp3 extends getid3_handler
 							}
 						}
 						if ($framecounter == 0) {
-							$info['error'][] = 'Corrupt MP3 file: framecounter == zero';
+							$this->error('Corrupt MP3 file: framecounter == zero');
 							return false;
 						}
 						$info['mpeg']['audio']['frame_count'] = getid3_lib::CastAsInt($framecounter);
@@ -1596,7 +1666,7 @@ class getid3_mp3 extends getid3_handler
 
 				if (empty($info['mpeg']['audio'])) {
 
-					$info['error'][] = 'could not find valid MPEG synch before end of file';
+					$this->error('could not find valid MPEG synch before end of file');
 					if (isset($info['audio']['bitrate'])) {
 						unset($info['audio']['bitrate']);
 					}
@@ -1619,17 +1689,25 @@ class getid3_mp3 extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @return array
+	 */
 	public static function MPEGaudioVersionArray() {
 		static $MPEGaudioVersion = array('2.5', false, '2', '1');
 		return $MPEGaudioVersion;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function MPEGaudioLayerArray() {
 		static $MPEGaudioLayer = array(false, 3, 2, 1);
 		return $MPEGaudioLayer;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function MPEGaudioBitrateArray() {
 		static $MPEGaudioBitrate;
 		if (empty($MPEGaudioBitrate)) {
@@ -1649,6 +1727,9 @@ class getid3_mp3 extends getid3_handler
 		return $MPEGaudioBitrate;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function MPEGaudioFrequencyArray() {
 		static $MPEGaudioFrequency;
 		if (empty($MPEGaudioFrequency)) {
@@ -1661,11 +1742,17 @@ class getid3_mp3 extends getid3_handler
 		return $MPEGaudioFrequency;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function MPEGaudioChannelModeArray() {
 		static $MPEGaudioChannelMode = array('stereo', 'joint stereo', 'dual channel', 'mono');
 		return $MPEGaudioChannelMode;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function MPEGaudioModeExtensionArray() {
 		static $MPEGaudioModeExtension;
 		if (empty($MPEGaudioModeExtension)) {
@@ -1678,17 +1765,33 @@ class getid3_mp3 extends getid3_handler
 		return $MPEGaudioModeExtension;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function MPEGaudioEmphasisArray() {
 		static $MPEGaudioEmphasis = array('none', '50/15ms', false, 'CCIT J.17');
 		return $MPEGaudioEmphasis;
 	}
 
+	/**
+	 * @param string $head4
+	 * @param bool   $allowBitrate15
+	 *
+	 * @return bool
+	 */
 	public static function MPEGaudioHeaderBytesValid($head4, $allowBitrate15=false) {
 		return self::MPEGaudioHeaderValid(self::MPEGaudioHeaderDecode($head4), false, $allowBitrate15);
 	}
 
+	/**
+	 * @param array $rawarray
+	 * @param bool  $echoerrors
+	 * @param bool  $allowBitrate15
+	 *
+	 * @return bool
+	 */
 	public static function MPEGaudioHeaderValid($rawarray, $echoerrors=false, $allowBitrate15=false) {
-		if (($rawarray['synch'] & 0x0FFE) != 0x0FFE) {
+		if (!isset($rawarray['synch']) || ($rawarray['synch'] & 0x0FFE) != 0x0FFE) {
 			return false;
 		}
 
@@ -1759,6 +1862,11 @@ class getid3_mp3 extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $Header4Bytes
+	 *
+	 * @return array|false
+	 */
 	public static function MPEGaudioHeaderDecode($Header4Bytes) {
 		// AAAA AAAA  AAAB BCCD  EEEE FFGH  IIJJ KLMM
 		// A - Frame sync (all bits set)
@@ -1780,22 +1888,31 @@ class getid3_mp3 extends getid3_handler
 		}
 
 		$MPEGrawHeader['synch']         = (getid3_lib::BigEndian2Int(substr($Header4Bytes, 0, 2)) & 0xFFE0) >> 4;
-		$MPEGrawHeader['version']       = (ord($Header4Bytes{1}) & 0x18) >> 3; //    BB
-		$MPEGrawHeader['layer']         = (ord($Header4Bytes{1}) & 0x06) >> 1; //      CC
-		$MPEGrawHeader['protection']    = (ord($Header4Bytes{1}) & 0x01);      //        D
-		$MPEGrawHeader['bitrate']       = (ord($Header4Bytes{2}) & 0xF0) >> 4; // EEEE
-		$MPEGrawHeader['sample_rate']   = (ord($Header4Bytes{2}) & 0x0C) >> 2; //     FF
-		$MPEGrawHeader['padding']       = (ord($Header4Bytes{2}) & 0x02) >> 1; //       G
-		$MPEGrawHeader['private']       = (ord($Header4Bytes{2}) & 0x01);      //        H
-		$MPEGrawHeader['channelmode']   = (ord($Header4Bytes{3}) & 0xC0) >> 6; // II
-		$MPEGrawHeader['modeextension'] = (ord($Header4Bytes{3}) & 0x30) >> 4; //   JJ
-		$MPEGrawHeader['copyright']     = (ord($Header4Bytes{3}) & 0x08) >> 3; //     K
-		$MPEGrawHeader['original']      = (ord($Header4Bytes{3}) & 0x04) >> 2; //      L
-		$MPEGrawHeader['emphasis']      = (ord($Header4Bytes{3}) & 0x03);      //       MM
+		$MPEGrawHeader['version']       = (ord($Header4Bytes[1]) & 0x18) >> 3; //    BB
+		$MPEGrawHeader['layer']         = (ord($Header4Bytes[1]) & 0x06) >> 1; //      CC
+		$MPEGrawHeader['protection']    = (ord($Header4Bytes[1]) & 0x01);      //        D
+		$MPEGrawHeader['bitrate']       = (ord($Header4Bytes[2]) & 0xF0) >> 4; // EEEE
+		$MPEGrawHeader['sample_rate']   = (ord($Header4Bytes[2]) & 0x0C) >> 2; //     FF
+		$MPEGrawHeader['padding']       = (ord($Header4Bytes[2]) & 0x02) >> 1; //       G
+		$MPEGrawHeader['private']       = (ord($Header4Bytes[2]) & 0x01);      //        H
+		$MPEGrawHeader['channelmode']   = (ord($Header4Bytes[3]) & 0xC0) >> 6; // II
+		$MPEGrawHeader['modeextension'] = (ord($Header4Bytes[3]) & 0x30) >> 4; //   JJ
+		$MPEGrawHeader['copyright']     = (ord($Header4Bytes[3]) & 0x08) >> 3; //     K
+		$MPEGrawHeader['original']      = (ord($Header4Bytes[3]) & 0x04) >> 2; //      L
+		$MPEGrawHeader['emphasis']      = (ord($Header4Bytes[3]) & 0x03);      //       MM
 
 		return $MPEGrawHeader;
 	}
 
+	/**
+	 * @param int|string $bitrate
+	 * @param string     $version
+	 * @param string     $layer
+	 * @param bool       $padding
+	 * @param int        $samplerate
+	 *
+	 * @return int|false
+	 */
 	public static function MPEGaudioFrameLength(&$bitrate, &$version, &$layer, $padding, &$samplerate) {
 		static $AudioFrameLengthCache = array();
 
@@ -1857,6 +1974,11 @@ class getid3_mp3 extends getid3_handler
 		return $AudioFrameLengthCache[$bitrate][$version][$layer][$padding][$samplerate];
 	}
 
+	/**
+	 * @param float|int $bit_rate
+	 *
+	 * @return int|float|string
+	 */
 	public static function ClosestStandardMP3Bitrate($bit_rate) {
 		static $standard_bit_rates = array (320000, 256000, 224000, 192000, 160000, 128000, 112000, 96000, 80000, 64000, 56000, 48000, 40000, 32000, 24000, 16000, 8000);
 		static $bit_rate_table = array (0=>'-');
@@ -1877,10 +1999,16 @@ class getid3_mp3 extends getid3_handler
 		return $bit_rate_table[$round_bit_rate];
 	}
 
+	/**
+	 * @param string $version
+	 * @param string $channelmode
+	 *
+	 * @return int
+	 */
 	public static function XingVBRidOffset($version, $channelmode) {
 		static $XingVBRidOffsetCache = array();
-		if (empty($XingVBRidOffset)) {
-			$XingVBRidOffset = array (
+		if (empty($XingVBRidOffsetCache)) {
+			$XingVBRidOffsetCache = array (
 				'1'   => array ('mono'          => 0x15, // 4 + 17 = 21
 								'stereo'        => 0x24, // 4 + 32 = 36
 								'joint stereo'  => 0x24,
@@ -1900,9 +2028,14 @@ class getid3_mp3 extends getid3_handler
 							   )
 			);
 		}
-		return $XingVBRidOffset[$version][$channelmode];
+		return $XingVBRidOffsetCache[$version][$channelmode];
 	}
 
+	/**
+	 * @param int $VBRmethodID
+	 *
+	 * @return string
+	 */
 	public static function LAMEvbrMethodLookup($VBRmethodID) {
 		static $LAMEvbrMethodLookup = array(
 			0x00 => 'unknown',
@@ -1919,6 +2052,11 @@ class getid3_mp3 extends getid3_handler
 		return (isset($LAMEvbrMethodLookup[$VBRmethodID]) ? $LAMEvbrMethodLookup[$VBRmethodID] : '');
 	}
 
+	/**
+	 * @param int $StereoModeID
+	 *
+	 * @return string
+	 */
 	public static function LAMEmiscStereoModeLookup($StereoModeID) {
 		static $LAMEmiscStereoModeLookup = array(
 			0 => 'mono',
@@ -1933,6 +2071,11 @@ class getid3_mp3 extends getid3_handler
 		return (isset($LAMEmiscStereoModeLookup[$StereoModeID]) ? $LAMEmiscStereoModeLookup[$StereoModeID] : '');
 	}
 
+	/**
+	 * @param int $SourceSampleFrequencyID
+	 *
+	 * @return string
+	 */
 	public static function LAMEmiscSourceSampleFrequencyLookup($SourceSampleFrequencyID) {
 		static $LAMEmiscSourceSampleFrequencyLookup = array(
 			0 => '<= 32 kHz',
@@ -1943,6 +2086,11 @@ class getid3_mp3 extends getid3_handler
 		return (isset($LAMEmiscSourceSampleFrequencyLookup[$SourceSampleFrequencyID]) ? $LAMEmiscSourceSampleFrequencyLookup[$SourceSampleFrequencyID] : '');
 	}
 
+	/**
+	 * @param int $SurroundInfoID
+	 *
+	 * @return string
+	 */
 	public static function LAMEsurroundInfoLookup($SurroundInfoID) {
 		static $LAMEsurroundInfoLookup = array(
 			0 => 'no surround info',
@@ -1953,6 +2101,11 @@ class getid3_mp3 extends getid3_handler
 		return (isset($LAMEsurroundInfoLookup[$SurroundInfoID]) ? $LAMEsurroundInfoLookup[$SurroundInfoID] : 'reserved');
 	}
 
+	/**
+	 * @param array $LAMEtag
+	 *
+	 * @return string
+	 */
 	public static function LAMEpresetUsedLookup($LAMEtag) {
 
 		if ($LAMEtag['preset_used_id'] == 0) {

--- a/application/libraries/getid3/module.audio.mpc.php
+++ b/application/libraries/getid3/module.audio.mpc.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.mpc.php                                        //
@@ -13,10 +14,15 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_mpc extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -29,8 +35,8 @@ class getid3_mpc extends getid3_handler
 		$info['audio']['channels']        = 2;  // up to SV7 the format appears to have been hardcoded for stereo only
 		$info['audio']['lossless']        = false;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$MPCheaderData = fread($this->getid3->fp, 4);
+		$this->fseek($info['avdataoffset']);
+		$MPCheaderData = $this->fread(4);
 		$info['mpc']['header']['preamble'] = substr($MPCheaderData, 0, 4); // should be 'MPCK' (SV8) or 'MP+' (SV7), otherwise possible stream data (SV4-SV6)
 		if (preg_match('#^MPCK#', $info['mpc']['header']['preamble'])) {
 
@@ -49,16 +55,17 @@ class getid3_mpc extends getid3_handler
 
 		} else {
 
-			$info['error'][] = 'Expecting "MP+" or "MPCK" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($MPCheaderData, 0, 4)).'"';
+			$this->error('Expecting "MP+" or "MPCK" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($MPCheaderData, 0, 4)).'"');
 			unset($info['fileformat']);
 			unset($info['mpc']);
 			return false;
 
 		}
-		return false;
 	}
 
-
+	/**
+	 * @return bool
+	 */
 	public function ParseMPCsv8() {
 		// this is SV8
 		// http://trac.musepack.net/trac/wiki/SV8Specification
@@ -69,7 +76,7 @@ class getid3_mpc extends getid3_handler
 		$keyNameSize            = 2;
 		$maxHandledPacketLength = 9; // specs say: "n*8; 0 < n < 10"
 
-		$offset = ftell($this->getid3->fp);
+		$offset = $this->ftell();
 		while ($offset < $info['avdataend']) {
 			$thisPacket = array();
 			$thisPacket['offset'] = $offset;
@@ -77,18 +84,18 @@ class getid3_mpc extends getid3_handler
 
 			// Size is a variable-size field, could be 1-4 bytes (possibly more?)
 			// read enough data in and figure out the exact size later
-			$MPCheaderData = fread($this->getid3->fp, $keyNameSize + $maxHandledPacketLength);
+			$MPCheaderData = $this->fread($keyNameSize + $maxHandledPacketLength);
 			$packet_offset += $keyNameSize;
 			$thisPacket['key']      = substr($MPCheaderData, 0, $keyNameSize);
 			$thisPacket['key_name'] = $this->MPCsv8PacketName($thisPacket['key']);
 			if ($thisPacket['key'] == $thisPacket['key_name']) {
-				$info['error'][] = 'Found unexpected key value "'.$thisPacket['key'].'" at offset '.$thisPacket['offset'];
+				$this->error('Found unexpected key value "'.$thisPacket['key'].'" at offset '.$thisPacket['offset']);
 				return false;
 			}
 			$packetLength = 0;
 			$thisPacket['packet_size'] = $this->SV8variableLengthInteger(substr($MPCheaderData, $keyNameSize), $packetLength); // includes keyname and packet_size field
 			if ($thisPacket['packet_size'] === false) {
-				$info['error'][] = 'Did not find expected packet length within '.$maxHandledPacketLength.' bytes at offset '.($thisPacket['offset'] + $keyNameSize);
+				$this->error('Did not find expected packet length within '.$maxHandledPacketLength.' bytes at offset '.($thisPacket['offset'] + $keyNameSize));
 				return false;
 			}
 			$packet_offset += $packetLength;
@@ -98,7 +105,7 @@ class getid3_mpc extends getid3_handler
 				case 'SH': // Stream Header
 					$moreBytesToRead = $thisPacket['packet_size'] - $keyNameSize - $maxHandledPacketLength;
 					if ($moreBytesToRead > 0) {
-						$MPCheaderData .= fread($this->getid3->fp, $moreBytesToRead);
+						$MPCheaderData .= $this->fread($moreBytesToRead);
 					}
 					$thisPacket['crc']               =       getid3_lib::BigEndian2Int(substr($MPCheaderData, $packet_offset, 4));
 					$packet_offset += 4;
@@ -136,7 +143,7 @@ class getid3_mpc extends getid3_handler
 				case 'RG': // Replay Gain
 					$moreBytesToRead = $thisPacket['packet_size'] - $keyNameSize - $maxHandledPacketLength;
 					if ($moreBytesToRead > 0) {
-						$MPCheaderData .= fread($this->getid3->fp, $moreBytesToRead);
+						$MPCheaderData .= $this->fread($moreBytesToRead);
 					}
 					$thisPacket['replaygain_version']     =       getid3_lib::BigEndian2Int(substr($MPCheaderData, $packet_offset, 1));
 					$packet_offset += 1;
@@ -158,7 +165,7 @@ class getid3_mpc extends getid3_handler
 				case 'EI': // Encoder Info
 					$moreBytesToRead = $thisPacket['packet_size'] - $keyNameSize - $maxHandledPacketLength;
 					if ($moreBytesToRead > 0) {
-						$MPCheaderData .= fread($this->getid3->fp, $moreBytesToRead);
+						$MPCheaderData .= $this->fread($moreBytesToRead);
 					}
 					$profile_pns                 = getid3_lib::BigEndian2Int(substr($MPCheaderData, $packet_offset, 1));
 					$packet_offset += 1;
@@ -194,19 +201,21 @@ class getid3_mpc extends getid3_handler
 					break;
 
 				default:
-					$info['error'][] = 'Found unhandled key type "'.$thisPacket['key'].'" at offset '.$thisPacket['offset'];
+					$this->error('Found unhandled key type "'.$thisPacket['key'].'" at offset '.$thisPacket['offset']);
 					return false;
-					break;
 			}
 			if (!empty($thisPacket)) {
 				$info['mpc']['packets'][] = $thisPacket;
 			}
-			fseek($this->getid3->fp, $offset);
+			$this->fseek($offset);
 		}
 		$thisfile_mpc_header['size'] = $offset;
 		return true;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function ParseMPCsv7() {
 		// this is SV7
 		// http://www.uni-jena.de/~pfk/mpp/sv8/header.html
@@ -217,7 +226,7 @@ class getid3_mpc extends getid3_handler
 
 		$thisfile_mpc_header['size'] = 28;
 		$MPCheaderData  = $info['mpc']['header']['preamble'];
-		$MPCheaderData .= fread($this->getid3->fp, $thisfile_mpc_header['size'] - strlen($info['mpc']['header']['preamble']));
+		$MPCheaderData .= $this->fread($thisfile_mpc_header['size'] - strlen($info['mpc']['header']['preamble']));
 		$offset = strlen('MP+');
 
 		$StreamVersionByte                           = getid3_lib::LittleEndian2Int(substr($MPCheaderData, $offset, 1));
@@ -228,7 +237,7 @@ class getid3_mpc extends getid3_handler
 		$offset += 4;
 
 		if ($thisfile_mpc_header['stream_version_major'] != 7) {
-			$info['error'][] = 'Only Musepack SV7 supported (this file claims to be v'.$thisfile_mpc_header['stream_version_major'].')';
+			$this->error('Only Musepack SV7 supported (this file claims to be v'.$thisfile_mpc_header['stream_version_major'].')');
 			return false;
 		}
 
@@ -267,7 +276,7 @@ class getid3_mpc extends getid3_handler
 		$thisfile_mpc_header['profile']     = $this->MPCprofileNameLookup($thisfile_mpc_header['raw']['profile']);
 		$thisfile_mpc_header['sample_rate'] = $this->MPCfrequencyLookup($thisfile_mpc_header['raw']['sample_rate']);
 		if ($thisfile_mpc_header['sample_rate'] == 0) {
-			$info['error'][] = 'Corrupt MPC file: frequency == zero';
+			$this->error('Corrupt MPC file: frequency == zero');
 			return false;
 		}
 		$info['audio']['sample_rate'] = $thisfile_mpc_header['sample_rate'];
@@ -275,7 +284,7 @@ class getid3_mpc extends getid3_handler
 
 		$info['playtime_seconds']     = ($thisfile_mpc_header['samples'] / $info['audio']['channels']) / $info['audio']['sample_rate'];
 		if ($info['playtime_seconds'] == 0) {
-			$info['error'][] = 'Corrupt MPC file: playtime_seconds == zero';
+			$this->error('Corrupt MPC file: playtime_seconds == zero');
 			return false;
 		}
 
@@ -321,6 +330,9 @@ class getid3_mpc extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function ParseMPCsv6() {
 		// this is SV4 - SV6
 
@@ -329,8 +341,8 @@ class getid3_mpc extends getid3_handler
 		$offset = 0;
 
 		$thisfile_mpc_header['size'] = 8;
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$MPCheaderData = fread($this->getid3->fp, $thisfile_mpc_header['size']);
+		$this->fseek($info['avdataoffset']);
+		$MPCheaderData = $this->fread($thisfile_mpc_header['size']);
 
 		// add size of file header to avdataoffset - calc bitrate correctly + MD5 data
 		$info['avdataoffset'] += $thisfile_mpc_header['size'];
@@ -372,11 +384,10 @@ class getid3_mpc extends getid3_handler
 				$info['error'] = 'Expecting 4, 5 or 6 in version field, found '.$thisfile_mpc_header['stream_version_major'].' instead';
 				unset($info['mpc']);
 				return false;
-				break;
 		}
 
 		if (($thisfile_mpc_header['stream_version_major'] > 4) && ($thisfile_mpc_header['block_size'] != 1)) {
-			$info['warning'][] = 'Block size expected to be 1, actual value found: '.$thisfile_mpc_header['block_size'];
+			$this->warning('Block size expected to be 1, actual value found: '.$thisfile_mpc_header['block_size']);
 		}
 
 		$thisfile_mpc_header['sample_rate']   = 44100; // AB: used by all files up to SV7
@@ -396,7 +407,11 @@ class getid3_mpc extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @param int $profileid
+	 *
+	 * @return string
+	 */
 	public function MPCprofileNameLookup($profileid) {
 		static $MPCprofileNameLookup = array(
 			0  => 'no profile',
@@ -419,6 +434,11 @@ class getid3_mpc extends getid3_handler
 		return (isset($MPCprofileNameLookup[$profileid]) ? $MPCprofileNameLookup[$profileid] : 'invalid');
 	}
 
+	/**
+	 * @param int $frequencyid
+	 *
+	 * @return int|string
+	 */
 	public function MPCfrequencyLookup($frequencyid) {
 		static $MPCfrequencyLookup = array(
 			0 => 44100,
@@ -429,6 +449,11 @@ class getid3_mpc extends getid3_handler
 		return (isset($MPCfrequencyLookup[$frequencyid]) ? $MPCfrequencyLookup[$frequencyid] : 'invalid');
 	}
 
+	/**
+	 * @param int $intvalue
+	 *
+	 * @return float|false
+	 */
 	public function MPCpeakDBLookup($intvalue) {
 		if ($intvalue > 0) {
 			return ((log10($intvalue) / log10(2)) - 15) * 6;
@@ -436,6 +461,11 @@ class getid3_mpc extends getid3_handler
 		return false;
 	}
 
+	/**
+	 * @param int $encoderversion
+	 *
+	 * @return string
+	 */
 	public function MPCencoderVersionLookup($encoderversion) {
 		//Encoder version * 100  (106 = 1.06)
 		//EncoderVersion % 10 == 0        Release (1.0)
@@ -463,6 +493,13 @@ class getid3_mpc extends getid3_handler
 		return number_format($encoderversion / 100, 2).' alpha';
 	}
 
+	/**
+	 * @param string $data
+	 * @param int    $packetLength
+	 * @param int    $maxHandledPacketLength
+	 *
+	 * @return int|false
+	 */
 	public function SV8variableLengthInteger($data, &$packetLength, $maxHandledPacketLength=9) {
 		$packet_size = 0;
 		for ($packetLength = 1; $packetLength <= $maxHandledPacketLength; $packetLength++) {
@@ -487,6 +524,11 @@ class getid3_mpc extends getid3_handler
 		return $packet_size;
 	}
 
+	/**
+	 * @param string $packetKey
+	 *
+	 * @return string
+	 */
 	public function MPCsv8PacketName($packetKey) {
 		static $MPCsv8PacketName = array();
 		if (empty($MPCsv8PacketName)) {

--- a/application/libraries/getid3/module.audio.ogg.php
+++ b/application/libraries/getid3/module.audio.ogg.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.ogg.php                                        //
@@ -13,11 +14,18 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.flac.php', __FILE__, true);
 
 class getid3_ogg extends getid3_handler
 {
-	// http://xiph.org/vorbis/doc/Vorbis_I_spec.html
+	/**
+	 * @link http://xiph.org/vorbis/doc/Vorbis_I_spec.html
+	 *
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -25,13 +33,13 @@ class getid3_ogg extends getid3_handler
 
 		// Warn about illegal tags - only vorbiscomments are allowed
 		if (isset($info['id3v2'])) {
-			$info['warning'][] = 'Illegal ID3v2 tag present.';
+			$this->warning('Illegal ID3v2 tag present.');
 		}
 		if (isset($info['id3v1'])) {
-			$info['warning'][] = 'Illegal ID3v1 tag present.';
+			$this->warning('Illegal ID3v1 tag present.');
 		}
 		if (isset($info['ape'])) {
-			$info['warning'][] = 'Illegal APE tag present.';
+			$this->warning('Illegal APE tag present.');
 		}
 
 
@@ -43,7 +51,7 @@ class getid3_ogg extends getid3_handler
 		$info['ogg']['pageheader'][$oggpageinfo['page_seqno']] = $oggpageinfo;
 
 		if ($this->ftell() >= $this->getid3->fread_buffer_size()) {
-			$info['error'][] = 'Could not find start of Ogg page in the first '.$this->getid3->fread_buffer_size().' bytes (this might not be an Ogg-Vorbis file?)';
+			$this->error('Could not find start of Ogg page in the first '.$this->getid3->fread_buffer_size().' bytes (this might not be an Ogg-Vorbis file?)');
 			unset($info['fileformat']);
 			unset($info['ogg']);
 			return false;
@@ -61,6 +69,12 @@ class getid3_ogg extends getid3_handler
 		} elseif (substr($filedata, 1, 6) == 'vorbis') {
 
 			$this->ParseVorbisPageHeader($filedata, $filedataoffset, $oggpageinfo);
+
+		} elseif (substr($filedata, 0, 8) == 'OpusHead') {
+
+			if ($this->ParseOpusPageHeader($filedata, $filedataoffset, $oggpageinfo) === false) {
+				return false;
+			}
 
 		} elseif (substr($filedata, 0, 8) == 'Speex   ') {
 
@@ -113,6 +127,66 @@ class getid3_ogg extends getid3_handler
 			if ($info['speex']['vbr']) {
 				$info['audio']['bitrate_mode'] = 'vbr';
 			}
+
+		} elseif (substr($filedata, 0, 7) == "\x80".'theora') {
+
+			// http://www.theora.org/doc/Theora.pdf (section 6.2)
+
+			$info['ogg']['pageheader']['theora']['theora_magic']             =                           substr($filedata, $filedataoffset,  7); // hard-coded to "\x80.'theora'
+			$filedataoffset += 7;
+			$info['ogg']['pageheader']['theora']['version_major']            = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  1));
+			$filedataoffset += 1;
+			$info['ogg']['pageheader']['theora']['version_minor']            = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  1));
+			$filedataoffset += 1;
+			$info['ogg']['pageheader']['theora']['version_revision']         = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  1));
+			$filedataoffset += 1;
+			$info['ogg']['pageheader']['theora']['frame_width_macroblocks']  = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  2));
+			$filedataoffset += 2;
+			$info['ogg']['pageheader']['theora']['frame_height_macroblocks'] = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  2));
+			$filedataoffset += 2;
+			$info['ogg']['pageheader']['theora']['resolution_x']             = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  3));
+			$filedataoffset += 3;
+			$info['ogg']['pageheader']['theora']['resolution_y']             = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  3));
+			$filedataoffset += 3;
+			$info['ogg']['pageheader']['theora']['picture_offset_x']         = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  1));
+			$filedataoffset += 1;
+			$info['ogg']['pageheader']['theora']['picture_offset_y']         = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  1));
+			$filedataoffset += 1;
+			$info['ogg']['pageheader']['theora']['frame_rate_numerator']     = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  4));
+			$filedataoffset += 4;
+			$info['ogg']['pageheader']['theora']['frame_rate_denominator']   = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  4));
+			$filedataoffset += 4;
+			$info['ogg']['pageheader']['theora']['pixel_aspect_numerator']   = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  3));
+			$filedataoffset += 3;
+			$info['ogg']['pageheader']['theora']['pixel_aspect_denominator'] = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  3));
+			$filedataoffset += 3;
+			$info['ogg']['pageheader']['theora']['color_space_id']           = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  1));
+			$filedataoffset += 1;
+			$info['ogg']['pageheader']['theora']['nominal_bitrate']          = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  3));
+			$filedataoffset += 3;
+			$info['ogg']['pageheader']['theora']['flags']                    = getid3_lib::BigEndian2Int(substr($filedata, $filedataoffset,  2));
+			$filedataoffset += 2;
+
+			$info['ogg']['pageheader']['theora']['quality']         = ($info['ogg']['pageheader']['theora']['flags'] & 0xFC00) >> 10;
+			$info['ogg']['pageheader']['theora']['kfg_shift']       = ($info['ogg']['pageheader']['theora']['flags'] & 0x03E0) >>  5;
+			$info['ogg']['pageheader']['theora']['pixel_format_id'] = ($info['ogg']['pageheader']['theora']['flags'] & 0x0018) >>  3;
+			$info['ogg']['pageheader']['theora']['reserved']        = ($info['ogg']['pageheader']['theora']['flags'] & 0x0007) >>  0; // should be 0
+			$info['ogg']['pageheader']['theora']['color_space']     = self::TheoraColorSpace($info['ogg']['pageheader']['theora']['color_space_id']);
+			$info['ogg']['pageheader']['theora']['pixel_format']    = self::TheoraPixelFormat($info['ogg']['pageheader']['theora']['pixel_format_id']);
+
+			$info['video']['dataformat']   = 'theora';
+			$info['mime_type']             = 'video/ogg';
+			//$info['audio']['bitrate_mode'] = 'abr';
+			//$info['audio']['lossless']     = false;
+			$info['video']['resolution_x'] = $info['ogg']['pageheader']['theora']['resolution_x'];
+			$info['video']['resolution_y'] = $info['ogg']['pageheader']['theora']['resolution_y'];
+			if ($info['ogg']['pageheader']['theora']['frame_rate_denominator'] > 0) {
+				$info['video']['frame_rate'] = (float) $info['ogg']['pageheader']['theora']['frame_rate_numerator'] / $info['ogg']['pageheader']['theora']['frame_rate_denominator'];
+			}
+			if ($info['ogg']['pageheader']['theora']['pixel_aspect_denominator'] > 0) {
+				$info['video']['pixel_aspect_ratio'] = (float) $info['ogg']['pageheader']['theora']['pixel_aspect_numerator'] / $info['ogg']['pageheader']['theora']['pixel_aspect_denominator'];
+			}
+			$this->warning('Ogg Theora (v3) not fully supported in this version of getID3 ['.$this->getid3->version().'] -- bitrate, playtime and all audio data are currently unavailable');
 
 
 		} elseif (substr($filedata, 0, 8) == "fishead\x00") {
@@ -172,8 +246,8 @@ class getid3_ogg extends getid3_handler
 
 				} elseif (substr($filedata, 1, 6) == 'theora') {
 
-					$info['video']['dataformat'] = 'theora';
-					$info['error'][] = 'Ogg Theora not correctly handled in this version of getID3 ['.$this->getid3->version().']';
+					$info['video']['dataformat'] = 'theora1';
+					$this->error('Ogg Theora (v1) not correctly handled in this version of getID3 ['.$this->getid3->version().']');
 					//break;
 
 				} elseif (substr($filedata, 1, 6) == 'vorbis') {
@@ -181,7 +255,7 @@ class getid3_ogg extends getid3_handler
 					$this->ParseVorbisPageHeader($filedata, $filedataoffset, $oggpageinfo);
 
 				} else {
-					$info['error'][] = 'unexpected';
+					$this->error('unexpected');
 					//break;
 				}
 			//} while ($oggpageinfo['page_seqno'] == 0);
@@ -189,12 +263,37 @@ class getid3_ogg extends getid3_handler
 
 			$this->fseek($oggpageinfo['page_start_offset']);
 
-			$info['error'][] = 'Ogg Skeleton not correctly handled in this version of getID3 ['.$this->getid3->version().']';
+			$this->error('Ogg Skeleton not correctly handled in this version of getID3 ['.$this->getid3->version().']');
 			//return false;
+
+		} elseif (substr($filedata, 0, 5) == "\x7F".'FLAC') {
+			// https://xiph.org/flac/ogg_mapping.html
+
+			$info['audio']['dataformat']   = 'flac';
+			$info['audio']['bitrate_mode'] = 'vbr';
+			$info['audio']['lossless']     = true;
+
+			$info['ogg']['flac']['header']['version_major']  =                         ord(substr($filedata,  5, 1));
+			$info['ogg']['flac']['header']['version_minor']  =                         ord(substr($filedata,  6, 1));
+			$info['ogg']['flac']['header']['header_packets'] =   getid3_lib::BigEndian2Int(substr($filedata,  7, 2)) + 1; // "A two-byte, big-endian binary number signifying the number of header (non-audio) packets, not including this one. This number may be zero (0x0000) to signify 'unknown' but be aware that some decoders may not be able to handle such streams."
+			$info['ogg']['flac']['header']['magic']          =                             substr($filedata,  9, 4);
+			if ($info['ogg']['flac']['header']['magic'] != 'fLaC') {
+				$this->error('Ogg-FLAC expecting "fLaC", found "'.$info['ogg']['flac']['header']['magic'].'" ('.trim(getid3_lib::PrintHexBytes($info['ogg']['flac']['header']['magic'])).')');
+				return false;
+			}
+			$info['ogg']['flac']['header']['STREAMINFO_bytes'] = getid3_lib::BigEndian2Int(substr($filedata, 13, 4));
+			$info['flac']['STREAMINFO'] = getid3_flac::parseSTREAMINFOdata(substr($filedata, 17, 34));
+			if (!empty($info['flac']['STREAMINFO']['sample_rate'])) {
+				$info['audio']['bitrate_mode']    = 'vbr';
+				$info['audio']['sample_rate']     = $info['flac']['STREAMINFO']['sample_rate'];
+				$info['audio']['channels']        = $info['flac']['STREAMINFO']['channels'];
+				$info['audio']['bits_per_sample'] = $info['flac']['STREAMINFO']['bits_per_sample'];
+				$info['playtime_seconds']         = $info['flac']['STREAMINFO']['samples_stream'] / $info['flac']['STREAMINFO']['sample_rate'];
+			}
 
 		} else {
 
-			$info['error'][] = 'Expecting either "Speex   " or "vorbis" identifier strings, found "'.substr($filedata, 0, 8).'"';
+			$this->error('Expecting one of "vorbis", "Speex", "OpusHead", "vorbis", "fishhead", "theora", "fLaC" identifier strings, found "'.substr($filedata, 0, 8).'"');
 			unset($info['ogg']);
 			unset($info['mime_type']);
 			return false;
@@ -217,7 +316,7 @@ class getid3_ogg extends getid3_handler
 			case 'flac':
 				$flac = new getid3_flac($this->getid3);
 				if (!$flac->parseMETAdata()) {
-					$info['error'][] = 'Failed to parse FLAC headers';
+					$this->error('Failed to parse FLAC headers');
 					return false;
 				}
 				unset($flac);
@@ -227,13 +326,24 @@ class getid3_ogg extends getid3_handler
 				$this->fseek($info['ogg']['pageheader'][$oggpageinfo['page_seqno']]['page_length'], SEEK_CUR);
 				$this->ParseVorbisComments();
 				break;
-		}
 
+			case 'opus':
+				$filedata = $this->fread($info['ogg']['pageheader'][$oggpageinfo['page_seqno']]['page_length']);
+				$info['ogg']['pageheader'][$oggpageinfo['page_seqno']]['stream_type'] = substr($filedata, 0, 8); // hard-coded to 'OpusTags'
+				if(substr($filedata, 0, 8)  != 'OpusTags') {
+					$this->error('Expected "OpusTags" as header but got "'.substr($filedata, 0, 8).'"');
+					return false;
+				}
+
+				$this->ParseVorbisComments();
+				break;
+
+		}
 
 		// Last Page - Number of Samples
 		if (!getid3_lib::intValueSupported($info['avdataend'])) {
 
-			$info['warning'][] = 'Unable to parse Ogg end chunk file (PHP does not support file operations beyond '.round(PHP_INT_MAX / 1073741824).'GB)';
+			$this->warning('Unable to parse Ogg end chunk file (PHP does not support file operations beyond '.round(PHP_INT_MAX / 1073741824).'GB)');
 
 		} else {
 
@@ -245,7 +355,7 @@ class getid3_ogg extends getid3_handler
 				$info['ogg']['pageheader']['eos'] = $this->ParseOggPageHeader();
 				$info['ogg']['samples']   = $info['ogg']['pageheader']['eos']['pcm_abs_position'];
 				if ($info['ogg']['samples'] == 0) {
-					$info['error'][] = 'Corrupt Ogg file: eos.number of samples == zero';
+					$this->error('Corrupt Ogg file: eos.number of samples == zero');
 					return false;
 				}
 				if (!empty($info['audio']['sample_rate'])) {
@@ -264,7 +374,7 @@ class getid3_ogg extends getid3_handler
 		}
 		if (isset($info['audio']['bitrate']) && !isset($info['playtime_seconds'])) {
 			if ($info['audio']['bitrate'] == 0) {
-				$info['error'][] = 'Corrupt Ogg file: bitrate_audio == zero';
+				$this->error('Corrupt Ogg file: bitrate_audio == zero');
 				return false;
 			}
 			$info['playtime_seconds'] = (float) ((($info['avdataend'] - $info['avdataoffset']) * 8) / $info['audio']['bitrate']);
@@ -300,6 +410,13 @@ class getid3_ogg extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $filedata
+	 * @param int    $filedataoffset
+	 * @param array  $oggpageinfo
+	 *
+	 * @return bool
+	 */
 	public function ParseVorbisPageHeader(&$filedata, &$filedataoffset, &$oggpageinfo) {
 		$info = &$this->getid3->info;
 		$info['audio']['dataformat'] = 'vorbis';
@@ -317,7 +434,7 @@ class getid3_ogg extends getid3_handler
 		$info['ogg']['samplerate']       = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset, 4));
 		$filedataoffset += 4;
 		if ($info['ogg']['samplerate'] == 0) {
-			$info['error'][] = 'Corrupt Ogg file: sample rate == zero';
+			$this->error('Corrupt Ogg file: sample rate == zero');
 			return false;
 		}
 		$info['audio']['sample_rate']    = $info['ogg']['samplerate'];
@@ -348,6 +465,68 @@ class getid3_ogg extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @link http://tools.ietf.org/html/draft-ietf-codec-oggopus-03
+	 *
+	 * @param string $filedata
+	 * @param int    $filedataoffset
+	 * @param array  $oggpageinfo
+	 *
+	 * @return bool
+	 */
+	public function ParseOpusPageHeader(&$filedata, &$filedataoffset, &$oggpageinfo) {
+		$info = &$this->getid3->info;
+		$info['audio']['dataformat']   = 'opus';
+		$info['mime_type']             = 'audio/ogg; codecs=opus';
+
+		/** @todo find a usable way to detect abr (vbr that is padded to be abr) */
+		$info['audio']['bitrate_mode'] = 'vbr';
+
+		$info['audio']['lossless']     = false;
+
+		$info['ogg']['pageheader']['opus']['opus_magic'] = substr($filedata, $filedataoffset, 8); // hard-coded to 'OpusHead'
+		$filedataoffset += 8;
+		$info['ogg']['pageheader']['opus']['version']    = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  1));
+		$filedataoffset += 1;
+
+		if ($info['ogg']['pageheader']['opus']['version'] < 1 || $info['ogg']['pageheader']['opus']['version'] > 15) {
+			$this->error('Unknown opus version number (only accepting 1-15)');
+			return false;
+		}
+
+		$info['ogg']['pageheader']['opus']['out_channel_count'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  1));
+		$filedataoffset += 1;
+
+		if ($info['ogg']['pageheader']['opus']['out_channel_count'] == 0) {
+			$this->error('Invalid channel count in opus header (must not be zero)');
+			return false;
+		}
+
+		$info['ogg']['pageheader']['opus']['pre_skip'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  2));
+		$filedataoffset += 2;
+
+		$info['ogg']['pageheader']['opus']['input_sample_rate'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  4));
+		$filedataoffset += 4;
+
+		//$info['ogg']['pageheader']['opus']['output_gain'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  2));
+		//$filedataoffset += 2;
+
+		//$info['ogg']['pageheader']['opus']['channel_mapping_family'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  1));
+		//$filedataoffset += 1;
+
+		$info['opus']['opus_version']       = $info['ogg']['pageheader']['opus']['version'];
+		$info['opus']['sample_rate_input']  = $info['ogg']['pageheader']['opus']['input_sample_rate'];
+		$info['opus']['out_channel_count']  = $info['ogg']['pageheader']['opus']['out_channel_count'];
+
+		$info['audio']['channels']          = $info['opus']['out_channel_count'];
+		$info['audio']['sample_rate_input'] = $info['opus']['sample_rate_input'];
+		$info['audio']['sample_rate']       = 48000; // "All Opus audio is coded at 48 kHz, and should also be decoded at 48 kHz for playback (unless the target hardware does not support this sampling rate). However, this field may be used to resample the audio back to the original sampling rate, for example, when saving the output to a file." -- https://mf4.xiph.org/jenkins/view/opus/job/opusfile-unix/ws/doc/html/structOpusHead.html
+		return true;
+	}
+
+	/**
+	 * @return array|false
+	 */
 	public function ParseOggPageHeader() {
 		// http://xiph.org/ogg/vorbis/doc/framing.html
 		$oggheader['page_start_offset'] = $this->ftell(); // where we started from in the file
@@ -360,7 +539,7 @@ class getid3_ogg extends getid3_handler
 				return false;
 			}
 			if ((($filedataoffset + 28) > strlen($filedata)) || (strlen($filedata) < 28)) {
-				if ($this->feof() || (($filedata .= $this->fread($this->getid3->fread_buffer_size())) === false)) {
+				if ($this->feof() || (($filedata .= $this->fread($this->getid3->fread_buffer_size())) === '')) {
 					// get some more data, unless eof, in which case fail
 					return false;
 				}
@@ -399,17 +578,24 @@ class getid3_ogg extends getid3_handler
 		return $oggheader;
 	}
 
-    // http://xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-810005
+	/**
+	 * @link http://xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-810005
+	 *
+	 * @return bool
+	 */
 	public function ParseVorbisComments() {
 		$info = &$this->getid3->info;
 
 		$OriginalOffset = $this->ftell();
+		$commentdata = null;
 		$commentdataoffset = 0;
 		$VorbisCommentPage = 1;
+		$CommentStartOffset = 0;
 
 		switch ($info['audio']['dataformat']) {
 			case 'vorbis':
 			case 'speex':
+			case 'opus':
 				$CommentStartOffset = $info['ogg']['pageheader'][$VorbisCommentPage]['page_start_offset'];  // Second Ogg page, after header block
 				$this->fseek($CommentStartOffset);
 				$commentdataoffset = 27 + $info['ogg']['pageheader'][$VorbisCommentPage]['page_segments'];
@@ -418,6 +604,10 @@ class getid3_ogg extends getid3_handler
 				if ($info['audio']['dataformat'] == 'vorbis') {
 					$commentdataoffset += (strlen('vorbis') + 1);
 				}
+				else if ($info['audio']['dataformat'] == 'opus') {
+					$commentdataoffset += strlen('OpusTags');
+				}
+
 				break;
 
 			case 'flac':
@@ -443,6 +633,12 @@ class getid3_ogg extends getid3_handler
 		$basicfields = array('TITLE', 'ARTIST', 'ALBUM', 'TRACKNUMBER', 'GENRE', 'DATE', 'DESCRIPTION', 'COMMENT');
 		$ThisFileInfo_ogg_comments_raw = &$info['ogg']['comments_raw'];
 		for ($i = 0; $i < $CommentsCount; $i++) {
+
+			if ($i >= 10000) {
+				// https://github.com/owncloud/music/issues/212#issuecomment-43082336
+				$this->warning('Unexpectedly large number ('.$CommentsCount.') of Ogg comments - breaking after reading '.$i.' comments');
+				break;
+			}
 
 			$ThisFileInfo_ogg_comments_raw[$i]['dataoffset'] = $CommentStartOffset + $commentdataoffset;
 
@@ -478,7 +674,7 @@ class getid3_ogg extends getid3_handler
 			$commentdataoffset += 4;
 			while ((strlen($commentdata) - $commentdataoffset) < $ThisFileInfo_ogg_comments_raw[$i]['size']) {
 				if (($ThisFileInfo_ogg_comments_raw[$i]['size'] > $info['avdataend']) || ($ThisFileInfo_ogg_comments_raw[$i]['size'] < 0)) {
-					$info['warning'][] = 'Invalid Ogg comment size (comment #'.$i.', claims to be '.number_format($ThisFileInfo_ogg_comments_raw[$i]['size']).' bytes) - aborting reading comments';
+					$this->warning('Invalid Ogg comment size (comment #'.$i.', claims to be '.number_format($ThisFileInfo_ogg_comments_raw[$i]['size']).' bytes) - aborting reading comments');
 					break 2;
 				}
 
@@ -502,12 +698,12 @@ class getid3_ogg extends getid3_handler
 
 				//$commentdata .= $this->fread($info['ogg']['pageheader'][$oggpageinfo['page_seqno']]['page_length']);
 				if (!isset($info['ogg']['pageheader'][$VorbisCommentPage])) {
-					$info['warning'][] = 'undefined Vorbis Comment page "'.$VorbisCommentPage.'" at offset '.$this->ftell();
+					$this->warning('undefined Vorbis Comment page "'.$VorbisCommentPage.'" at offset '.$this->ftell());
 					break;
 				}
 				$readlength = self::OggPageSegmentLength($info['ogg']['pageheader'][$VorbisCommentPage], 1);
 				if ($readlength <= 0) {
-					$info['warning'][] = 'invalid length Vorbis Comment page "'.$VorbisCommentPage.'" at offset '.$this->ftell();
+					$this->warning('invalid length Vorbis Comment page "'.$VorbisCommentPage.'" at offset '.$this->ftell());
 					break;
 				}
 				$commentdata .= $this->fread($readlength);
@@ -521,7 +717,7 @@ class getid3_ogg extends getid3_handler
 			if (!$commentstring) {
 
 				// no comment?
-				$info['warning'][] = 'Blank Ogg comment ['.$i.']';
+				$this->warning('Blank Ogg comment ['.$i.']');
 
 			} elseif (strstr($commentstring, '=')) {
 
@@ -554,8 +750,12 @@ class getid3_ogg extends getid3_handler
 					$ogg = new self($this->getid3);
 					$ogg->setStringMode($data);
 					$info['ogg']['comments']['picture'][] = array(
-						'image_mime' => $imageinfo['mime'],
-						'data'       => $ogg->saveAttachment('coverart', 0, strlen($data), $imageinfo['mime']),
+						'image_mime'   => $imageinfo['mime'],
+						'datalength'   => strlen($data),
+						'picturetype'  => 'cover art',
+						'image_height' => $imageinfo['height'],
+						'image_width'  => $imageinfo['width'],
+						'data'         => $ogg->saveAttachment('coverart', 0, strlen($data), $imageinfo['mime']),
 					);
 					unset($ogg);
 
@@ -567,7 +767,7 @@ class getid3_ogg extends getid3_handler
 
 			} else {
 
-				$info['warning'][] = '[known problem with CDex >= v1.40, < v1.50b7] Invalid Ogg comment name/value pair ['.$i.']: '.$commentstring;
+				$this->warning('[known problem with CDex >= v1.40, < v1.50b7] Invalid Ogg comment name/value pair ['.$i.']: '.$commentstring);
 
 			}
 			unset($ThisFileInfo_ogg_comments_raw[$i]);
@@ -620,6 +820,11 @@ class getid3_ogg extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int $mode
+	 *
+	 * @return string|null
+	 */
 	public static function SpeexBandModeLookup($mode) {
 		static $SpeexBandModeLookup = array();
 		if (empty($SpeexBandModeLookup)) {
@@ -630,8 +835,14 @@ class getid3_ogg extends getid3_handler
 		return (isset($SpeexBandModeLookup[$mode]) ? $SpeexBandModeLookup[$mode] : null);
 	}
 
-
+	/**
+	 * @param array $OggInfoArray
+	 * @param int   $SegmentNumber
+	 *
+	 * @return int
+	 */
 	public static function OggPageSegmentLength($OggInfoArray, $SegmentNumber=1) {
+		$segmentlength = 0;
 		for ($i = 0; $i < $SegmentNumber; $i++) {
 			$segmentlength = 0;
 			foreach ($OggInfoArray['segment_table'] as $key => $value) {
@@ -644,7 +855,11 @@ class getid3_ogg extends getid3_handler
 		return $segmentlength;
 	}
 
-
+	/**
+	 * @param int $nominal_bitrate
+	 *
+	 * @return float
+	 */
 	public static function get_quality_from_nominal_bitrate($nominal_bitrate) {
 
 		// decrease precision
@@ -666,6 +881,40 @@ class getid3_ogg extends getid3_handler
 		//return $qval; // 5.031324
 		//return intval($qval); // 5
 		return round($qval, 1); // 5 or 4.9
+	}
+
+	/**
+	 * @param int $colorspace_id
+	 *
+	 * @return string|null
+	 */
+	public static function TheoraColorSpace($colorspace_id) {
+		// http://www.theora.org/doc/Theora.pdf (table 6.3)
+		static $TheoraColorSpaceLookup = array();
+		if (empty($TheoraColorSpaceLookup)) {
+			$TheoraColorSpaceLookup[0] = 'Undefined';
+			$TheoraColorSpaceLookup[1] = 'Rec. 470M';
+			$TheoraColorSpaceLookup[2] = 'Rec. 470BG';
+			$TheoraColorSpaceLookup[3] = 'Reserved';
+		}
+		return (isset($TheoraColorSpaceLookup[$colorspace_id]) ? $TheoraColorSpaceLookup[$colorspace_id] : null);
+	}
+
+	/**
+	 * @param int $pixelformat_id
+	 *
+	 * @return string|null
+	 */
+	public static function TheoraPixelFormat($pixelformat_id) {
+		// http://www.theora.org/doc/Theora.pdf (table 6.4)
+		static $TheoraPixelFormatLookup = array();
+		if (empty($TheoraPixelFormatLookup)) {
+			$TheoraPixelFormatLookup[0] = '4:2:0';
+			$TheoraPixelFormatLookup[1] = 'Reserved';
+			$TheoraPixelFormatLookup[2] = '4:2:2';
+			$TheoraPixelFormatLookup[3] = '4:4:4';
+		}
+		return (isset($TheoraPixelFormatLookup[$pixelformat_id]) ? $TheoraPixelFormatLookup[$pixelformat_id] : null);
 	}
 
 }

--- a/application/libraries/getid3/module.audio.rkau.php
+++ b/application/libraries/getid3/module.audio.rkau.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.shorten.php                                    //
@@ -13,18 +14,23 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_rkau extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$RKAUHeader = fread($this->getid3->fp, 20);
+		$this->fseek($info['avdataoffset']);
+		$RKAUHeader = $this->fread(20);
 		$magic = 'RKA';
 		if (substr($RKAUHeader, 0, 3) != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($RKAUHeader, 0, 3)).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($RKAUHeader, 0, 3)).'"');
 			return false;
 		}
 
@@ -35,7 +41,7 @@ class getid3_rkau extends getid3_handler
 		$info['rkau']['raw']['version']   = getid3_lib::LittleEndian2Int(substr($RKAUHeader, 3, 1));
 		$info['rkau']['version']          = '1.'.str_pad($info['rkau']['raw']['version'] & 0x0F, 2, '0', STR_PAD_LEFT);
 		if (($info['rkau']['version'] > 1.07) || ($info['rkau']['version'] < 1.06)) {
-			$info['error'][] = 'This version of getID3() ['.$this->getid3->version().'] can only parse RKAU files v1.06 and 1.07 (this file is v'.$info['rkau']['version'].')';
+			$this->error('This version of getID3() ['.$this->getid3->version().'] can only parse RKAU files v1.06 and 1.07 (this file is v'.$info['rkau']['version'].')');
 			unset($info['rkau']);
 			return false;
 		}
@@ -49,7 +55,7 @@ class getid3_rkau extends getid3_handler
 		$this->RKAUqualityLookup($info['rkau']);
 
 		$info['rkau']['raw']['flags']            = getid3_lib::LittleEndian2Int(substr($RKAUHeader, 15, 1));
-		$info['rkau']['flags']['joint_stereo']   = (bool) (!($info['rkau']['raw']['flags'] & 0x01));
+		$info['rkau']['flags']['joint_stereo']   = !($info['rkau']['raw']['flags'] & 0x01);
 		$info['rkau']['flags']['streaming']      =  (bool)  ($info['rkau']['raw']['flags'] & 0x02);
 		$info['rkau']['flags']['vrq_lossy_mode'] =  (bool)  ($info['rkau']['raw']['flags'] & 0x04);
 
@@ -75,7 +81,11 @@ class getid3_rkau extends getid3_handler
 
 	}
 
-
+	/**
+	 * @param array $RKAUdata
+	 *
+	 * @return bool
+	 */
 	public function RKAUqualityLookup(&$RKAUdata) {
 		$level   = ($RKAUdata['raw']['quality'] & 0xF0) >> 4;
 		$quality =  $RKAUdata['raw']['quality'] & 0x0F;

--- a/application/libraries/getid3/module.audio.shorten.php
+++ b/application/libraries/getid3/module.audio.shorten.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.shorten.php                                    //
@@ -13,19 +14,23 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
-
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 class getid3_shorten extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+		$this->fseek($info['avdataoffset']);
 
-		$ShortenHeader = fread($this->getid3->fp, 8);
+		$ShortenHeader = $this->fread(8);
 		$magic = 'ajkg';
 		if (substr($ShortenHeader, 0, 4) != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($ShortenHeader, 0, 4)).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($ShortenHeader, 0, 4)).'"');
 			return false;
 		}
 		$info['fileformat']            = 'shn';
@@ -35,18 +40,18 @@ class getid3_shorten extends getid3_handler
 
 		$info['shn']['version'] = getid3_lib::LittleEndian2Int(substr($ShortenHeader, 4, 1));
 
-		fseek($this->getid3->fp, $info['avdataend'] - 12, SEEK_SET);
-		$SeekTableSignatureTest = fread($this->getid3->fp, 12);
-		$info['shn']['seektable']['present'] = (bool) (substr($SeekTableSignatureTest, 4, 8) == 'SHNAMPSK');
+		$this->fseek($info['avdataend'] - 12);
+		$SeekTableSignatureTest = $this->fread(12);
+		$info['shn']['seektable']['present'] = substr($SeekTableSignatureTest, 4, 8) == 'SHNAMPSK';
 		if ($info['shn']['seektable']['present']) {
 			$info['shn']['seektable']['length'] = getid3_lib::LittleEndian2Int(substr($SeekTableSignatureTest, 0, 4));
 			$info['shn']['seektable']['offset'] = $info['avdataend'] - $info['shn']['seektable']['length'];
-			fseek($this->getid3->fp, $info['shn']['seektable']['offset'], SEEK_SET);
-			$SeekTableMagic = fread($this->getid3->fp, 4);
+			$this->fseek($info['shn']['seektable']['offset']);
+			$SeekTableMagic = $this->fread(4);
 			$magic = 'SEEK';
 			if ($SeekTableMagic != $magic) {
 
-				$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['shn']['seektable']['offset'].', found "'.getid3_lib::PrintHexBytes($SeekTableMagic).'"';
+				$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['shn']['seektable']['offset'].', found "'.getid3_lib::PrintHexBytes($SeekTableMagic).'"');
 				return false;
 
 			} else {
@@ -67,7 +72,7 @@ class getid3_shorten extends getid3_handler
 				//   long Offset1[4];
 				// }TSeekEntry;
 
-				$SeekTableData = fread($this->getid3->fp, $info['shn']['seektable']['length'] - 16);
+				$SeekTableData = $this->fread($info['shn']['seektable']['length'] - 16);
 				$info['shn']['seektable']['entry_count'] = floor(strlen($SeekTableData) / 80);
 				//$info['shn']['seektable']['entries'] = array();
 				//$SeekTableOffset = 0;
@@ -113,7 +118,7 @@ class getid3_shorten extends getid3_handler
 		}
 
 		if (preg_match('#(1|ON)#i', ini_get('safe_mode'))) {
-			$info['error'][] = 'PHP running in Safe Mode - backtick operator not available, cannot run shntool to analyze Shorten files';
+			$this->error('PHP running in Safe Mode - backtick operator not available, cannot run shntool to analyze Shorten files');
 			return false;
 		}
 
@@ -122,7 +127,7 @@ class getid3_shorten extends getid3_handler
 			$RequiredFiles = array('shorten.exe', 'cygwin1.dll', 'head.exe');
 			foreach ($RequiredFiles as $required_file) {
 				if (!is_readable(GETID3_HELPERAPPSDIR.$required_file)) {
-					$info['error'][] = GETID3_HELPERAPPSDIR.$required_file.' does not exist';
+					$this->error(GETID3_HELPERAPPSDIR.$required_file.' does not exist');
 					return false;
 				}
 			}
@@ -136,7 +141,7 @@ class getid3_shorten extends getid3_handler
 				$shorten_present = file_exists('/usr/local/bin/shorten') || `which shorten`;
 			}
 			if (!$shorten_present) {
-				$info['error'][] = 'shorten binary was not found in path or /usr/local/bin';
+				$this->error('shorten binary was not found in path or /usr/local/bin');
 				return false;
 			}
 			$commandline = (file_exists('/usr/local/bin/shorten') ? '/usr/local/bin/' : '' ) . 'shorten -x '.escapeshellarg($info['filenamepath']).' - | head -c 64';
@@ -147,6 +152,9 @@ class getid3_shorten extends getid3_handler
 
 		if (!empty($output) && (substr($output, 12, 4) == 'fmt ')) {
 
+			if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+				exit;
+			}
 			getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio-video.riff.php', __FILE__, true);
 
 			$fmt_size = getid3_lib::LittleEndian2Int(substr($output, 16, 4));
@@ -161,7 +169,7 @@ class getid3_shorten extends getid3_handler
 
 			} else {
 
-				$info['error'][] = 'shorten failed to decode DATA chunk to expected location, cannot determine playtime';
+				$this->error('shorten failed to decode DATA chunk to expected location, cannot determine playtime');
 				return false;
 
 			}
@@ -170,7 +178,7 @@ class getid3_shorten extends getid3_handler
 
 		} else {
 
-			$info['error'][] = 'shorten failed to decode file to WAV for parsing';
+			$this->error('shorten failed to decode file to WAV for parsing');
 			return false;
 
 		}

--- a/application/libraries/getid3/module.audio.tak.php
+++ b/application/libraries/getid3/module.audio.tak.php
@@ -1,0 +1,214 @@
+<?php
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at http://getid3.sourceforge.net                 //
+//            or https://www.getid3.org                         //
+//          also https://github.com/JamesHeinrich/getID3       //
+/////////////////////////////////////////////////////////////////
+// See readme.txt for more details                             //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// module.audio.tak.php                                        //
+// module for analyzing Tom's lossless Audio Kompressor        //
+// dependencies: NONE                                          //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+
+class getid3_tak extends getid3_handler
+{
+
+	public function Analyze() {
+		$info = &$this->getid3->info;
+
+		$info['fileformat']            = 'tak';
+		$info['audio']['dataformat']   = 'tak';
+		$info['audio']['bitrate_mode'] = 'vbr';
+		$info['audio']['lossless']     = true;
+
+		$info['tak_audio']['raw'] = array();
+		$thisfile_takaudio                = &$info['tak_audio'];
+		$thisfile_takaudio_raw            = &$thisfile_takaudio['raw'];
+
+		$this->fseek($info['avdataoffset']);
+		$TAKMetaData = $this->fread(4);
+
+		$thisfile_takaudio_raw['magic'] = $TAKMetaData;
+		$magic = 'tBaK';
+		if ($thisfile_takaudio_raw['magic'] != $magic) {
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($thisfile_takaudio_raw['magic']).'"');
+			unset($info['fileformat']);
+			return false;
+		}
+		$offset = 4; //skip magic
+		$this->fseek($offset);
+		$TAKMetaData = $this->fread(4); //read Metadata Block Header
+		$objtype = getid3_lib::BigEndian2Int(substr($TAKMetaData, 0, 1)); //Metadata Block Object Type
+		$objlength = getid3_lib::LittleEndian2Int(substr($TAKMetaData, 1, 3)); //Metadata Block Object Lenght excluding header
+		if ($objtype == 1) { //The First Metadata Block Object must be of Type 1 (STREAMINFO)
+			$offset += 4; //skip to Metadata Block contents
+			$this->fseek($offset);
+		        $TAKMetaData = $this->fread($objlength); // Get the raw Metadata Block Data
+			$thisfile_takaudio_raw['STREAMINFO'] = getid3_lib::LittleEndian2Bin(substr($TAKMetaData, 0, $objlength - 3));
+			$offset += $objlength; // Move to the next Metadata Block Object
+			$thisfile_takaudio['channels'] = getid3_lib::Bin2Dec(substr($thisfile_takaudio_raw['STREAMINFO'], 1, 4)) + 1;
+			$thisfile_takaudio['bits_per_sample'] = getid3_lib::Bin2Dec(substr($thisfile_takaudio_raw['STREAMINFO'], 5, 5)) + 8;
+			$thisfile_takaudio['sample_rate'] = getid3_lib::Bin2Dec(substr($thisfile_takaudio_raw['STREAMINFO'], 10, 18)) + 6000;
+			$thisfile_takaudio['samples'] = getid3_lib::Bin2Dec(substr($thisfile_takaudio_raw['STREAMINFO'], 31, 35));
+			$thisfile_takaudio['framesize'] = self::TAKFramesizeLookup(getid3_lib::Bin2Dec(substr($thisfile_takaudio_raw['STREAMINFO'], 66, 4)));
+			$thisfile_takaudio['codectype'] = self::TAKCodecTypeLookup(getid3_lib::Bin2Dec(substr($thisfile_takaudio_raw['STREAMINFO'], 74, 6)));
+		} else {
+			$this->error('Expecting Type 1 (STREAMINFO) Metadata Object header, but found Type "'.$objtype.'" Object instead');
+			unset($info['fileformat']);
+			return false;
+		}
+		$this->fseek($offset);
+		$TAKMetaData = $this->fread(4);
+		$objtype = getid3_lib::BigEndian2Int(substr($TAKMetaData, 0, 1));
+		$objlength = getid3_lib::LittleEndian2Int(substr($TAKMetaData, 1, 3));
+		while ($objtype != 0) {
+			switch ($objtype) {
+			case 4 :
+				// ENCODERINFO Metadata Block
+				$offset += 4;
+				$this->fseek($offset);
+		                $TAKMetaData = $this->fread($objlength);
+				$ver = getid3_lib::LittleEndian2Int(substr($TAKMetaData, 0, 3));
+				$major = ($ver & 0xff0000) >> 16;
+				$minor = ($ver & 0x00ff00) >> 8;
+				$revision= $ver & 0x0000ff;
+				$thisfile_takaudio['version'] = 'TAK V '.$major.'.'.$minor.'.'.$revision;
+				$thisfile_takaudio['profile'] = self::TAKProfileLookup(getid3_lib::BigEndian2Int(substr($TAKMetaData, 3, 1)));
+				$offset += $objlength;
+				break;
+			case 6 :
+				// MD5 Checksum Metadata Block
+				$offset += 4;
+				$this->fseek($offset);
+		                $TAKMetaData = $this->fread($objlength);
+				$thisfile_takaudio_raw['MD5Data'] = substr($TAKMetaData, 0, 16);
+				$offset += $objlength;
+				break;
+			case 7 :
+				// LASTFRAME Metadata Block
+				$offset += 4;
+				$this->fseek($offset);
+		                $TAKMetaData = $this->fread($objlength);
+				$thisfile_takaudio['lastframe_pos'] = getid3_lib::LittleEndian2Int(substr($TAKMetaData, 0, 5));
+				$thisfile_takaudio['last_frame_size'] = getid3_lib::LittleEndian2Int(substr($TAKMetaData, 5, 3));
+				$offset += $objlength;
+				break;
+			case 3 :
+				// ORIGINALFILEDATA Metadata Block
+				$offset += 4;
+				$this->fseek($offset);
+		                $TAKMetaData = $this->fread($objlength);
+				$headersize = getid3_lib::LittleEndian2Int(substr($TAKMetaData, 0, 3));
+				$footersize = getid3_lib::LittleEndian2Int(substr($TAKMetaData, 3, 3));
+				if ($headersize) $thisfile_takaudio_raw['header_data'] = substr($TAKMetaData, 6, $headersize);
+				if ($footersize) $thisfile_takaudio_raw['footer_data'] = substr($TAKMetaData, $headersize, $footersize);
+				$offset += $objlength;
+				break;
+			default :
+				// PADDING or SEEKTABLE Metadata Block. Just skip it
+				$offset += 4;
+				$this->fseek($offset);
+		                $TAKMetaData = $this->fread($objlength);
+				$offset += $objlength;
+				break;
+			}
+			$this->fseek($offset);
+			$TAKMetaData = $this->fread(4);
+			$objtype = getid3_lib::BigEndian2Int(substr($TAKMetaData, 0, 1));
+			$objlength = getid3_lib::LittleEndian2Int(substr($TAKMetaData, 1, 3));
+		}
+		// Finished all Metadata Blocks. So update $info['avdataoffset'] because next block is the first Audio data block
+		$info['avdataoffset'] = $offset;
+
+		$info['audio']['channels'] = $thisfile_takaudio['channels'];
+		if ($thisfile_takaudio['sample_rate'] == 0) {
+			$this->error('Corrupt TAK file: samplerate == zero');
+			return false;
+		}
+		$info['audio']['sample_rate'] = $thisfile_takaudio['sample_rate'];
+		$thisfile_takaudio['playtime'] = $thisfile_takaudio['samples'] / $thisfile_takaudio['sample_rate'];
+		if ($thisfile_takaudio['playtime'] == 0) {
+			$this->error('Corrupt TAK file: playtime == zero');
+			return false;
+		}
+		$info['playtime_seconds'] = $thisfile_takaudio['playtime'];
+		$thisfile_takaudio['compressed_size'] = $info['avdataend'] - $info['avdataoffset'];
+		$thisfile_takaudio['uncompressed_size'] = $thisfile_takaudio['samples'] * $thisfile_takaudio['channels'] * ($thisfile_takaudio['bits_per_sample'] / 8);
+		if ($thisfile_takaudio['uncompressed_size'] == 0) {
+			$this->error('Corrupt TAK file: uncompressed_size == zero');
+			return false;
+		}
+		$thisfile_takaudio['compression_ratio'] = $thisfile_takaudio['compressed_size'] / ($thisfile_takaudio['uncompressed_size'] + $offset);
+		$thisfile_takaudio['bitrate'] = (($thisfile_takaudio['samples'] * $thisfile_takaudio['channels'] * $thisfile_takaudio['bits_per_sample']) / $thisfile_takaudio['playtime']) * $thisfile_takaudio['compression_ratio'];
+		$info['audio']['bitrate'] = $thisfile_takaudio['bitrate'];
+
+		if (empty($thisfile_takaudio_raw['MD5Data'])) {
+			//$this->warning('MD5Data is not set');
+		} elseif ($thisfile_takaudio_raw['MD5Data'] === str_repeat("\x00", 16)) {
+			//$this->warning('MD5Data is null');
+		} else {
+			$info['md5_data_source'] = '';
+			$md5 = $thisfile_takaudio_raw['MD5Data'];
+			for ($i = 0; $i < strlen($md5); $i++) {
+				$info['md5_data_source'] .= str_pad(dechex(ord($md5[$i])), 2, '00', STR_PAD_LEFT);
+			}
+			if (!preg_match('/^[0-9a-f]{32}$/', $info['md5_data_source'])) {
+				unset($info['md5_data_source']);
+			}
+		}
+
+		foreach (array('bits_per_sample', 'version', 'profile') as $key) {
+			if (!empty($thisfile_takaudio[$key])) {
+				$info['audio'][$key] = $thisfile_takaudio[$key];
+			}
+		}
+
+		return true;
+	}
+
+	public function TAKFramesizeLookup($framesize) {
+		static $TAKFramesizeLookup = array(
+			0     => '94 ms',
+			1     => '125 ms',
+			2     => '188 ms',
+			3     => '250 ms',
+			4     => '4096 samples',
+			5     => '8192 samples',
+			6     => '16384 samples',
+			7     => '512 samples',
+			8     => '1024 samples',
+			9     => '2048 samples'
+		);
+		return (isset($TAKFramesizeLookup[$framesize]) ? $TAKFramesizeLookup[$framesize] : 'invalid');
+	}
+	public function TAKCodecTypeLookup($code) {
+		static $TAKCodecTypeLookup = array(
+			0     => 'Integer 24 bit (TAK 1.0)',
+			1     => 'Experimental!',
+			2     => 'Integer 24 bit (TAK 2.0)',
+			3     => 'LossyWav (TAK 2.1)',
+			4     => 'Integer 24 bit MC (TAK 2.2)'
+		);
+		return (isset($TAKCodecTypeLookup[$code]) ? $TAKCodecTypeLookup[$code] : 'invalid');
+	}
+	public function TAKProfileLookup($code) {
+		$out ='-p';
+		$evaluation = ($code & 0xf0) >> 4;
+		$compresion = $code & 0x0f;
+		static $TAKEvaluationLookup = array(
+			0     => '',
+			1     => 'e',
+			2     => 'm'
+		);
+		return (isset($TAKEvaluationLookup[$evaluation]) ? $out .= $compresion . $TAKEvaluationLookup[$evaluation] : 'invalid');
+	}
+
+}

--- a/application/libraries/getid3/module.audio.tta.php
+++ b/application/libraries/getid3/module.audio.tta.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.tta.php                                        //
@@ -13,10 +14,15 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_tta extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -25,20 +31,20 @@ class getid3_tta extends getid3_handler
 		$info['audio']['lossless']     = true;
 		$info['audio']['bitrate_mode'] = 'vbr';
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$ttaheader = fread($this->getid3->fp, 26);
+		$this->fseek($info['avdataoffset']);
+		$ttaheader = $this->fread(26);
 
 		$info['tta']['magic'] = substr($ttaheader, 0, 3);
 		$magic = 'TTA';
 		if ($info['tta']['magic'] != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['tta']['magic']).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['tta']['magic']).'"');
 			unset($info['fileformat']);
 			unset($info['audio']);
 			unset($info['tta']);
 			return false;
 		}
 
-		switch ($ttaheader{3}) {
+		switch ($ttaheader[3]) {
 			case "\x01": // TTA v1.x
 			case "\x02": // TTA v1.x
 			case "\x03": // TTA v1.x
@@ -46,7 +52,7 @@ class getid3_tta extends getid3_handler
 				$info['tta']['major_version'] = 1;
 				$info['avdataoffset'] += 16;
 
-				$info['tta']['compression_level']   = ord($ttaheader{3});
+				$info['tta']['compression_level']   = ord($ttaheader[3]);
 				$info['tta']['channels']            = getid3_lib::LittleEndian2Int(substr($ttaheader,  4,  2));
 				$info['tta']['bits_per_sample']     = getid3_lib::LittleEndian2Int(substr($ttaheader,  6,  2));
 				$info['tta']['sample_rate']         = getid3_lib::LittleEndian2Int(substr($ttaheader,  8,  4));
@@ -89,9 +95,8 @@ class getid3_tta extends getid3_handler
 				break;
 
 			default:
-				$info['error'][] = 'This version of getID3() ['.$this->getid3->version().'] only knows how to handle TTA v1 and v2 - it may not work correctly with this file which appears to be TTA v'.$ttaheader{3};
+				$this->error('This version of getID3() ['.$this->getid3->version().'] only knows how to handle TTA v1 and v2 - it may not work correctly with this file which appears to be TTA v'.$ttaheader[3]);
 				return false;
-				break;
 		}
 
 		$info['audio']['encoder']         = 'TTA v'.$info['tta']['major_version'];

--- a/application/libraries/getid3/module.audio.wavpack.php
+++ b/application/libraries/getid3/module.audio.wavpack.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.audio.wavpack.php                                    //
@@ -13,20 +14,24 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
-
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 class getid3_wavpack extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+		$this->fseek($info['avdataoffset']);
 
 		while (true) {
 
-			$wavpackheader = fread($this->getid3->fp, 32);
+			$wavpackheader = $this->fread(32);
 
-			if (ftell($this->getid3->fp) >= $info['avdataend']) {
+			if ($this->ftell() >= $info['avdataend']) {
 				break;
 			} elseif (feof($this->getid3->fp)) {
 				break;
@@ -40,13 +45,13 @@ class getid3_wavpack extends getid3_handler
 					break;
 			}
 
-			$blockheader_offset = ftell($this->getid3->fp) - 32;
+			$blockheader_offset = $this->ftell() - 32;
 			$blockheader_magic  =                              substr($wavpackheader,  0,  4);
 			$blockheader_size   = getid3_lib::LittleEndian2Int(substr($wavpackheader,  4,  4));
 
 			$magic = 'wvpk';
 			if ($blockheader_magic != $magic) {
-				$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$blockheader_offset.', found "'.getid3_lib::PrintHexBytes($blockheader_magic).'"';
+				$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$blockheader_offset.', found "'.getid3_lib::PrintHexBytes($blockheader_magic).'"');
 				switch (isset($info['audio']['dataformat']) ? $info['audio']['dataformat'] : '') {
 					case 'wavpack':
 					case 'wvc':
@@ -85,7 +90,7 @@ class getid3_wavpack extends getid3_handler
 				$info['wavpack']['blockheader']['size']   = $blockheader_size;
 
 				if ($info['wavpack']['blockheader']['size'] >= 0x100000) {
-					$info['error'][] = 'Expecting WavPack block size less than "0x100000", found "'.$info['wavpack']['blockheader']['size'].'" at offset '.$info['wavpack']['blockheader']['offset'];
+					$this->error('Expecting WavPack block size less than "0x100000", found "'.$info['wavpack']['blockheader']['size'].'" at offset '.$info['wavpack']['blockheader']['offset']);
 					switch (isset($info['audio']['dataformat']) ? $info['audio']['dataformat'] : '') {
 						case 'wavpack':
 						case 'wvc':
@@ -99,13 +104,13 @@ class getid3_wavpack extends getid3_handler
 					return false;
 				}
 
-				$info['wavpack']['blockheader']['minor_version'] = ord($wavpackheader{8});
-				$info['wavpack']['blockheader']['major_version'] = ord($wavpackheader{9});
+				$info['wavpack']['blockheader']['minor_version'] = ord($wavpackheader[8]);
+				$info['wavpack']['blockheader']['major_version'] = ord($wavpackheader[9]);
 
 				if (($info['wavpack']['blockheader']['major_version'] != 4) ||
 					(($info['wavpack']['blockheader']['minor_version'] < 4) &&
 					($info['wavpack']['blockheader']['minor_version'] > 16))) {
-						$info['error'][] = 'Expecting WavPack version between "4.2" and "4.16", found version "'.$info['wavpack']['blockheader']['major_version'].'.'.$info['wavpack']['blockheader']['minor_version'].'" at offset '.$info['wavpack']['blockheader']['offset'];
+						$this->error('Expecting WavPack version between "4.2" and "4.16", found version "'.$info['wavpack']['blockheader']['major_version'].'.'.$info['wavpack']['blockheader']['minor_version'].'" at offset '.$info['wavpack']['blockheader']['offset']);
 						switch (isset($info['audio']['dataformat']) ? $info['audio']['dataformat'] : '') {
 							case 'wavpack':
 							case 'wvc':
@@ -119,8 +124,8 @@ class getid3_wavpack extends getid3_handler
 						return false;
 				}
 
-				$info['wavpack']['blockheader']['track_number']  = ord($wavpackheader{10}); // unused
-				$info['wavpack']['blockheader']['index_number']  = ord($wavpackheader{11}); // unused
+				$info['wavpack']['blockheader']['track_number']  = ord($wavpackheader[10]); // unused
+				$info['wavpack']['blockheader']['index_number']  = ord($wavpackheader[11]); // unused
 				$info['wavpack']['blockheader']['total_samples'] = getid3_lib::LittleEndian2Int(substr($wavpackheader, 12,  4));
 				$info['wavpack']['blockheader']['block_index']   = getid3_lib::LittleEndian2Int(substr($wavpackheader, 16,  4));
 				$info['wavpack']['blockheader']['block_samples'] = getid3_lib::LittleEndian2Int(substr($wavpackheader, 20,  4));
@@ -143,14 +148,14 @@ class getid3_wavpack extends getid3_handler
 				$info['audio']['lossless'] = !$info['wavpack']['blockheader']['flags']['hybrid'];
 			}
 
-			while (!feof($this->getid3->fp) && (ftell($this->getid3->fp) < ($blockheader_offset + $blockheader_size + 8))) {
+			while (!feof($this->getid3->fp) && ($this->ftell() < ($blockheader_offset + $blockheader_size + 8))) {
 
-				$metablock = array('offset'=>ftell($this->getid3->fp));
-				$metablockheader = fread($this->getid3->fp, 2);
+				$metablock = array('offset'=>$this->ftell());
+				$metablockheader = $this->fread(2);
 				if (feof($this->getid3->fp)) {
 					break;
 				}
-				$metablock['id'] = ord($metablockheader{0});
+				$metablock['id'] = ord($metablockheader[0]);
 				$metablock['function_id'] = ($metablock['id'] & 0x3F);
 				$metablock['function_name'] = $this->WavPackMetablockNameLookup($metablock['function_id']);
 
@@ -166,10 +171,11 @@ class getid3_wavpack extends getid3_handler
 				$metablock['padded_data'] = (bool) ($metablock['id'] & 0x40);
 				$metablock['large_block'] = (bool) ($metablock['id'] & 0x80);
 				if ($metablock['large_block']) {
-					$metablockheader .= fread($this->getid3->fp, 2);
+					$metablockheader .= $this->fread(2);
 				}
 				$metablock['size'] = getid3_lib::LittleEndian2Int(substr($metablockheader, 1)) * 2; // size is stored in words
 				$metablock['data'] = null;
+				$metablock['comments'] = array();
 
 				if ($metablock['size'] > 0) {
 
@@ -180,7 +186,7 @@ class getid3_wavpack extends getid3_handler
 						case 0x24: // ID_CUESHEET
 						case 0x25: // ID_CONFIG_BLOCK
 						case 0x26: // ID_MD5_CHECKSUM
-							$metablock['data'] = fread($this->getid3->fp, $metablock['size']);
+							$metablock['data'] = $this->fread($metablock['size']);
 
 							if ($metablock['padded_data']) {
 								// padded to the nearest even byte
@@ -203,12 +209,12 @@ class getid3_wavpack extends getid3_handler
 						case 0x0B: // ID_WVC_BITSTREAM
 						case 0x0C: // ID_WVX_BITSTREAM
 						case 0x0D: // ID_CHANNEL_INFO
-							fseek($this->getid3->fp, $metablock['offset'] + ($metablock['large_block'] ? 4 : 2) + $metablock['size'], SEEK_SET);
+							$this->fseek($metablock['offset'] + ($metablock['large_block'] ? 4 : 2) + $metablock['size']);
 							break;
 
 						default:
-							$info['warning'][] = 'Unexpected metablock type "0x'.str_pad(dechex($metablock['function_id']), 2, '0', STR_PAD_LEFT).'" at offset '.$metablock['offset'];
-							fseek($this->getid3->fp, $metablock['offset'] + ($metablock['large_block'] ? 4 : 2) + $metablock['size'], SEEK_SET);
+							$this->warning('Unexpected metablock type "0x'.str_pad(dechex($metablock['function_id']), 2, '0', STR_PAD_LEFT).'" at offset '.$metablock['offset']);
+							$this->fseek($metablock['offset'] + ($metablock['large_block'] ? 4 : 2) + $metablock['size']);
 							break;
 					}
 
@@ -218,7 +224,7 @@ class getid3_wavpack extends getid3_handler
 							$original_wav_filesize = getid3_lib::LittleEndian2Int(substr($metablock['data'], 4, 4));
 
 							$getid3_temp = new getID3();
-							$getid3_temp->openfile($this->getid3->filename);
+							$getid3_temp->openfile($this->getid3->filename, $this->getid3->info['filesize'], $this->getid3->fp);
 							$getid3_riff = new getid3_riff($getid3_temp);
 							$getid3_riff->ParseRIFFdata($metablock['data']);
 							$metablock['riff']            = $getid3_temp->info['riff'];
@@ -235,14 +241,14 @@ class getid3_wavpack extends getid3_handler
 
 
 						case 0x22: // ID_RIFF_TRAILER
-							$metablockRIFFfooter = $metablockRIFFheader.$metablock['data'];
+							$metablockRIFFfooter = isset($metablockRIFFheader) ? $metablockRIFFheader : ''.$metablock['data'];
 							getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio-video.riff.php', __FILE__, true);
 
 							$startoffset = $metablock['offset'] + ($metablock['large_block'] ? 4 : 2);
 							$getid3_temp = new getID3();
-							$getid3_temp->openfile($this->getid3->filename);
+							$getid3_temp->openfile($this->getid3->filename, $this->getid3->info['filesize'], $this->getid3->fp);
 							$getid3_temp->info['avdataend']  = $info['avdataend'];
-							$getid3_temp->info['fileformat'] = 'riff';
+							//$getid3_temp->info['fileformat'] = 'riff';
 							$getid3_riff = new getid3_riff($getid3_temp);
 							$metablock['riff'] = $getid3_riff->ParseRIFF($startoffset, $startoffset + $metablock['size']);
 
@@ -255,12 +261,12 @@ class getid3_wavpack extends getid3_handler
 
 
 						case 0x23: // ID_REPLAY_GAIN
-							$info['warning'][] = 'WavPack "Replay Gain" contents not yet handled by getID3() in metablock at offset '.$metablock['offset'];
+							$this->warning('WavPack "Replay Gain" contents not yet handled by getID3() in metablock at offset '.$metablock['offset']);
 							break;
 
 
 						case 0x24: // ID_CUESHEET
-							$info['warning'][] = 'WavPack "Cuesheet" contents not yet handled by getID3() in metablock at offset '.$metablock['offset'];
+							$this->warning('WavPack "Cuesheet" contents not yet handled by getID3() in metablock at offset '.$metablock['offset']);
 							break;
 
 
@@ -318,7 +324,7 @@ class getid3_wavpack extends getid3_handler
 							if (strlen($metablock['data']) == 16) {
 								$info['md5_data_source'] = strtolower(getid3_lib::PrintHexBytes($metablock['data'], true, false, false));
 							} else {
-								$info['warning'][] = 'Expecting 16 bytes of WavPack "MD5 Checksum" in metablock at offset '.$metablock['offset'].', but found '.strlen($metablock['data']).' bytes';
+								$this->warning('Expecting 16 bytes of WavPack "MD5 Checksum" in metablock at offset '.$metablock['offset'].', but found '.strlen($metablock['data']).' bytes');
 							}
 							break;
 
@@ -367,7 +373,11 @@ class getid3_wavpack extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @param int $id
+	 *
+	 * @return string
+	 */
 	public function WavPackMetablockNameLookup(&$id) {
 		static $WavPackMetablockNameLookup = array(
 			0x00 => 'Dummy',

--- a/application/libraries/getid3/module.graphic.bmp.php
+++ b/application/libraries/getid3/module.graphic.bmp.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.graphic.bmp.php                                      //
@@ -13,12 +14,18 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_bmp extends getid3_handler
 {
 	public $ExtractPalette = false;
 	public $ExtractData    = false;
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -36,16 +43,16 @@ class getid3_bmp extends getid3_handler
 		// WORD    bfReserved2;
 		// DWORD   bfOffBits;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+		$this->fseek($info['avdataoffset']);
 		$offset = 0;
-		$BMPheader = fread($this->getid3->fp, 14 + 40);
+		$BMPheader = $this->fread(14 + 40);
 
 		$thisfile_bmp_header_raw['identifier']  = substr($BMPheader, $offset, 2);
 		$offset += 2;
 
 		$magic = 'BM';
 		if ($thisfile_bmp_header_raw['identifier'] != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($thisfile_bmp_header_raw['identifier']).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($thisfile_bmp_header_raw['identifier']).'"');
 			unset($info['fileformat']);
 			unset($info['bmp']);
 			return false;
@@ -85,7 +92,7 @@ class getid3_bmp extends getid3_handler
 			$thisfile_bmp['type_os']      = 'Windows';
 			$thisfile_bmp['type_version'] = 5;
 		} else {
-			$info['error'][] = 'Unknown BMP subtype (or not a BMP file)';
+			$this->error('Unknown BMP subtype (or not a BMP file)');
 			unset($info['fileformat']);
 			unset($info['bmp']);
 			return false;
@@ -220,7 +227,7 @@ class getid3_bmp extends getid3_handler
 
 			if (($thisfile_bmp['type_version'] >= 4) || ($thisfile_bmp_header_raw['compression'] == 3)) {
 				// should only be v4+, but BMPs with type_version==1 and BI_BITFIELDS compression have been seen
-				$BMPheader .= fread($this->getid3->fp, 44);
+				$BMPheader .= $this->fread(44);
 
 				// BITMAPV4HEADER - [44 bytes] - http://msdn.microsoft.com/library/en-us/gdi/bitmaps_2k1e.asp
 				// Win95+, WinNT4.0+
@@ -262,7 +269,7 @@ class getid3_bmp extends getid3_handler
 			}
 
 			if ($thisfile_bmp['type_version'] >= 5) {
-				$BMPheader .= fread($this->getid3->fp, 16);
+				$BMPheader .= $this->fread(16);
 
 				// BITMAPV5HEADER - [16 bytes] - http://msdn.microsoft.com/library/en-us/gdi/bitmaps_7c36.asp
 				// Win98+, Win2000+
@@ -282,7 +289,7 @@ class getid3_bmp extends getid3_handler
 
 		} else {
 
-			$info['error'][] = 'Unknown BMP format in header.';
+			$this->error('Unknown BMP format in header.');
 			return false;
 
 		}
@@ -296,7 +303,7 @@ class getid3_bmp extends getid3_handler
 				$PaletteEntries = $thisfile_bmp_header_raw['colors_used'];
 			}
 			if ($PaletteEntries > 0) {
-				$BMPpalette = fread($this->getid3->fp, 4 * $PaletteEntries);
+				$BMPpalette = $this->fread(4 * $PaletteEntries);
 				$paletteoffset = 0;
 				for ($i = 0; $i < $PaletteEntries; $i++) {
 					// RGBQUAD          - http://msdn.microsoft.com/library/en-us/gdi/bitmaps_5f8y.asp
@@ -318,9 +325,9 @@ class getid3_bmp extends getid3_handler
 		}
 
 		if ($this->ExtractData) {
-			fseek($this->getid3->fp, $thisfile_bmp_header_raw['data_offset'], SEEK_SET);
+			$this->fseek($thisfile_bmp_header_raw['data_offset']);
 			$RowByteLength = ceil(($thisfile_bmp_header_raw['width'] * ($thisfile_bmp_header_raw['bits_per_pixel'] / 8)) / 4) * 4; // round up to nearest DWORD boundry
-			$BMPpixelData = fread($this->getid3->fp, $thisfile_bmp_header_raw['height'] * $RowByteLength);
+			$BMPpixelData = $this->fread($thisfile_bmp_header_raw['height'] * $RowByteLength);
 			$pixeldataoffset = 0;
 			$thisfile_bmp_header_raw['compression'] = (isset($thisfile_bmp_header_raw['compression']) ? $thisfile_bmp_header_raw['compression'] : '');
 			switch ($thisfile_bmp_header_raw['compression']) {
@@ -330,7 +337,7 @@ class getid3_bmp extends getid3_handler
 						case 1:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col = $col) {
-									$paletteindexbyte = ord($BMPpixelData{$pixeldataoffset++});
+									$paletteindexbyte = ord($BMPpixelData[$pixeldataoffset++]);
 									for ($i = 7; $i >= 0; $i--) {
 										$paletteindex = ($paletteindexbyte & (0x01 << $i)) >> $i;
 										$thisfile_bmp['data'][$row][$col] = $thisfile_bmp['palette'][$paletteindex];
@@ -347,7 +354,7 @@ class getid3_bmp extends getid3_handler
 						case 4:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col = $col) {
-									$paletteindexbyte = ord($BMPpixelData{$pixeldataoffset++});
+									$paletteindexbyte = ord($BMPpixelData[$pixeldataoffset++]);
 									for ($i = 1; $i >= 0; $i--) {
 										$paletteindex = ($paletteindexbyte & (0x0F << (4 * $i))) >> (4 * $i);
 										$thisfile_bmp['data'][$row][$col] = $thisfile_bmp['palette'][$paletteindex];
@@ -364,7 +371,7 @@ class getid3_bmp extends getid3_handler
 						case 8:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col++) {
-									$paletteindex = ord($BMPpixelData{$pixeldataoffset++});
+									$paletteindex = ord($BMPpixelData[$pixeldataoffset++]);
 									$thisfile_bmp['data'][$row][$col] = $thisfile_bmp['palette'][$paletteindex];
 								}
 								while (($pixeldataoffset % 4) != 0) {
@@ -377,7 +384,7 @@ class getid3_bmp extends getid3_handler
 						case 24:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col++) {
-									$thisfile_bmp['data'][$row][$col] = (ord($BMPpixelData{$pixeldataoffset+2}) << 16) | (ord($BMPpixelData{$pixeldataoffset+1}) << 8) | ord($BMPpixelData{$pixeldataoffset});
+									$thisfile_bmp['data'][$row][$col] = (ord($BMPpixelData[$pixeldataoffset+2]) << 16) | (ord($BMPpixelData[$pixeldataoffset+1]) << 8) | ord($BMPpixelData[$pixeldataoffset]);
 									$pixeldataoffset += 3;
 								}
 								while (($pixeldataoffset % 4) != 0) {
@@ -390,7 +397,7 @@ class getid3_bmp extends getid3_handler
 						case 32:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col++) {
-									$thisfile_bmp['data'][$row][$col] = (ord($BMPpixelData{$pixeldataoffset+3}) << 24) | (ord($BMPpixelData{$pixeldataoffset+2}) << 16) | (ord($BMPpixelData{$pixeldataoffset+1}) << 8) | ord($BMPpixelData{$pixeldataoffset});
+									$thisfile_bmp['data'][$row][$col] = (ord($BMPpixelData[$pixeldataoffset+3]) << 24) | (ord($BMPpixelData[$pixeldataoffset+2]) << 16) | (ord($BMPpixelData[$pixeldataoffset+1]) << 8) | ord($BMPpixelData[$pixeldataoffset]);
 									$pixeldataoffset += 4;
 								}
 								while (($pixeldataoffset % 4) != 0) {
@@ -405,7 +412,7 @@ class getid3_bmp extends getid3_handler
 							break;
 
 						default:
-							$info['error'][] = 'Unknown bits-per-pixel value ('.$thisfile_bmp_header_raw['bits_per_pixel'].') - cannot read pixel data';
+							$this->error('Unknown bits-per-pixel value ('.$thisfile_bmp_header_raw['bits_per_pixel'].') - cannot read pixel data');
 							break;
 					}
 					break;
@@ -480,7 +487,7 @@ class getid3_bmp extends getid3_handler
 							break;
 
 						default:
-							$info['error'][] = 'Unknown bits-per-pixel value ('.$thisfile_bmp_header_raw['bits_per_pixel'].') - cannot read pixel data';
+							$this->error('Unknown bits-per-pixel value ('.$thisfile_bmp_header_raw['bits_per_pixel'].') - cannot read pixel data');
 							break;
 					}
 					break;
@@ -527,6 +534,7 @@ class getid3_bmp extends getid3_handler
 											// high- and low-order 4 bits, one color index for each pixel. In absolute mode,
 											// each run must be aligned on a word boundary.
 											unset($paletteindexes);
+											$paletteindexes = array();
 											for ($i = 0; $i < ceil($secondbyte / 2); $i++) {
 												$paletteindexbyte = getid3_lib::LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
 												$paletteindexes[] = ($paletteindexbyte & 0xF0) >> 4;
@@ -569,7 +577,7 @@ class getid3_bmp extends getid3_handler
 							break;
 
 						default:
-							$info['error'][] = 'Unknown bits-per-pixel value ('.$thisfile_bmp_header_raw['bits_per_pixel'].') - cannot read pixel data';
+							$this->error('Unknown bits-per-pixel value ('.$thisfile_bmp_header_raw['bits_per_pixel'].') - cannot read pixel data');
 							break;
 					}
 					break;
@@ -609,14 +617,14 @@ class getid3_bmp extends getid3_handler
 							break;
 
 						default:
-							$info['error'][] = 'Unknown bits-per-pixel value ('.$thisfile_bmp_header_raw['bits_per_pixel'].') - cannot read pixel data';
+							$this->error('Unknown bits-per-pixel value ('.$thisfile_bmp_header_raw['bits_per_pixel'].') - cannot read pixel data');
 							break;
 					}
 					break;
 
 
 				default: // unhandled compression type
-					$info['error'][] = 'Unknown/unhandled compression type value ('.$thisfile_bmp_header_raw['compression'].') - cannot decompress pixel data';
+					$this->error('Unknown/unhandled compression type value ('.$thisfile_bmp_header_raw['compression'].') - cannot decompress pixel data');
 					break;
 			}
 		}
@@ -624,7 +632,11 @@ class getid3_bmp extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @param array $BMPinfo
+	 *
+	 * @return bool
+	 */
 	public function PlotBMP(&$BMPinfo) {
 		$starttime = time();
 		if (!isset($BMPinfo['bmp']['data']) || !is_array($BMPinfo['bmp']['data'])) {
@@ -632,15 +644,15 @@ class getid3_bmp extends getid3_handler
 			return false;
 		}
 		set_time_limit(intval(round($BMPinfo['resolution_x'] * $BMPinfo['resolution_y'] / 10000)));
-		if ($im = ImageCreateTrueColor($BMPinfo['resolution_x'], $BMPinfo['resolution_y'])) {
+		if ($im = imagecreatetruecolor($BMPinfo['resolution_x'], $BMPinfo['resolution_y'])) {
 			for ($row = 0; $row < $BMPinfo['resolution_y']; $row++) {
 				for ($col = 0; $col < $BMPinfo['resolution_x']; $col++) {
 					if (isset($BMPinfo['bmp']['data'][$row][$col])) {
 						$red   = ($BMPinfo['bmp']['data'][$row][$col] & 0x00FF0000) >> 16;
 						$green = ($BMPinfo['bmp']['data'][$row][$col] & 0x0000FF00) >> 8;
 						$blue  = ($BMPinfo['bmp']['data'][$row][$col] & 0x000000FF);
-						$pixelcolor = ImageColorAllocate($im, $red, $green, $blue);
-						ImageSetPixel($im, $col, $row, $pixelcolor);
+						$pixelcolor = imagecolorallocate($im, $red, $green, $blue);
+						imagesetpixel($im, $col, $row, $pixelcolor);
 					} else {
 						//echo 'ERROR: no data for pixel '.$row.' x '.$col.'<BR>';
 						//return false;
@@ -649,18 +661,23 @@ class getid3_bmp extends getid3_handler
 			}
 			if (headers_sent()) {
 				echo 'plotted '.($BMPinfo['resolution_x'] * $BMPinfo['resolution_y']).' pixels in '.(time() - $starttime).' seconds<BR>';
-				ImageDestroy($im);
+				imagedestroy($im);
 				exit;
 			} else {
 				header('Content-type: image/png');
-				ImagePNG($im);
-				ImageDestroy($im);
+				imagepng($im);
+				imagedestroy($im);
 				return true;
 			}
 		}
 		return false;
 	}
 
+	/**
+	 * @param int $compressionid
+	 *
+	 * @return string
+	 */
 	public function BMPcompressionWindowsLookup($compressionid) {
 		static $BMPcompressionWindowsLookup = array(
 			0 => 'BI_RGB',
@@ -673,6 +690,11 @@ class getid3_bmp extends getid3_handler
 		return (isset($BMPcompressionWindowsLookup[$compressionid]) ? $BMPcompressionWindowsLookup[$compressionid] : 'invalid');
 	}
 
+	/**
+	 * @param int $compressionid
+	 *
+	 * @return string
+	 */
 	public function BMPcompressionOS2Lookup($compressionid) {
 		static $BMPcompressionOS2Lookup = array(
 			0 => 'BI_RGB',

--- a/application/libraries/getid3/module.graphic.efax.php
+++ b/application/libraries/getid3/module.graphic.efax.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.archive.efax.php                                     //
@@ -13,26 +14,31 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_efax extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$efaxheader = fread($this->getid3->fp, 1024);
+		$this->fseek($info['avdataoffset']);
+		$efaxheader = $this->fread(1024);
 
 		$info['efax']['header']['magic'] = substr($efaxheader, 0, 2);
 		if ($info['efax']['header']['magic'] != "\xDC\xFE") {
-			$info['error'][] = 'Invalid eFax byte order identifier (expecting DC FE, found '.getid3_lib::PrintHexBytes($info['efax']['header']['magic']).') at offset '.$info['avdataoffset'];
+			$this->error('Invalid eFax byte order identifier (expecting DC FE, found '.getid3_lib::PrintHexBytes($info['efax']['header']['magic']).') at offset '.$info['avdataoffset']);
 			return false;
 		}
 		$info['fileformat'] = 'efax';
 
 		$info['efax']['header']['filesize'] = getid3_lib::LittleEndian2Int(substr($efaxheader, 2, 4));
 		if ($info['efax']['header']['filesize'] != $info['filesize']) {
-			$info['error'][] = 'Probable '.(($info['efax']['header']['filesize'] > $info['filesize']) ? 'truncated' : 'corrupt').' file, expecting '.$info['efax']['header']['filesize'].' bytes, found '.$info['filesize'].' bytes';
+			$this->error('Probable '.(($info['efax']['header']['filesize'] > $info['filesize']) ? 'truncated' : 'corrupt').' file, expecting '.$info['efax']['header']['filesize'].' bytes, found '.$info['filesize'].' bytes');
 		}
 		$info['efax']['header']['software1'] =                        rtrim(substr($efaxheader,  26, 32), "\x00");
 		$info['efax']['header']['software2'] =                        rtrim(substr($efaxheader,  58, 32), "\x00");
@@ -41,10 +47,8 @@ class getid3_efax extends getid3_handler
 		$info['efax']['header']['pages']      = getid3_lib::LittleEndian2Int(substr($efaxheader, 198, 2));
 		$info['efax']['header']['data_bytes'] = getid3_lib::LittleEndian2Int(substr($efaxheader, 202, 4));
 
-$info['error'][] = 'eFax parsing not enabled in this version of getID3() ['.$this->getid3->version().']';
-return false;
-
-		return true;
+		$this->error('eFax parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
+		return false;
 	}
 
 }

--- a/application/libraries/getid3/module.graphic.gif.php
+++ b/application/libraries/getid3/module.graphic.gif.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.graphic.gif.php                                      //
@@ -13,10 +14,20 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+/**
+ * @link https://www.w3.org/Graphics/GIF/spec-gif89a.txt
+ * @link http://www.matthewflickinger.com/lab/whatsinagif/bits_and_bytes.asp
+ */
+
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_gif extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -25,8 +36,8 @@ class getid3_gif extends getid3_handler
 		$info['video']['lossless']           = true;
 		$info['video']['pixel_aspect_ratio'] = (float) 1;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$GIFheader = fread($this->getid3->fp, 13);
+		$this->fseek($info['avdataoffset']);
+		$GIFheader = $this->fread(13);
 		$offset = 0;
 
 		$info['gif']['header']['raw']['identifier']            =                              substr($GIFheader, $offset, 3);
@@ -34,11 +45,15 @@ class getid3_gif extends getid3_handler
 
 		$magic = 'GIF';
 		if ($info['gif']['header']['raw']['identifier'] != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['gif']['header']['raw']['identifier']).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['gif']['header']['raw']['identifier']).'"');
 			unset($info['fileformat']);
 			unset($info['gif']);
 			return false;
 		}
+
+		//if (!$this->getid3->option_extra_info) {
+		//	$this->warning('GIF Extensions and Global Color Table not returned due to !getid3->option_extra_info');
+		//}
 
 		$info['gif']['header']['raw']['version']               =                              substr($GIFheader, $offset, 3);
 		$offset += 3;
@@ -77,100 +92,121 @@ class getid3_gif extends getid3_handler
 			$info['gif']['header']['aspect_ratio'] = ($info['gif']['header']['raw']['aspect_ratio'] + 15) / 64;
 		}
 
-//		if ($info['gif']['header']['flags']['global_color_table']) {
-//			$GIFcolorTable = fread($this->getid3->fp, 3 * $info['gif']['header']['global_color_size']);
-//			$offset = 0;
-//			for ($i = 0; $i < $info['gif']['header']['global_color_size']; $i++) {
-//				$red   = getid3_lib::LittleEndian2Int(substr($GIFcolorTable, $offset++, 1));
-//				$green = getid3_lib::LittleEndian2Int(substr($GIFcolorTable, $offset++, 1));
-//				$blue  = getid3_lib::LittleEndian2Int(substr($GIFcolorTable, $offset++, 1));
-//				$info['gif']['global_color_table'][$i] = (($red << 16) | ($green << 8) | ($blue));
-//			}
-//		}
-//
-//		// Image Descriptor
-//		while (!feof($this->getid3->fp)) {
-//			$NextBlockTest = fread($this->getid3->fp, 1);
-//			switch ($NextBlockTest) {
-//
-//				case ',': // ',' - Image separator character
-//
-//					$ImageDescriptorData = $NextBlockTest.fread($this->getid3->fp, 9);
-//					$ImageDescriptor = array();
-//					$ImageDescriptor['image_left']   = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 1, 2));
-//					$ImageDescriptor['image_top']    = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 3, 2));
-//					$ImageDescriptor['image_width']  = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 5, 2));
-//					$ImageDescriptor['image_height'] = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 7, 2));
-//					$ImageDescriptor['flags_raw']    = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 9, 1));
-//					$ImageDescriptor['flags']['use_local_color_map'] = (bool) ($ImageDescriptor['flags_raw'] & 0x80);
-//					$ImageDescriptor['flags']['image_interlaced']    = (bool) ($ImageDescriptor['flags_raw'] & 0x40);
-//					$info['gif']['image_descriptor'][] = $ImageDescriptor;
-//
-//					if ($ImageDescriptor['flags']['use_local_color_map']) {
-//
-//						$info['warning'][] = 'This version of getID3() cannot parse local color maps for GIFs';
-//						return true;
-//
-//					}
-//echo 'Start of raster data: '.ftell($this->getid3->fp).'<BR>';
-//					$RasterData = array();
-//					$RasterData['code_size']        = getid3_lib::LittleEndian2Int(fread($this->getid3->fp, 1));
-//					$RasterData['block_byte_count'] = getid3_lib::LittleEndian2Int(fread($this->getid3->fp, 1));
-//					$info['gif']['raster_data'][count($info['gif']['image_descriptor']) - 1] = $RasterData;
-//
-//					$CurrentCodeSize = $RasterData['code_size'] + 1;
-//					for ($i = 0; $i < pow(2, $RasterData['code_size']); $i++) {
-//						$DefaultDataLookupTable[$i] = chr($i);
-//					}
-//					$DefaultDataLookupTable[pow(2, $RasterData['code_size']) + 0] = ''; // Clear Code
-//					$DefaultDataLookupTable[pow(2, $RasterData['code_size']) + 1] = ''; // End Of Image Code
-//
-//
-//					$NextValue = $this->GetLSBits($CurrentCodeSize);
-//					echo 'Clear Code: '.$NextValue.'<BR>';
-//
-//					$NextValue = $this->GetLSBits($CurrentCodeSize);
-//					echo 'First Color: '.$NextValue.'<BR>';
-//
-//					$Prefix = $NextValue;
-//$i = 0;
-//					while ($i++ < 20) {
-//						$NextValue = $this->GetLSBits($CurrentCodeSize);
-//						echo $NextValue.'<BR>';
-//					}
-//return true;
-//					break;
-//
-//				case '!':
-//					// GIF Extension Block
-//					$ExtensionBlockData = $NextBlockTest.fread($this->getid3->fp, 2);
-//					$ExtensionBlock = array();
-//					$ExtensionBlock['function_code']  = getid3_lib::LittleEndian2Int(substr($ExtensionBlockData, 1, 1));
-//					$ExtensionBlock['byte_length']    = getid3_lib::LittleEndian2Int(substr($ExtensionBlockData, 2, 1));
-//					$ExtensionBlock['data']           = fread($this->getid3->fp, $ExtensionBlock['byte_length']);
-//					$info['gif']['extension_blocks'][] = $ExtensionBlock;
-//					break;
-//
-//				case ';':
-//					$info['gif']['terminator_offset'] = ftell($this->getid3->fp) - 1;
-//					// GIF Terminator
-//					break;
-//
-//				default:
-//					break;
-//
-//
-//			}
-//		}
+		if ($info['gif']['header']['flags']['global_color_table']) {
+			$GIFcolorTable = $this->fread(3 * $info['gif']['header']['global_color_size']);
+			if ($this->getid3->option_extra_info) {
+				$offset = 0;
+				for ($i = 0; $i < $info['gif']['header']['global_color_size']; $i++) {
+					$red   = getid3_lib::LittleEndian2Int(substr($GIFcolorTable, $offset++, 1));
+					$green = getid3_lib::LittleEndian2Int(substr($GIFcolorTable, $offset++, 1));
+					$blue  = getid3_lib::LittleEndian2Int(substr($GIFcolorTable, $offset++, 1));
+					$info['gif']['global_color_table'][$i] = (($red << 16) | ($green << 8) | ($blue));
+					$info['gif']['global_color_table_rgb'][$i] = sprintf('%02X%02X%02X', $red, $green, $blue);
+				}
+			}
+		}
+
+		// Image Descriptor
+		$info['gif']['animation']['animated'] = false;
+		while (!feof($this->getid3->fp)) {
+			$NextBlockTest = $this->fread(1);
+			switch ($NextBlockTest) {
+
+/*
+				case ',': // ',' - Image separator character
+					$ImageDescriptorData = $NextBlockTest.$this->fread(9);
+					$ImageDescriptor = array();
+					$ImageDescriptor['image_left']   = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 1, 2));
+					$ImageDescriptor['image_top']    = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 3, 2));
+					$ImageDescriptor['image_width']  = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 5, 2));
+					$ImageDescriptor['image_height'] = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 7, 2));
+					$ImageDescriptor['flags_raw']    = getid3_lib::LittleEndian2Int(substr($ImageDescriptorData, 9, 1));
+					$ImageDescriptor['flags']['use_local_color_map'] = (bool) ($ImageDescriptor['flags_raw'] & 0x80);
+					$ImageDescriptor['flags']['image_interlaced']    = (bool) ($ImageDescriptor['flags_raw'] & 0x40);
+					$info['gif']['image_descriptor'][] = $ImageDescriptor;
+
+					if ($ImageDescriptor['flags']['use_local_color_map']) {
+
+						$this->warning('This version of getID3() cannot parse local color maps for GIFs');
+						return true;
+
+					}
+					$RasterData = array();
+					$RasterData['code_size']        = getid3_lib::LittleEndian2Int($this->fread(1));
+					$RasterData['block_byte_count'] = getid3_lib::LittleEndian2Int($this->fread(1));
+					$info['gif']['raster_data'][count($info['gif']['image_descriptor']) - 1] = $RasterData;
+
+					$CurrentCodeSize = $RasterData['code_size'] + 1;
+					for ($i = 0; $i < pow(2, $RasterData['code_size']); $i++) {
+						$DefaultDataLookupTable[$i] = chr($i);
+					}
+					$DefaultDataLookupTable[pow(2, $RasterData['code_size']) + 0] = ''; // Clear Code
+					$DefaultDataLookupTable[pow(2, $RasterData['code_size']) + 1] = ''; // End Of Image Code
+
+					$NextValue = $this->GetLSBits($CurrentCodeSize);
+					echo 'Clear Code: '.$NextValue.'<BR>';
+
+					$NextValue = $this->GetLSBits($CurrentCodeSize);
+					echo 'First Color: '.$NextValue.'<BR>';
+
+					$Prefix = $NextValue;
+					$i = 0;
+					while ($i++ < 20) {
+						$NextValue = $this->GetLSBits($CurrentCodeSize);
+						echo $NextValue.'<br>';
+					}
+					echo 'escaping<br>';
+					return true;
+					break;
+*/
+
+				case '!':
+					// GIF Extension Block
+					$ExtensionBlockData = $NextBlockTest.$this->fread(2);
+					$ExtensionBlock = array();
+					$ExtensionBlock['function_code']  = getid3_lib::LittleEndian2Int(substr($ExtensionBlockData, 1, 1));
+					$ExtensionBlock['byte_length']    = getid3_lib::LittleEndian2Int(substr($ExtensionBlockData, 2, 1));
+					$ExtensionBlock['data']           = (($ExtensionBlock['byte_length'] > 0) ? $this->fread($ExtensionBlock['byte_length']) : null);
+
+					if (substr($ExtensionBlock['data'], 0, 11) == 'NETSCAPE2.0') { // Netscape Application Block (NAB)
+						$ExtensionBlock['data'] .= $this->fread(4);
+						if (substr($ExtensionBlock['data'], 11, 2) == "\x03\x01") {
+							$info['gif']['animation']['animated']   = true;
+							$info['gif']['animation']['loop_count'] = getid3_lib::LittleEndian2Int(substr($ExtensionBlock['data'], 13, 2));
+						} else {
+							$this->warning('Expecting 03 01 at offset '.($this->ftell() - 4).', found "'.getid3_lib::PrintHexBytes(substr($ExtensionBlock['data'], 11, 2)).'"');
+						}
+					}
+
+					if ($this->getid3->option_extra_info) {
+						$info['gif']['extension_blocks'][] = $ExtensionBlock;
+					}
+					break;
+
+				case ';':
+					$info['gif']['terminator_offset'] = $this->ftell() - 1;
+					// GIF Terminator
+					break;
+
+				default:
+					break;
+
+
+			}
+		}
 
 		return true;
 	}
 
-
+	/**
+	 * @param int $bits
+	 *
+	 * @return float|int
+	 */
 	public function GetLSBits($bits) {
 		static $bitbuffer = '';
 		while (strlen($bitbuffer) < $bits) {
-			$bitbuffer = str_pad(decbin(ord(fread($this->getid3->fp, 1))), 8, '0', STR_PAD_LEFT).$bitbuffer;
+			$bitbuffer = str_pad(decbin(ord($this->fread(1))), 8, '0', STR_PAD_LEFT).$bitbuffer;
 		}
 		$value = bindec(substr($bitbuffer, 0 - $bits));
 		$bitbuffer = substr($bitbuffer, 0, 0 - $bits);

--- a/application/libraries/getid3/module.graphic.jpg.php
+++ b/application/libraries/getid3/module.graphic.jpg.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.graphic.jpg.php                                      //
@@ -14,11 +15,14 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
-
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 class getid3_jpg extends getid3_handler
 {
-
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -28,10 +32,11 @@ class getid3_jpg extends getid3_handler
 		$info['video']['bits_per_sample']    = 24;
 		$info['video']['pixel_aspect_ratio'] = (float) 1;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+		$this->fseek($info['avdataoffset']);
 
 		$imageinfo = array();
-		list($width, $height, $type) = getid3_lib::GetDataImageSize(fread($this->getid3->fp, $info['filesize']), $imageinfo);
+		//list($width, $height, $type) = getid3_lib::GetDataImageSize($this->fread($info['filesize']), $imageinfo);
+		list($width, $height, $type) = getimagesize($info['filenamepath'], $imageinfo); // https://www.getid3.org/phpBB3/viewtopic.php?t=1474
 
 
 		if (isset($imageinfo['APP13'])) {
@@ -45,10 +50,10 @@ class getid3_jpg extends getid3_handler
 					foreach ($iptc_values as $key => $value) {
 						$IPTCrecordName = $this->IPTCrecordName($iptc_record);
 						$IPTCrecordTagName = $this->IPTCrecordTagName($iptc_record, $iptc_tagkey);
-						if (isset($info['iptc'][$IPTCrecordName][$IPTCrecordTagName])) {
-							$info['iptc'][$IPTCrecordName][$IPTCrecordTagName][] = $value;
+						if (isset($info['iptc']['comments'][$IPTCrecordName][$IPTCrecordTagName])) {
+							$info['iptc']['comments'][$IPTCrecordName][$IPTCrecordTagName][] = $value;
 						} else {
-							$info['iptc'][$IPTCrecordName][$IPTCrecordTagName] = array($value);
+							$info['iptc']['comments'][$IPTCrecordName][$IPTCrecordTagName] = array($value);
 						}
 					}
 				}
@@ -64,14 +69,25 @@ class getid3_jpg extends getid3_handler
 				if (isset($imageinfo['APP1'])) {
 					if (function_exists('exif_read_data')) {
 						if (substr($imageinfo['APP1'], 0, 4) == 'Exif') {
-//$info['warning'][] = 'known issue: https://bugs.php.net/bug.php?id=62523';
-//return false;
+							//$this->warning('known issue: https://bugs.php.net/bug.php?id=62523');
+							//return false;
+							set_error_handler(function($errno, $errstr, $errfile, $errline, array $errcontext) {
+								if (!(error_reporting() & $errno)) {
+									// error is not specified in the error_reporting setting, so we ignore it
+									return false;
+								}
+
+								$errcontext['info']['warning'][] = 'Error parsing EXIF data ('.$errstr.')';
+							});
+
 							$info['jpg']['exif'] = exif_read_data($info['filenamepath'], null, true, false);
+
+							restore_error_handler();
 						} else {
-							$info['warning'][] = 'exif_read_data() cannot parse non-EXIF data in APP1 (expected "Exif", found "'.substr($imageinfo['APP1'], 0, 4).'")';
+							$this->warning('exif_read_data() cannot parse non-EXIF data in APP1 (expected "Exif", found "'.substr($imageinfo['APP1'], 0, 4).'")');
 						}
 					} else {
-						$info['warning'][] = 'EXIF parsing only available when '.(GETID3_OS_ISWINDOWS ? 'php_exif.dll enabled' : 'compiled with --enable-exif');
+						$this->warning('EXIF parsing only available when '.(GETID3_OS_ISWINDOWS ? 'php_exif.dll enabled' : 'compiled with --enable-exif'));
 					}
 				}
 				$returnOK = true;
@@ -95,6 +111,7 @@ class getid3_jpg extends getid3_handler
 		if (isset($info['jpg']['exif']['GPS'])) {
 
 			if (isset($info['jpg']['exif']['GPS']['GPSVersion'])) {
+				$version_subparts = array();
 				for ($i = 0; $i < 4; $i++) {
 					$version_subparts[$i] = ord(substr($info['jpg']['exif']['GPS']['GPSVersion'], $i, 1));
 				}
@@ -107,23 +124,18 @@ class getid3_jpg extends getid3_handler
 				$computed_time[3] = (isset($explodedGPSDateStamp[1]) ? $explodedGPSDateStamp[1] : '');
 				$computed_time[4] = (isset($explodedGPSDateStamp[2]) ? $explodedGPSDateStamp[2] : '');
 
-				if (function_exists('date_default_timezone_set')) {
-					date_default_timezone_set('UTC');
-				} else {
-					ini_set('date.timezone', 'UTC');
-				}
-
 				$computed_time = array(0=>0, 1=>0, 2=>0, 3=>0, 4=>0, 5=>0);
 				if (isset($info['jpg']['exif']['GPS']['GPSTimeStamp']) && is_array($info['jpg']['exif']['GPS']['GPSTimeStamp'])) {
 					foreach ($info['jpg']['exif']['GPS']['GPSTimeStamp'] as $key => $value) {
 						$computed_time[$key] = getid3_lib::DecimalizeFraction($value);
 					}
 				}
-				$info['jpg']['exif']['GPS']['computed']['timestamp'] = mktime($computed_time[0], $computed_time[1], $computed_time[2], $computed_time[3], $computed_time[4], $computed_time[5]);
+				$info['jpg']['exif']['GPS']['computed']['timestamp'] = gmmktime($computed_time[0], $computed_time[1], $computed_time[2], $computed_time[3], $computed_time[4], $computed_time[5]);
 			}
 
 			if (isset($info['jpg']['exif']['GPS']['GPSLatitude']) && is_array($info['jpg']['exif']['GPS']['GPSLatitude'])) {
 				$direction_multiplier = ((isset($info['jpg']['exif']['GPS']['GPSLatitudeRef']) && ($info['jpg']['exif']['GPS']['GPSLatitudeRef'] == 'S')) ? -1 : 1);
+				$computed_latitude = array();
 				foreach ($info['jpg']['exif']['GPS']['GPSLatitude'] as $key => $value) {
 					$computed_latitude[$key] = getid3_lib::DecimalizeFraction($value);
 				}
@@ -132,6 +144,7 @@ class getid3_jpg extends getid3_handler
 
 			if (isset($info['jpg']['exif']['GPS']['GPSLongitude']) && is_array($info['jpg']['exif']['GPS']['GPSLongitude'])) {
 				$direction_multiplier = ((isset($info['jpg']['exif']['GPS']['GPSLongitudeRef']) && ($info['jpg']['exif']['GPS']['GPSLongitudeRef'] == 'W')) ? -1 : 1);
+				$computed_longitude = array();
 				foreach ($info['jpg']['exif']['GPS']['GPSLongitude'] as $key => $value) {
 					$computed_longitude[$key] = getid3_lib::DecimalizeFraction($value);
 				}
@@ -148,17 +161,16 @@ class getid3_jpg extends getid3_handler
 		}
 
 
-		if (getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.xmp.php', __FILE__, false)) {
-			if (isset($info['filenamepath'])) {
-				$image_xmp = new Image_XMP($info['filenamepath']);
-				$xmp_raw = $image_xmp->getAllTags();
-				foreach ($xmp_raw as $key => $value) {
-					if (strpos($key, ':')) {
-						list($subsection, $tagname) = explode(':', $key);
-						$info['xmp'][$subsection][$tagname] = $this->CastAsAppropriate($value);
-					} else {
-						$info['warning'][] = 'XMP: expecting "<subsection>:<tagname>", found "'.$key.'"';
-					}
+		getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.xmp.php', __FILE__, true);
+		if (isset($info['filenamepath'])) {
+			$image_xmp = new Image_XMP($info['filenamepath']);
+			$xmp_raw = $image_xmp->getAllTags();
+			foreach ($xmp_raw as $key => $value) {
+				if (strpos($key, ':')) {
+					list($subsection, $tagname) = explode(':', $key);
+					$info['xmp'][$subsection][$tagname] = $this->CastAsAppropriate($value);
+				} else {
+					$this->warning('XMP: expecting "<subsection>:<tagname>", found "'.$key.'"');
 				}
 			}
 		}
@@ -170,7 +182,11 @@ class getid3_jpg extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @param mixed $value
+	 *
+	 * @return mixed
+	 */
 	public function CastAsAppropriate($value) {
 		if (is_array($value)) {
 			return $value;
@@ -184,7 +200,11 @@ class getid3_jpg extends getid3_handler
 		return $value;
 	}
 
-
+	/**
+	 * @param int $iptc_record
+	 *
+	 * @return string
+	 */
 	public function IPTCrecordName($iptc_record) {
 		// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/IPTC.html
 		static $IPTCrecordName = array();
@@ -201,7 +221,12 @@ class getid3_jpg extends getid3_handler
 		return (isset($IPTCrecordName[$iptc_record]) ? $IPTCrecordName[$iptc_record] : '');
 	}
 
-
+	/**
+	 * @param int $iptc_record
+	 * @param int $iptc_tagkey
+	 *
+	 * @return string
+	 */
 	public function IPTCrecordTagName($iptc_record, $iptc_tagkey) {
 		// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/IPTC.html
 		static $IPTCrecordTagName = array();

--- a/application/libraries/getid3/module.graphic.png.php
+++ b/application/libraries/getid3/module.graphic.png.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.graphic.png.php                                      //
@@ -13,11 +14,25 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_png extends getid3_handler
 {
+	/**
+	 * If data chunk is larger than this do not read it completely (getID3 only needs the first
+	 * few dozen bytes for parsing).
+	 *
+	 * @var int
+	 */
+	public $max_data_bytes = 10000000;
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
+
 		$info = &$this->getid3->info;
 
 		// shortcut
@@ -28,29 +43,39 @@ class getid3_png extends getid3_handler
 		$info['video']['dataformat'] = 'png';
 		$info['video']['lossless']   = false;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$PNGfiledata = fread($this->getid3->fp, $this->getid3->fread_buffer_size());
+		$this->fseek($info['avdataoffset']);
+		$PNGfiledata = $this->fread($this->getid3->fread_buffer_size());
 		$offset = 0;
 
 		$PNGidentifier = substr($PNGfiledata, $offset, 8); // $89 $50 $4E $47 $0D $0A $1A $0A
 		$offset += 8;
 
 		if ($PNGidentifier != "\x89\x50\x4E\x47\x0D\x0A\x1A\x0A") {
-			$info['error'][] = 'First 8 bytes of file ('.getid3_lib::PrintHexBytes($PNGidentifier).') did not match expected PNG identifier';
+			$this->error('First 8 bytes of file ('.getid3_lib::PrintHexBytes($PNGidentifier).') did not match expected PNG identifier');
 			unset($info['fileformat']);
 			return false;
 		}
 
-		while (((ftell($this->getid3->fp) - (strlen($PNGfiledata) - $offset)) < $info['filesize'])) {
+		while ((($this->ftell() - (strlen($PNGfiledata) - $offset)) < $info['filesize'])) {
 			$chunk['data_length'] = getid3_lib::BigEndian2Int(substr($PNGfiledata, $offset, 4));
-			$offset += 4;
-			while (((strlen($PNGfiledata) - $offset) < ($chunk['data_length'] + 4)) && (ftell($this->getid3->fp) < $info['filesize'])) {
-				$PNGfiledata .= fread($this->getid3->fp, $this->getid3->fread_buffer_size());
+			if ($chunk['data_length'] === false) {
+				$this->error('Failed to read data_length at offset '.$offset);
+				return false;
 			}
-			$chunk['type_text']   =               substr($PNGfiledata, $offset, 4);
+			$offset += 4;
+			$truncated_data = false;
+			while (((strlen($PNGfiledata) - $offset) < ($chunk['data_length'] + 4)) && ($this->ftell() < $info['filesize'])) {
+				if (strlen($PNGfiledata) < $this->max_data_bytes) {
+					$PNGfiledata .= $this->fread($this->getid3->fread_buffer_size());
+				} else {
+					$this->warning('At offset '.$offset.' chunk "'.substr($PNGfiledata, $offset, 4).'" exceeded max_data_bytes value of '.$this->max_data_bytes.', data chunk will be truncated at '.(strlen($PNGfiledata) - 8).' bytes');
+					break;
+				}
+			}
+			$chunk['type_text']   =                           substr($PNGfiledata, $offset, 4);
 			$offset += 4;
 			$chunk['type_raw']    = getid3_lib::BigEndian2Int($chunk['type_text']);
-			$chunk['data']        =               substr($PNGfiledata, $offset, $chunk['data_length']);
+			$chunk['data']        =                           substr($PNGfiledata, $offset, $chunk['data_length']);
 			$offset += $chunk['data_length'];
 			$chunk['crc']         = getid3_lib::BigEndian2Int(substr($PNGfiledata, $offset, 4));
 			$offset += 4;
@@ -124,10 +149,11 @@ class getid3_png extends getid3_handler
 
 						case 4:
 						case 6:
-							$info['error'][] = 'Invalid color_type in tRNS chunk: '.$thisfile_png['IHDR']['raw']['color_type'];
+							$this->error('Invalid color_type in tRNS chunk: '.$thisfile_png['IHDR']['raw']['color_type']);
+							break;
 
 						default:
-							$info['warning'][] = 'Unhandled color_type in tRNS chunk: '.$thisfile_png['IHDR']['raw']['color_type'];
+							$this->warning('Unhandled color_type in tRNS chunk: '.$thisfile_png['IHDR']['raw']['color_type']);
 							break;
 					}
 					break;
@@ -161,7 +187,7 @@ class getid3_png extends getid3_handler
 
 				case 'iCCP': // Embedded ICC Profile
 					$thisfile_png_chunk_type_text['header']                  = $chunk;
-					list($profilename, $compressiondata)                                 = explode("\x00", $chunk['data'], 2);
+					list($profilename, $compressiondata)                     = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['profile_name']            = $profilename;
 					$thisfile_png_chunk_type_text['compression_method']      = getid3_lib::BigEndian2Int(substr($compressiondata, 0, 1));
 					$thisfile_png_chunk_type_text['compression_profile']     = substr($compressiondata, 1);
@@ -172,7 +198,7 @@ class getid3_png extends getid3_handler
 
 				case 'tEXt': // Textual Data
 					$thisfile_png_chunk_type_text['header']  = $chunk;
-					list($keyword, $text)                                = explode("\x00", $chunk['data'], 2);
+					list($keyword, $text) = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['keyword'] = $keyword;
 					$thisfile_png_chunk_type_text['text']    = $text;
 
@@ -182,7 +208,7 @@ class getid3_png extends getid3_handler
 
 				case 'zTXt': // Compressed Textual Data
 					$thisfile_png_chunk_type_text['header']                  = $chunk;
-					list($keyword, $otherdata)                                           = explode("\x00", $chunk['data'], 2);
+					list($keyword, $otherdata)                               = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['keyword']                 = $keyword;
 					$thisfile_png_chunk_type_text['compression_method']      = getid3_lib::BigEndian2Int(substr($otherdata, 0, 1));
 					$thisfile_png_chunk_type_text['compressed_text']         = substr($otherdata, 1);
@@ -205,7 +231,7 @@ class getid3_png extends getid3_handler
 
 				case 'iTXt': // International Textual Data
 					$thisfile_png_chunk_type_text['header']                  = $chunk;
-					list($keyword, $otherdata)                                           = explode("\x00", $chunk['data'], 2);
+					list($keyword, $otherdata)                               = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['keyword']                 = $keyword;
 					$thisfile_png_chunk_type_text['compression']             = (bool) getid3_lib::BigEndian2Int(substr($otherdata, 0, 1));
 					$thisfile_png_chunk_type_text['compression_method']      = getid3_lib::BigEndian2Int(substr($otherdata, 1, 1));
@@ -306,7 +332,7 @@ class getid3_png extends getid3_handler
 
 				case 'sPLT': // Suggested Palette
 					$thisfile_png_chunk_type_text['header']                           = $chunk;
-					list($palettename, $otherdata)                                                = explode("\x00", $chunk['data'], 2);
+					list($palettename, $otherdata)                                    = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['palette_name']                     = $palettename;
 					$sPLToffset = 0;
 					$thisfile_png_chunk_type_text['sample_depth_bits']                = getid3_lib::BigEndian2Int(substr($otherdata, $sPLToffset, 1));
@@ -421,23 +447,69 @@ class getid3_png extends getid3_handler
 					$thisfile_png_chunk_type_text[$idatinformationfieldindex]['header'] = $chunk;
 					break;
 
-
 				case 'IEND': // Image Trailer
 					$thisfile_png_chunk_type_text['header'] = $chunk;
 					break;
 
+				case 'acTL': // Animation Control chunk
+					// https://wiki.mozilla.org/APNG_Specification#.60acTL.60:_The_Animation_Control_Chunk
+					$thisfile_png['animation']['num_frames'] = getid3_lib::BigEndian2Int(substr($chunk['data'], 0, 4)); // Number of frames
+					$thisfile_png['animation']['num_plays']  = getid3_lib::BigEndian2Int(substr($chunk['data'], 4, 4)); // Number of times to loop this APNG.  0 indicates infinite looping.
+
+					unset($chunk['data']);
+					$thisfile_png_chunk_type_text['header'] = $chunk;
+					break;
+
+				case 'fcTL': // Frame Control chunk
+					// https://wiki.mozilla.org/APNG_Specification#.60fcTL.60:_The_Frame_Control_Chunk
+					$fcTL = array();
+					$fcTL['sequence_number'] = getid3_lib::BigEndian2Int(substr($chunk['data'],  0, 4)); // Sequence number of the animation chunk, starting from 0
+					$fcTL['width']           = getid3_lib::BigEndian2Int(substr($chunk['data'],  4, 4)); // Width of the following frame
+					$fcTL['height']          = getid3_lib::BigEndian2Int(substr($chunk['data'],  8, 4)); // Height of the following frame
+					$fcTL['x_offset']        = getid3_lib::BigEndian2Int(substr($chunk['data'], 12, 4)); // X position at which to render the following frame
+					$fcTL['y_offset']        = getid3_lib::BigEndian2Int(substr($chunk['data'], 16, 4)); // Y position at which to render the following frame
+					$fcTL['delay_num']       = getid3_lib::BigEndian2Int(substr($chunk['data'], 20, 2)); // Frame delay fraction numerator
+					$fcTL['delay_den']       = getid3_lib::BigEndian2Int(substr($chunk['data'], 22, 2)); // Frame delay fraction numerator
+					$fcTL['dispose_op']      = getid3_lib::BigEndian2Int(substr($chunk['data'], 23, 1)); // Type of frame area disposal to be done after rendering this frame
+					$fcTL['blend_op']        = getid3_lib::BigEndian2Int(substr($chunk['data'], 23, 1)); // Type of frame area rendering for this frame
+					if ($fcTL['delay_den']) {
+						$fcTL['delay'] = $fcTL['delay_num'] / $fcTL['delay_den'];
+					}
+					$thisfile_png['animation']['fcTL'][$fcTL['sequence_number']] = $fcTL;
+
+					unset($chunk['data']);
+					$thisfile_png_chunk_type_text['header'] = $chunk;
+					break;
+
+				case 'fdAT': // Frame Data chunk
+					// https://wiki.mozilla.org/APNG_Specification#.60fcTL.60:_The_Frame_Control_Chunk
+					// "The `fdAT` chunk has the same purpose as an `IDAT` chunk. It has the same structure as an `IDAT` chunk, except preceded by a sequence number."
+					unset($chunk['data']);
+					$thisfile_png_chunk_type_text['header'] = $chunk;
+					break;
 
 				default:
 					//unset($chunk['data']);
 					$thisfile_png_chunk_type_text['header'] = $chunk;
-					$info['warning'][] = 'Unhandled chunk type: '.$chunk['type_text'];
+					$this->warning('Unhandled chunk type: '.$chunk['type_text']);
 					break;
 			}
 		}
-
+		if (!empty($thisfile_png['animation']['num_frames']) && !empty($thisfile_png['animation']['fcTL'])) {
+			$info['video']['dataformat'] = 'apng';
+			$info['playtime_seconds'] = 0;
+			foreach ($thisfile_png['animation']['fcTL'] as $seqno => $fcTL) {
+				$info['playtime_seconds'] += $fcTL['delay'];
+			}
+		}
 		return true;
 	}
 
+	/**
+	 * @param int $sRGB
+	 *
+	 * @return string
+	 */
 	public function PNGsRGBintentLookup($sRGB) {
 		static $PNGsRGBintentLookup = array(
 			0 => 'Perceptual',
@@ -448,6 +520,11 @@ class getid3_png extends getid3_handler
 		return (isset($PNGsRGBintentLookup[$sRGB]) ? $PNGsRGBintentLookup[$sRGB] : 'invalid');
 	}
 
+	/**
+	 * @param int $compressionmethod
+	 *
+	 * @return string
+	 */
 	public function PNGcompressionMethodLookup($compressionmethod) {
 		static $PNGcompressionMethodLookup = array(
 			0 => 'deflate/inflate'
@@ -455,6 +532,11 @@ class getid3_png extends getid3_handler
 		return (isset($PNGcompressionMethodLookup[$compressionmethod]) ? $PNGcompressionMethodLookup[$compressionmethod] : 'invalid');
 	}
 
+	/**
+	 * @param int $unitid
+	 *
+	 * @return string
+	 */
 	public function PNGpHYsUnitLookup($unitid) {
 		static $PNGpHYsUnitLookup = array(
 			0 => 'unknown',
@@ -463,6 +545,11 @@ class getid3_png extends getid3_handler
 		return (isset($PNGpHYsUnitLookup[$unitid]) ? $PNGpHYsUnitLookup[$unitid] : 'invalid');
 	}
 
+	/**
+	 * @param int $unitid
+	 *
+	 * @return string
+	 */
 	public function PNGoFFsUnitLookup($unitid) {
 		static $PNGoFFsUnitLookup = array(
 			0 => 'pixel',
@@ -471,6 +558,11 @@ class getid3_png extends getid3_handler
 		return (isset($PNGoFFsUnitLookup[$unitid]) ? $PNGoFFsUnitLookup[$unitid] : 'invalid');
 	}
 
+	/**
+	 * @param int $equationtype
+	 *
+	 * @return string
+	 */
 	public function PNGpCALequationTypeLookup($equationtype) {
 		static $PNGpCALequationTypeLookup = array(
 			0 => 'Linear mapping',
@@ -481,6 +573,11 @@ class getid3_png extends getid3_handler
 		return (isset($PNGpCALequationTypeLookup[$equationtype]) ? $PNGpCALequationTypeLookup[$equationtype] : 'invalid');
 	}
 
+	/**
+	 * @param int $unitid
+	 *
+	 * @return string
+	 */
 	public function PNGsCALUnitLookup($unitid) {
 		static $PNGsCALUnitLookup = array(
 			0 => 'meter',
@@ -489,27 +586,28 @@ class getid3_png extends getid3_handler
 		return (isset($PNGsCALUnitLookup[$unitid]) ? $PNGsCALUnitLookup[$unitid] : 'invalid');
 	}
 
+	/**
+	 * @param int $color_type
+	 * @param int $bit_depth
+	 *
+	 * @return int|false
+	 */
 	public function IHDRcalculateBitsPerSample($color_type, $bit_depth) {
 		switch ($color_type) {
 			case 0: // Each pixel is a grayscale sample.
 				return $bit_depth;
-				break;
 
 			case 2: // Each pixel is an R,G,B triple
 				return 3 * $bit_depth;
-				break;
 
 			case 3: // Each pixel is a palette index; a PLTE chunk must appear.
 				return $bit_depth;
-				break;
 
 			case 4: // Each pixel is a grayscale sample, followed by an alpha sample.
 				return 2 * $bit_depth;
-				break;
 
 			case 6: // Each pixel is an R,G,B triple, followed by an alpha sample.
 				return 4 * $bit_depth;
-				break;
 		}
 		return false;
 	}

--- a/application/libraries/getid3/module.graphic.svg.php
+++ b/application/libraries/getid3/module.graphic.svg.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.graphic.svg.php                                      //
@@ -13,17 +14,21 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_svg extends getid3_handler
 {
-
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
+		$this->fseek($info['avdataoffset']);
 
-		$SVGheader = fread($this->getid3->fp, 4096);
+		$SVGheader = $this->fread(4096);
 		if (preg_match('#\<\?xml([^\>]+)\?\>#i', $SVGheader, $matches)) {
 			$info['svg']['xml']['raw'] = $matches;
 		}
@@ -94,7 +99,7 @@ class getid3_svg extends getid3_handler
 
 			return true;
 		}
-		$info['error'][] = 'Did not find expected <svg> tag';
+		$this->error('Did not find expected <svg> tag');
 		return false;
 	}
 

--- a/application/libraries/getid3/module.graphic.tiff.php
+++ b/application/libraries/getid3/module.graphic.tiff.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.archive.tiff.php                                     //
@@ -13,15 +14,20 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_tiff extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$TIFFheader = fread($this->getid3->fp, 4);
+		$this->fseek($info['avdataoffset']);
+		$TIFFheader = $this->fread(4);
 
 		switch (substr($TIFFheader, 0, 2)) {
 			case 'II':
@@ -31,75 +37,90 @@ class getid3_tiff extends getid3_handler
 				$info['tiff']['byte_order'] = 'Motorola';
 				break;
 			default:
-				$info['error'][] = 'Invalid TIFF byte order identifier ('.substr($TIFFheader, 0, 2).') at offset '.$info['avdataoffset'];
+				$this->error('Invalid TIFF byte order identifier ('.substr($TIFFheader, 0, 2).') at offset '.$info['avdataoffset']);
 				return false;
-				break;
 		}
 
 		$info['fileformat']          = 'tiff';
 		$info['video']['dataformat'] = 'tiff';
 		$info['video']['lossless']   = true;
 		$info['tiff']['ifd']         = array();
-		$CurrentIFD                          = array();
+		$CurrentIFD                  = array();
 
 		$FieldTypeByteLength = array(1=>1, 2=>1, 3=>2, 4=>4, 5=>8);
 
-		$nextIFDoffset = $this->TIFFendian2Int(fread($this->getid3->fp, 4), $info['tiff']['byte_order']);
+		$nextIFDoffset = $this->TIFFendian2Int($this->fread(4), $info['tiff']['byte_order']);
 
 		while ($nextIFDoffset > 0) {
 
 			$CurrentIFD['offset'] = $nextIFDoffset;
 
-			fseek($this->getid3->fp, $info['avdataoffset'] + $nextIFDoffset, SEEK_SET);
-			$CurrentIFD['fieldcount'] = $this->TIFFendian2Int(fread($this->getid3->fp, 2), $info['tiff']['byte_order']);
+			$this->fseek($info['avdataoffset'] + $nextIFDoffset);
+			$CurrentIFD['fieldcount'] = $this->TIFFendian2Int($this->fread(2), $info['tiff']['byte_order']);
 
 			for ($i = 0; $i < $CurrentIFD['fieldcount']; $i++) {
-				$CurrentIFD['fields'][$i]['raw']['tag']    = $this->TIFFendian2Int(fread($this->getid3->fp, 2), $info['tiff']['byte_order']);
-				$CurrentIFD['fields'][$i]['raw']['type']   = $this->TIFFendian2Int(fread($this->getid3->fp, 2), $info['tiff']['byte_order']);
-				$CurrentIFD['fields'][$i]['raw']['length'] = $this->TIFFendian2Int(fread($this->getid3->fp, 4), $info['tiff']['byte_order']);
-				$CurrentIFD['fields'][$i]['raw']['offset'] =                       fread($this->getid3->fp, 4);
+				$CurrentIFD['fields'][$i]['raw']['tag']      = $this->TIFFendian2Int($this->fread(2), $info['tiff']['byte_order']);
+				$CurrentIFD['fields'][$i]['raw']['type']     = $this->TIFFendian2Int($this->fread(2), $info['tiff']['byte_order']);
+				$CurrentIFD['fields'][$i]['raw']['length']   = $this->TIFFendian2Int($this->fread(4), $info['tiff']['byte_order']);
+				$CurrentIFD['fields'][$i]['raw']['valoff']   =                       $this->fread(4); // To save time and space the Value Offset contains the Value instead of pointing to the Value if and only if the Value fits into 4 bytes. If the Value is shorter than 4 bytes, it is left-justified within the 4-byte Value Offset, i.e., stored in the lowernumbered bytes. Whether the Value fits within 4 bytes is determined by the Type and Count of the field.
+				$CurrentIFD['fields'][$i]['raw']['tag_name'] = $this->TIFFcommentName($CurrentIFD['fields'][$i]['raw']['tag']);
 
 				switch ($CurrentIFD['fields'][$i]['raw']['type']) {
 					case 1: // BYTE  An 8-bit unsigned integer.
 						if ($CurrentIFD['fields'][$i]['raw']['length'] <= 4) {
-							$CurrentIFD['fields'][$i]['value']  = $this->TIFFendian2Int(substr($CurrentIFD['fields'][$i]['raw']['offset'], 0, 1), $info['tiff']['byte_order']);
+							$CurrentIFD['fields'][$i]['value']  = $this->TIFFendian2Int(substr($CurrentIFD['fields'][$i]['raw']['valoff'], 0, 1), $info['tiff']['byte_order']);
 						} else {
-							$CurrentIFD['fields'][$i]['offset'] = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['offset'], $info['tiff']['byte_order']);
+							$CurrentIFD['fields'][$i]['offset'] = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['valoff'], $info['tiff']['byte_order']);
 						}
 						break;
 
 					case 2: // ASCII 8-bit bytes  that store ASCII codes; the last byte must be null.
 						if ($CurrentIFD['fields'][$i]['raw']['length'] <= 4) {
-							$CurrentIFD['fields'][$i]['value']  = substr($CurrentIFD['fields'][$i]['raw']['offset'], 3);
+							$CurrentIFD['fields'][$i]['value']  = substr($CurrentIFD['fields'][$i]['raw']['valoff'], 3);
 						} else {
-							$CurrentIFD['fields'][$i]['offset'] = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['offset'], $info['tiff']['byte_order']);
+							$CurrentIFD['fields'][$i]['offset'] = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['valoff'], $info['tiff']['byte_order']);
 						}
 						break;
 
 					case 3: // SHORT A 16-bit (2-byte) unsigned integer.
 						if ($CurrentIFD['fields'][$i]['raw']['length'] <= 2) {
-							$CurrentIFD['fields'][$i]['value']  = $this->TIFFendian2Int(substr($CurrentIFD['fields'][$i]['raw']['offset'], 0, 2), $info['tiff']['byte_order']);
+							$CurrentIFD['fields'][$i]['value']  = $this->TIFFendian2Int(substr($CurrentIFD['fields'][$i]['raw']['valoff'], 0, 2), $info['tiff']['byte_order']);
 						} else {
-							$CurrentIFD['fields'][$i]['offset'] = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['offset'], $info['tiff']['byte_order']);
+							$CurrentIFD['fields'][$i]['offset'] = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['valoff'], $info['tiff']['byte_order']);
 						}
 						break;
 
 					case 4: // LONG  A 32-bit (4-byte) unsigned integer.
-						if ($CurrentIFD['fields'][$i]['raw']['length'] <= 1) {
-							$CurrentIFD['fields'][$i]['value']  = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['offset'], $info['tiff']['byte_order']);
+						if ($CurrentIFD['fields'][$i]['raw']['length'] <= 4) {
+							$CurrentIFD['fields'][$i]['value']  = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['valoff'], $info['tiff']['byte_order']);
 						} else {
-							$CurrentIFD['fields'][$i]['offset'] = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['offset'], $info['tiff']['byte_order']);
+							$CurrentIFD['fields'][$i]['offset'] = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['valoff'], $info['tiff']['byte_order']);
 						}
 						break;
 
 					case 5: // RATIONAL   Two LONG_s:  the first represents the numerator of a fraction, the second the denominator.
+					case 7: // UNDEFINED An 8-bit byte that may contain anything, depending on the definition of the field.
+						$CurrentIFD['fields'][$i]['offset'] = $this->TIFFendian2Int($CurrentIFD['fields'][$i]['raw']['valoff'], $info['tiff']['byte_order']);
+						break;
+
+					// Warning: It is possible that other TIFF field types will be added in the future. Readers should skip over fields containing an unexpected field type.
+					// In TIFF 6.0, some new field types have been defined:
+					// These new field types are also governed by the byte order (II or MM) in the TIFF header.
+					case 6: // SBYTE An 8-bit signed (twos-complement) integer.
+					case 8: // SSHORT A 16-bit (2-byte) signed (twos-complement) integer.
+					case 9: // SLONG A 32-bit (4-byte) signed (twos-complement) integer.
+					case 10: // SRATIONAL Two SLONGs: the first represents the numerator of a fraction, the second the denominator.
+					case 11: // FLOAT Single precision (4-byte) IEEE format
+					case 12: // DOUBLE Double precision (8-byte) IEEE format
+					default:
+						$this->warning('unhandled IFD field type '.$CurrentIFD['fields'][$i]['raw']['type'].' for IFD entry '.$i);
 						break;
 				}
 			}
 
 			$info['tiff']['ifd'][] = $CurrentIFD;
 			$CurrentIFD = array();
-			$nextIFDoffset = $this->TIFFendian2Int(fread($this->getid3->fp, 4), $info['tiff']['byte_order']);
+			$nextIFDoffset = $this->TIFFendian2Int($this->fread(4), $info['tiff']['byte_order']);
 
 		}
 
@@ -111,8 +132,8 @@ class getid3_tiff extends getid3_handler
 					case 258: // BitsPerSample
 					case 259: // Compression
 						if (!isset($fieldarray['value'])) {
-							fseek($this->getid3->fp, $fieldarray['offset'], SEEK_SET);
-							$info['tiff']['ifd'][$IFDid]['fields'][$key]['raw']['data'] = fread($this->getid3->fp, $fieldarray['raw']['length'] * $FieldTypeByteLength[$fieldarray['raw']['type']]);
+							$this->fseek($fieldarray['offset']);
+							$info['tiff']['ifd'][$IFDid]['fields'][$key]['raw']['data'] = $this->fread($fieldarray['raw']['length'] * $FieldTypeByteLength[$fieldarray['raw']['type']]);
 
 						}
 						break;
@@ -127,9 +148,19 @@ class getid3_tiff extends getid3_handler
 						if (isset($fieldarray['value'])) {
 							$info['tiff']['ifd'][$IFDid]['fields'][$key]['raw']['data'] = $fieldarray['value'];
 						} else {
-							fseek($this->getid3->fp, $fieldarray['offset'], SEEK_SET);
-							$info['tiff']['ifd'][$IFDid]['fields'][$key]['raw']['data'] = fread($this->getid3->fp, $fieldarray['raw']['length'] * $FieldTypeByteLength[$fieldarray['raw']['type']]);
+							$this->fseek($fieldarray['offset']);
+							$info['tiff']['ifd'][$IFDid]['fields'][$key]['raw']['data'] = $this->fread($fieldarray['raw']['length'] * $FieldTypeByteLength[$fieldarray['raw']['type']]);
 
+						}
+						break;
+					case 700:
+						$XMPmagic = '<?xpacket';
+						$this->fseek($fieldarray['offset']);
+						$xmpkey = (isset($info['tiff']['XMP']) ? count($info['tiff']['XMP']) : 0);
+						$info['tiff']['XMP'][$xmpkey]['raw'] = $this->fread($fieldarray['raw']['length']);
+						if (substr($info['tiff']['XMP'][$xmpkey]['raw'], 0, strlen($XMPmagic)) != $XMPmagic) {
+							$this->warning('did not find expected XMP data at offset '.$fieldarray['offset']);
+							unset($info['tiff']['XMP'][$xmpkey]['raw']);
 						}
 						break;
 				}
@@ -164,7 +195,7 @@ class getid3_tiff extends getid3_handler
 					case 306: // DateTime
 					case 315: // Artist
 					case 316: // HostComputer
-						$TIFFcommentName = $this->TIFFcommentName($fieldarray['raw']['tag']);
+						$TIFFcommentName = strtolower($fieldarray['raw']['tag_name']);
 						if (isset($info['tiff']['comments'][$TIFFcommentName])) {
 							$info['tiff']['comments'][$TIFFcommentName][] =       $info['tiff']['ifd'][$IFDid]['fields'][$key]['raw']['data'];
 						} else {
@@ -181,7 +212,12 @@ class getid3_tiff extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @param string $bytestring
+	 * @param string $byteorder
+	 *
+	 * @return int|float|false
+	 */
 	public function TIFFendian2Int($bytestring, $byteorder) {
 		if ($byteorder == 'Intel') {
 			return getid3_lib::LittleEndian2Int($bytestring);
@@ -191,34 +227,290 @@ class getid3_tiff extends getid3_handler
 		return false;
 	}
 
+	/**
+	 * @param int $id
+	 *
+	 * @return string
+	 */
 	public function TIFFcompressionMethod($id) {
+		// https://en.wikipedia.org/wiki/TIFF#TIFF_Compression_Tag
 		static $TIFFcompressionMethod = array();
 		if (empty($TIFFcompressionMethod)) {
 			$TIFFcompressionMethod = array(
-				1     => 'Uncompressed',
-				2     => 'Huffman',
-				3     => 'Fax - CCITT 3',
-				5     => 'LZW',
-				32773 => 'PackBits',
+				0x0001 => 'Uncompressed',
+				0x0002 => 'Huffman',
+				0x0003 => 'CCITT T.4',
+				0x0004 => 'CCITT T.6',
+				0x0005 => 'LZW',
+				0x0006 => 'JPEG-old',
+				0x0007 => 'JPEG',
+				0x0008 => 'deflate',
+				0x0009 => 'JBIG ITU-T T.85',
+				0x000A => 'JBIG ITU-T T.43',
+				0x7FFE => 'NeXT RLE 2-bit',
+				0x8005 => 'PackBits',
+				0x8029 => 'ThunderScan RLE 4-bit',
+				0x807F => 'RasterPadding',
+				0x8080 => 'RLE-LW',
+				0x8081 => 'RLE-CT',
+				0x8082 => 'RLE-BL',
+				0x80B2 => 'deflate-PK',
+				0x80B3 => 'Kodak-DCS',
+				0x8765 => 'JBIG',
+				0x8798 => 'JPEG2000',
+				0x8799 => 'Nikon NEF',
+				0x879B => 'JBIG2',
 			);
 		}
 		return (isset($TIFFcompressionMethod[$id]) ? $TIFFcompressionMethod[$id] : 'unknown/invalid ('.$id.')');
 	}
 
+	/**
+	 * @param int $id
+	 *
+	 * @return string
+	 */
 	public function TIFFcommentName($id) {
+		// https://www.awaresystems.be/imaging/tiff/tifftags.html
 		static $TIFFcommentName = array();
 		if (empty($TIFFcommentName)) {
 			$TIFFcommentName = array(
-				270 => 'imagedescription',
-				271 => 'make',
-				272 => 'model',
-				305 => 'software',
-				306 => 'datetime',
-				315 => 'artist',
-				316 => 'hostcomputer',
+				254 => 'NewSubfileType',
+				255 => 'SubfileType',
+				256 => 'ImageWidth',
+				257 => 'ImageLength',
+				258 => 'BitsPerSample',
+				259 => 'Compression',
+				262 => 'PhotometricInterpretation',
+				263 => 'Threshholding',
+				264 => 'CellWidth',
+				265 => 'CellLength',
+				266 => 'FillOrder',
+				269 => 'DocumentName',
+				270 => 'ImageDescription',
+				271 => 'Make',
+				272 => 'Model',
+				273 => 'StripOffsets',
+				274 => 'Orientation',
+				277 => 'SamplesPerPixel',
+				278 => 'RowsPerStrip',
+				279 => 'StripByteCounts',
+				280 => 'MinSampleValue',
+				281 => 'MaxSampleValue',
+				282 => 'XResolution',
+				283 => 'YResolution',
+				284 => 'PlanarConfiguration',
+				285 => 'PageName',
+				286 => 'XPosition',
+				287 => 'YPosition',
+				288 => 'FreeOffsets',
+				289 => 'FreeByteCounts',
+				290 => 'GrayResponseUnit',
+				291 => 'GrayResponseCurve',
+				292 => 'T4Options',
+				293 => 'T6Options',
+				296 => 'ResolutionUnit',
+				297 => 'PageNumber',
+				301 => 'TransferFunction',
+				305 => 'Software',
+				306 => 'DateTime',
+				315 => 'Artist',
+				316 => 'HostComputer',
+				317 => 'Predictor',
+				318 => 'WhitePoint',
+				319 => 'PrimaryChromaticities',
+				320 => 'ColorMap',
+				321 => 'HalftoneHints',
+				322 => 'TileWidth',
+				323 => 'TileLength',
+				324 => 'TileOffsets',
+				325 => 'TileByteCounts',
+				326 => 'BadFaxLines',
+				327 => 'CleanFaxData',
+				328 => 'ConsecutiveBadFaxLines',
+				330 => 'SubIFDs',
+				332 => 'InkSet',
+				333 => 'InkNames',
+				334 => 'NumberOfInks',
+				336 => 'DotRange',
+				337 => 'TargetPrinter',
+				338 => 'ExtraSamples',
+				339 => 'SampleFormat',
+				340 => 'SMinSampleValue',
+				341 => 'SMaxSampleValue',
+				342 => 'TransferRange',
+				343 => 'ClipPath',
+				344 => 'XClipPathUnits',
+				345 => 'YClipPathUnits',
+				346 => 'Indexed',
+				347 => 'JPEGTables',
+				351 => 'OPIProxy',
+				400 => 'GlobalParametersIFD',
+				401 => 'ProfileType',
+				402 => 'FaxProfile',
+				403 => 'CodingMethods',
+				404 => 'VersionYear',
+				405 => 'ModeNumber',
+				433 => 'Decode',
+				434 => 'DefaultImageColor',
+				512 => 'JPEGProc',
+				513 => 'JPEGInterchangeFormat',
+				514 => 'JPEGInterchangeFormatLngth',
+				515 => 'JPEGRestartInterval',
+				517 => 'JPEGLosslessPredictors',
+				518 => 'JPEGPointTransforms',
+				519 => 'JPEGQTables',
+				520 => 'JPEGDCTables',
+				521 => 'JPEGACTables',
+				529 => 'YCbCrCoefficients',
+				530 => 'YCbCrSubSampling',
+				531 => 'YCbCrPositioning',
+				532 => 'ReferenceBlackWhite',
+				559 => 'StripRowCounts',
+				700 => 'XMP',
+
+				32781 => 'ImageID',
+				33432 => 'Copyright',
+				34732 => 'ImageLayer',
+
+				// Private Tags - https://www.awaresystems.be/imaging/tiff/tifftags/private.html
+				32932 => 'Wang Annotation',                    // Annotation data, as used in 'Imaging for Windows'.
+				33445 => 'MD FileTag',                         // Specifies the pixel data format encoding in the Molecular Dynamics GEL file format.
+				33446 => 'MD ScalePixel',                      // Specifies a scale factor in the Molecular Dynamics GEL file format.
+				33447 => 'MD ColorTable',                      // Used to specify the conversion from 16bit to 8bit in the Molecular Dynamics GEL file format.
+				33448 => 'MD LabName',                         // Name of the lab that scanned this file, as used in the Molecular Dynamics GEL file format.
+				33449 => 'MD SampleInfo',                      // Information about the sample, as used in the Molecular Dynamics GEL file format.
+				33450 => 'MD PrepDate',                        // Date the sample was prepared, as used in the Molecular Dynamics GEL file format.
+				33451 => 'MD PrepTime',                        // Time the sample was prepared, as used in the Molecular Dynamics GEL file format.
+				33452 => 'MD FileUnits',                       // Units for data in this file, as used in the Molecular Dynamics GEL file format.
+				33550 => 'ModelPixelScaleTag',                 // Used in interchangeable GeoTIFF files.
+				33723 => 'IPTC',                               // IPTC (International Press Telecommunications Council) metadata.
+				33918 => 'INGR Packet Data Tag',               // Intergraph Application specific storage.
+				33919 => 'INGR Flag Registers',                // Intergraph Application specific flags.
+				33920 => 'IrasB Transformation Matrix',        // Originally part of Intergraph's GeoTIFF tags, but likely understood by IrasB only.
+				33922 => 'ModelTiepointTag',                   // Originally part of Intergraph's GeoTIFF tags, but now used in interchangeable GeoTIFF files.
+				34264 => 'ModelTransformationTag',             // Used in interchangeable GeoTIFF files.
+				34377 => 'Photoshop',                          // Collection of Photoshop 'Image Resource Blocks'.
+				34665 => 'Exif IFD',                           // A pointer to the Exif IFD.
+				34675 => 'ICC Profile',                        // ICC profile data.
+				34735 => 'GeoKeyDirectoryTag',                 // Used in interchangeable GeoTIFF files.
+				34736 => 'GeoDoubleParamsTag',                 // Used in interchangeable GeoTIFF files.
+				34737 => 'GeoAsciiParamsTag',                  // Used in interchangeable GeoTIFF files.
+				34853 => 'GPS IFD',                            // A pointer to the Exif-related GPS Info IFD.
+				34908 => 'HylaFAX FaxRecvParams',              // Used by HylaFAX.
+				34909 => 'HylaFAX FaxSubAddress',              // Used by HylaFAX.
+				34910 => 'HylaFAX FaxRecvTime',                // Used by HylaFAX.
+				37724 => 'ImageSourceData',                    // Used by Adobe Photoshop.
+				40965 => 'Interoperability IFD',               // A pointer to the Exif-related Interoperability IFD.
+				42112 => 'GDAL_METADATA',                      // Used by the GDAL library, holds an XML list of name=value 'metadata' values about the image as a whole, and about specific samples.
+				42113 => 'GDAL_NODATA',                        // Used by the GDAL library, contains an ASCII encoded nodata or background pixel value.
+				50215 => 'Oce Scanjob Description',            // Used in the Oce scanning process.
+				50216 => 'Oce Application Selector',           // Used in the Oce scanning process.
+				50217 => 'Oce Identification Number',          // Used in the Oce scanning process.
+				50218 => 'Oce ImageLogic Characteristics',     // Used in the Oce scanning process.
+				50706 => 'DNGVersion',                         // Used in IFD 0 of DNG files.
+				50707 => 'DNGBackwardVersion',                 // Used in IFD 0 of DNG files.
+				50708 => 'UniqueCameraModel',                  // Used in IFD 0 of DNG files.
+				50709 => 'LocalizedCameraModel',               // Used in IFD 0 of DNG files.
+				50710 => 'CFAPlaneColor',                      // Used in Raw IFD of DNG files.
+				50711 => 'CFALayout',                          // Used in Raw IFD of DNG files.
+				50712 => 'LinearizationTable',                 // Used in Raw IFD of DNG files.
+				50713 => 'BlackLevelRepeatDim',                // Used in Raw IFD of DNG files.
+				50714 => 'BlackLevel',                         // Used in Raw IFD of DNG files.
+				50715 => 'BlackLevelDeltaH',                   // Used in Raw IFD of DNG files.
+				50716 => 'BlackLevelDeltaV',                   // Used in Raw IFD of DNG files.
+				50717 => 'WhiteLevel',                         // Used in Raw IFD of DNG files.
+				50718 => 'DefaultScale',                       // Used in Raw IFD of DNG files.
+				50719 => 'DefaultCropOrigin',                  // Used in Raw IFD of DNG files.
+				50720 => 'DefaultCropSize',                    // Used in Raw IFD of DNG files.
+				50721 => 'ColorMatrix1',                       // Used in IFD 0 of DNG files.
+				50722 => 'ColorMatrix2',                       // Used in IFD 0 of DNG files.
+				50723 => 'CameraCalibration1',                 // Used in IFD 0 of DNG files.
+				50724 => 'CameraCalibration2',                 // Used in IFD 0 of DNG files.
+				50725 => 'ReductionMatrix1',                   // Used in IFD 0 of DNG files.
+				50726 => 'ReductionMatrix2',                   // Used in IFD 0 of DNG files.
+				50727 => 'AnalogBalance',                      // Used in IFD 0 of DNG files.
+				50728 => 'AsShotNeutral',                      // Used in IFD 0 of DNG files.
+				50729 => 'AsShotWhiteXY',                      // Used in IFD 0 of DNG files.
+				50730 => 'BaselineExposure',                   // Used in IFD 0 of DNG files.
+				50731 => 'BaselineNoise',                      // Used in IFD 0 of DNG files.
+				50732 => 'BaselineSharpness',                  // Used in IFD 0 of DNG files.
+				50733 => 'BayerGreenSplit',                    // Used in Raw IFD of DNG files.
+				50734 => 'LinearResponseLimit',                // Used in IFD 0 of DNG files.
+				50735 => 'CameraSerialNumber',                 // Used in IFD 0 of DNG files.
+				50736 => 'LensInfo',                           // Used in IFD 0 of DNG files.
+				50737 => 'ChromaBlurRadius',                   // Used in Raw IFD of DNG files.
+				50738 => 'AntiAliasStrength',                  // Used in Raw IFD of DNG files.
+				50740 => 'DNGPrivateData',                     // Used in IFD 0 of DNG files.
+				50741 => 'MakerNoteSafety',                    // Used in IFD 0 of DNG files.
+				50778 => 'CalibrationIlluminant1',             // Used in IFD 0 of DNG files.
+				50779 => 'CalibrationIlluminant2',             // Used in IFD 0 of DNG files.
+				50780 => 'BestQualityScale',                   // Used in Raw IFD of DNG files.
+				50784 => 'Alias Layer Metadata',               // Alias Sketchbook Pro layer usage description.
+				50908 => 'TIFF_RSID',                          // This private tag is used in a GEOTIFF standard by DGIWG.
+				50909 => 'GEO_METADATA',                       // This private tag is used in a GEOTIFF standard by DGIWG.
+
+				// EXIF tags - https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/exif.html
+				33434 => 'ExposureTime',                               // Exposure time, given in seconds.
+				33437 => 'FNumber',                                    // The F number.
+				34850 => 'ExposureProgram',                            // The class of the program used by the camera to set exposure when the picture is taken.
+				34852 => 'SpectralSensitivity',                        // Indicates the spectral sensitivity of each channel of the camera used.
+				34855 => 'ISOSpeedRatings',                            // Indicates the ISO Speed and ISO Latitude of the camera or input device as specified in ISO 12232.
+				34856 => 'OECF',                                       // Indicates the Opto-Electric Conversion Function (OECF) specified in ISO 14524.
+				36864 => 'ExifVersion',                                // The version of the supported Exif standard.
+				36867 => 'DateTimeOriginal',                           // The date and time when the original image data was generated.
+				36868 => 'DateTimeDigitized',                          // The date and time when the image was stored as digital data.
+				37121 => 'ComponentsConfiguration',                    // Specific to compressed data; specifies the channels and complements PhotometricInterpretation
+				37122 => 'CompressedBitsPerPixel',                     // Specific to compressed data; states the compressed bits per pixel.
+				37377 => 'ShutterSpeedValue',                          // Shutter speed.
+				37378 => 'ApertureValue',                              // The lens aperture.
+				37379 => 'BrightnessValue',                            // The value of brightness.
+				37380 => 'ExposureBiasValue',                          // The exposure bias.
+				37381 => 'MaxApertureValue',                           // The smallest F number of the lens.
+				37382 => 'SubjectDistance',                            // The distance to the subject, given in meters.
+				37383 => 'MeteringMode',                               // The metering mode.
+				37384 => 'LightSource',                                // The kind of light source.
+				37385 => 'Flash',                                      // Indicates the status of flash when the image was shot.
+				37386 => 'FocalLength',                                // The actual focal length of the lens, in mm.
+				37396 => 'SubjectArea',                                // Indicates the location and area of the main subject in the overall scene.
+				37500 => 'MakerNote',                                  // Manufacturer specific information.
+				37510 => 'UserComment',                                // Keywords or comments on the image; complements ImageDescription.
+				37520 => 'SubsecTime',                                 // A tag used to record fractions of seconds for the DateTime tag.
+				37521 => 'SubsecTimeOriginal',                         // A tag used to record fractions of seconds for the DateTimeOriginal tag.
+				37522 => 'SubsecTimeDigitized',                        // A tag used to record fractions of seconds for the DateTimeDigitized tag.
+				40960 => 'FlashpixVersion',                            // The Flashpix format version supported by a FPXR file.
+				40961 => 'ColorSpace',                                 // The color space information tag is always recorded as the color space specifier.
+				40962 => 'PixelXDimension',                            // Specific to compressed data; the valid width of the meaningful image.
+				40963 => 'PixelYDimension',                            // Specific to compressed data; the valid height of the meaningful image.
+				40964 => 'RelatedSoundFile',                           // Used to record the name of an audio file related to the image data.
+				41483 => 'FlashEnergy',                                // Indicates the strobe energy at the time the image is captured, as measured in Beam Candle Power Seconds
+				41484 => 'SpatialFrequencyResponse',                   // Records the camera or input device spatial frequency table and SFR values in the direction of image width, image height, and diagonal direction, as specified in ISO 12233.
+				41486 => 'FocalPlaneXResolution',                      // Indicates the number of pixels in the image width (X) direction per FocalPlaneResolutionUnit on the camera focal plane.
+				41487 => 'FocalPlaneYResolution',                      // Indicates the number of pixels in the image height (Y) direction per FocalPlaneResolutionUnit on the camera focal plane.
+				41488 => 'FocalPlaneResolutionUnit',                   // Indicates the unit for measuring FocalPlaneXResolution and FocalPlaneYResolution.
+				41492 => 'SubjectLocation',                            // Indicates the location of the main subject in the scene.
+				41493 => 'ExposureIndex',                              // Indicates the exposure index selected on the camera or input device at the time the image is captured.
+				41495 => 'SensingMethod',                              // Indicates the image sensor type on the camera or input device.
+				41728 => 'FileSource',                                 // Indicates the image source.
+				41729 => 'SceneType',                                  // Indicates the type of scene.
+				41730 => 'CFAPattern',                                 // Indicates the color filter array (CFA) geometric pattern of the image sensor when a one-chip color area sensor is used.
+				41985 => 'CustomRendered',                             // Indicates the use of special processing on image data, such as rendering geared to output.
+				41986 => 'ExposureMode',                               // Indicates the exposure mode set when the image was shot.
+				41987 => 'WhiteBalance',                               // Indicates the white balance mode set when the image was shot.
+				41988 => 'DigitalZoomRatio',                           // Indicates the digital zoom ratio when the image was shot.
+				41989 => 'FocalLengthIn35mmFilm',                      // Indicates the equivalent focal length assuming a 35mm film camera, in mm.
+				41990 => 'SceneCaptureType',                           // Indicates the type of scene that was shot.
+				41991 => 'GainControl',                                // Indicates the degree of overall image gain adjustment.
+				41992 => 'Contrast',                                   // Indicates the direction of contrast processing applied by the camera when the image was shot.
+				41993 => 'Saturation',                                 // Indicates the direction of saturation processing applied by the camera when the image was shot.
+				41994 => 'Sharpness',                                  // Indicates the direction of sharpness processing applied by the camera when the image was shot.
+				41995 => 'DeviceSettingDescription',                   // This tag indicates information on the picture-taking conditions of a particular camera model.
+				41996 => 'SubjectDistanceRange',                       // Indicates the distance to the subject.
+				42016 => 'ImageUniqueID',                              // Indicates an identifier assigned uniquely to each image.
 			);
 		}
 		return (isset($TIFFcommentName[$id]) ? $TIFFcommentName[$id] : 'unknown/invalid ('.$id.')');
 	}
+
 
 }

--- a/application/libraries/getid3/module.misc.cue.php
+++ b/application/libraries/getid3/module.misc.cue.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.misc.cue.php                                         //
@@ -14,7 +15,7 @@
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // Module originally written [2009-Mar-25] by                  //
-//      Nigel Barnes <ngbarnesØhotmail*com>                    //
+//      Nigel Barnes <ngbarnesÃ˜hotmail*com>                    //
 // Minor reformatting and similar small changes to integrate   //
 //   into getID3 by James Heinrich <info@getid3.org>           //
 //                                                            ///
@@ -30,10 +31,18 @@
  * A CueSheet class used to open and parse cuesheets.
  *
  */
+
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+
 class getid3_cue extends getid3_handler
 {
 	public $cuesheet = array();
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -43,18 +52,24 @@ class getid3_cue extends getid3_handler
 		return true;
 	}
 
-
-
+	/**
+	 * @param string $filename
+	 *
+	 * @return array
+	 */
 	public function readCueSheetFilename($filename)
 	{
 		$filedata = file_get_contents($filename);
 		return $this->readCueSheet($filedata);
 	}
+
 	/**
-	* Parses a cue sheet file.
-	*
-	* @param string $filename - The filename for the cue sheet to open.
-	*/
+	 * Parses a cue sheet file.
+	 *
+	 * @param string $filedata
+	 *
+	 * @return array
+	 */
 	public function readCueSheet(&$filedata)
 	{
 		$cue_lines = array();
@@ -71,10 +86,10 @@ class getid3_cue extends getid3_handler
 	}
 
 	/**
-	* Parses the cue sheet array.
-	*
-	* @param array $file - The cuesheet as an array of each line.
-	*/
+	 * Parses the cue sheet array.
+	 *
+	 * @param array $file - The cuesheet as an array of each line.
+	 */
 	public function parseCueSheet($file)
 	{
 		//-1 means still global, all others are track specific
@@ -124,11 +139,11 @@ class getid3_cue extends getid3_handler
 	}
 
 	/**
-	* Parses the REM command.
-	*
-	* @param string $line - The line in the cue file that contains the TRACK command.
-	* @param integer $track_on - The track currently processing.
-	*/
+	 * Parses the REM command.
+	 *
+	 * @param string  $line - The line in the cue file that contains the TRACK command.
+	 * @param integer $track_on - The track currently processing.
+	 */
 	public function parseComment($line, $track_on)
 	{
 		$explodedline = explode(' ', $line, 3);
@@ -147,11 +162,12 @@ class getid3_cue extends getid3_handler
 	}
 
 	/**
-	* Parses the FILE command.
-	*
-	* @param string $line - The line in the cue file that contains the FILE command.
-	* @return array - Array of FILENAME and TYPE of file..
-	*/
+	 * Parses the FILE command.
+	 *
+	 * @param string $line - The line in the cue file that contains the FILE command.
+	 *
+	 * @return array - Array of FILENAME and TYPE of file..
+	 */
 	public function parseFile($line)
 	{
 		$line =            substr($line, strpos($line, ' ') + 1);
@@ -167,11 +183,11 @@ class getid3_cue extends getid3_handler
 	}
 
 	/**
-	* Parses the FLAG command.
-	*
-	* @param string $line - The line in the cue file that contains the TRACK command.
-	* @param integer $track_on - The track currently processing.
-	*/
+	 * Parses the FLAG command.
+	 *
+	 * @param string  $line - The line in the cue file that contains the TRACK command.
+	 * @param integer $track_on - The track currently processing.
+	 */
 	public function parseFlags($line, $track_on)
 	{
 		if ($track_on != -1)
@@ -205,11 +221,11 @@ class getid3_cue extends getid3_handler
 	}
 
 	/**
-	* Collect any unidentified data.
-	*
-	* @param string $line - The line in the cue file that contains the TRACK command.
-	* @param integer $track_on - The track currently processing.
-	*/
+	 * Collect any unidentified data.
+	 *
+	 * @param string  $line - The line in the cue file that contains the TRACK command.
+	 * @param integer $track_on - The track currently processing.
+	 */
 	public function parseGarbage($line, $track_on)
 	{
 		if ( strlen($line) > 0 )
@@ -226,15 +242,16 @@ class getid3_cue extends getid3_handler
 	}
 
 	/**
-	* Parses the INDEX command of a TRACK.
-	*
-	* @param string $line - The line in the cue file that contains the TRACK command.
-	* @param integer $track_on - The track currently processing.
-	*/
+	 * Parses the INDEX command of a TRACK.
+	 *
+	 * @param string  $line - The line in the cue file that contains the TRACK command.
+	 * @param integer $track_on - The track currently processing.
+	 */
 	public function parseIndex($line, $track_on)
 	{
 		$type = strtolower(substr($line, 0, strpos($line, ' ')));
 		$line =            substr($line, strpos($line, ' ') + 1);
+		$number = 0;
 
 		if ($type == 'index')
 		{
@@ -260,6 +277,10 @@ class getid3_cue extends getid3_handler
 		}
 	}
 
+	/**
+	 * @param string $line
+	 * @param int    $track_on
+	 */
 	public function parseString($line, $track_on)
 	{
 		$category = strtolower(substr($line, 0, strpos($line, ' ')));
@@ -291,11 +312,11 @@ class getid3_cue extends getid3_handler
 	}
 
 	/**
-	* Parses the TRACK command.
-	*
-	* @param string $line - The line in the cue file that contains the TRACK command.
-	* @param integer $track_on - The track currently processing.
-	*/
+	 * Parses the TRACK command.
+	 *
+	 * @param string  $line - The line in the cue file that contains the TRACK command.
+	 * @param integer $track_on - The track currently processing.
+	 */
 	public function parseTrack($line, $track_on)
 	{
 		$line = substr($line, strpos($line, ' ') + 1);

--- a/application/libraries/getid3/module.misc.exe.php
+++ b/application/libraries/getid3/module.misc.exe.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.misc.exe.php                                         //
@@ -13,19 +14,24 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_exe extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		fseek($this->getid3->fp, $info['avdataoffset'], SEEK_SET);
-		$EXEheader = fread($this->getid3->fp, 28);
+		$this->fseek($info['avdataoffset']);
+		$EXEheader = $this->fread(28);
 
 		$magic = 'MZ';
 		if (substr($EXEheader, 0, 2) != $magic) {
-			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($EXEheader, 0, 2)).'"';
+			$this->error('Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($EXEheader, 0, 2)).'"');
 			return false;
 		}
 
@@ -50,8 +56,8 @@ class getid3_exe extends getid3_handler
 		$info['exe']['mz']['memory_minimum']     = $info['exe']['mz']['raw']['min_memory_paragraphs'] * 16;
 		$info['exe']['mz']['memory_recommended'] = $info['exe']['mz']['raw']['max_memory_paragraphs'] * 16;
 
-$info['error'][] = 'EXE parsing not enabled in this version of getID3() ['.$this->getid3->version().']';
-return false;
+		$this->error('EXE parsing not enabled in this version of getID3() ['.$this->getid3->version().']');
+		return false;
 
 	}
 

--- a/application/libraries/getid3/module.misc.par2.php
+++ b/application/libraries/getid3/module.misc.par2.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.misc.par2.php                                        //
@@ -13,16 +14,21 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_par2 extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
 		$info['fileformat'] = 'par2';
 
-		$info['error'][] = 'PAR2 parsing not enabled in this version of getID3()';
+		$this->error('PAR2 parsing not enabled in this version of getID3()');
 		return false;
 
 	}

--- a/application/libraries/getid3/module.misc.pdf.php
+++ b/application/libraries/getid3/module.misc.pdf.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.misc.pdf.php                                         //
@@ -13,18 +14,134 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_pdf extends getid3_handler
 {
+	public $returnXREF = false; // return full details of PDF Cross-Reference Table (XREF)
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
-		$info['fileformat'] = 'pdf';
+		$this->fseek(0);
+		if (preg_match('#^%PDF-([0-9\\.]+)$#', rtrim($this->fgets()), $matches)) {
+			$info['pdf']['header']['version'] = floatval($matches[1]);
+			$info['fileformat'] = 'pdf';
 
-		$info['error'][] = 'PDF parsing not enabled in this version of getID3() ['.$this->getid3->version().']';
+			// the PDF Cross-Reference Table (XREF) is located near the end of the file
+			// the starting offset is specified in the penultimate section, on the two lines just before "%%EOF"
+			// the first line is "startxref", the second line is the byte offset of the XREF.
+			// We know the length of "%%EOF" and "startxref", but the offset could be 2-10 bytes,
+			// and we're not sure if the line ends are one or two bytes, so we might find "startxref" as little as 18(?) bytes
+			// from EOF, but it could 30 bytes, so we start 40 bytes back just to be safe and do a search for the data we want.
+			$this->fseek(-40, SEEK_END);
+			if (preg_match('#[\r\n]startxref[ \r\n]+([0-9]+)[ \r\n]+#', $this->fread(40), $matches)) {
+				$info['pdf']['trailer']['startxref'] = intval($matches[1]);
+				$this->parseXREF($info['pdf']['trailer']['startxref']);
+				if (!empty($info['pdf']['xref']['offset'])) {
+					while (!$this->feof() && (max(array_keys($info['pdf']['xref']['offset'])) > $info['pdf']['xref']['count'])) {
+						// suspect that there may be another XREF entry somewhere in the file, brute-force scan for it
+						/*
+						// starting at last known entry of main XREF table
+						$this->fseek(max($info['pdf']['xref']['offset']));
+						*/
+						// starting at the beginning of the file
+						$this->fseek(0);
+						while (!$this->feof()) {
+							$XREFoffset = $this->ftell();
+							if (rtrim($this->fgets()) == 'xref') {
+								if (empty($info['pdf']['xref']['xref_offsets']) || !in_array($XREFoffset, $info['pdf']['xref']['xref_offsets'])) {
+									$this->parseXREF($XREFoffset);
+									break;
+								}
+							}
+						}
+					}
+					foreach ($info['pdf']['xref']['offset'] as $objectNumber => $offset) {
+						if ($info['pdf']['xref']['entry'][$objectNumber] == 'f') {
+							// "free" object means "deleted", ignore
+							continue;
+						}
+						$this->fseek($offset);
+						$line = rtrim($this->fgets());
+						if (preg_match('#^'.$objectNumber.' ([0-9]+) obj#', $line, $matches)) {
+							if (strlen($line) > strlen($matches[0])) {
+								// object header line not actually on its own line, rewind file pointer to start reading data
+								$this->fseek($offset + strlen($matches[0]));
+							}
+							$objectData  = '';
+							while (true) {
+								$line = $this->fgets();
+								if (rtrim($line) == 'endobj') {
+									break;
+								}
+								$objectData .= $line;
+							}
+							if (preg_match('#^<<[\r\n\s]*(/Type|/Pages|/Parent [0-9]+ [0-9]+ [A-Z]|/Count [0-9]+|/Kids *\\[[0-9A-Z ]+\\]|[\r\n\s])+[\r\n\s]*>>#', $objectData, $matches)) {
+								if (preg_match('#/Count ([0-9]+)#', $objectData, $matches)) {
+									$info['pdf']['pages'] = (int) $matches[1];
+									break; // for now this is the only data we're looking for in the PDF not need to loop through every object in the file (and a large PDF may contain MANY objects). And it MAY be possible that there are other objects elsewhere in the file that define additional (or removed?) pages
+								}
+							}
+						} else {
+							$this->error('Unexpected structure "'.$line.'" at offset '.$offset);
+							break;
+						}
+					}
+					if (!$this->returnXREF) {
+						unset($info['pdf']['xref']['offset'], $info['pdf']['xref']['generation'], $info['pdf']['xref']['entry']);
+					}
+
+				} else {
+					$this->error('Did not find "xref" at offset '.$info['pdf']['trailer']['startxref']);
+				}
+			} else {
+				$this->error('Did not find "startxref" in the last 40 bytes of the PDF');
+			}
+
+			$this->warning('PDF parsing incomplete in this version of getID3() ['.$this->getid3->version().']');
+			return true;
+		}
+		$this->error('Did not find "%PDF" at the beginning of the PDF');
 		return false;
 
+	}
+
+	/**
+	 * @return bool
+	 */
+	private function parseXREF($XREFoffset) {
+		$info = &$this->getid3->info;
+
+		$this->fseek($XREFoffset);
+		if (rtrim($this->fgets()) == 'xref') {
+
+			$info['pdf']['xref']['xref_offsets'][$XREFoffset] = $XREFoffset;
+			list($firstObjectNumber, $XREFcount) = explode(' ', rtrim($this->fgets()));
+			$XREFcount = (int) $XREFcount;
+			$info['pdf']['xref']['count'] = $XREFcount + (!empty($info['pdf']['xref']['count']) ? $info['pdf']['xref']['count'] : 0);
+			for ($i = 0; $i < $XREFcount; $i++) {
+				$line = rtrim($this->fgets());
+				if (preg_match('#^([0-9]+) ([0-9]+) ([nf])$#', $line, $matches)) {
+					$info['pdf']['xref']['offset'][($firstObjectNumber + $i)]     = (int) $matches[1];
+					$info['pdf']['xref']['generation'][($firstObjectNumber + $i)] = (int) $matches[2];
+					$info['pdf']['xref']['entry'][($firstObjectNumber + $i)]      =       $matches[3];
+				} else {
+					$this->error('failed to parse XREF entry #'.$i.' in XREF table at offset '.$XREFoffset);
+					return false;
+				}
+			}
+			sort($info['pdf']['xref']['xref_offsets']);
+			return true;
+
+		}
+		$this->warning('failed to find expected XREF structure at offset '.$XREFoffset);
+		return false;
 	}
 
 }

--- a/application/libraries/getid3/module.tag.apetag.php
+++ b/application/libraries/getid3/module.tag.apetag.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.tag.apetag.php                                       //
@@ -13,16 +14,32 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+
 class getid3_apetag extends getid3_handler
 {
-	public $inline_attachments = true; // true: return full data for all attachments; false: return no data for all attachments; integer: return data for attachments <= than this; string: save as file to this directory
+	/**
+	 * true: return full data for all attachments;
+	 * false: return no data for all attachments;
+	 * integer: return data for attachments <= than this;
+	 * string: save as file to this directory.
+	 *
+	 * @var int|bool|string
+	 */
+	public $inline_attachments = true;
+
 	public $overrideendoffset  = 0;
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
 		if (!getid3_lib::intValueSupported($info['filesize'])) {
-			$info['warning'][] = 'Unable to check for APEtags because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB';
+			$this->warning('Unable to check for APEtags because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB');
 			return false;
 		}
 
@@ -32,8 +49,8 @@ class getid3_apetag extends getid3_handler
 
 		if ($this->overrideendoffset == 0) {
 
-			fseek($this->getid3->fp, 0 - $id3v1tagsize - $apetagheadersize - $lyrics3tagsize, SEEK_END);
-			$APEfooterID3v1 = fread($this->getid3->fp, $id3v1tagsize + $apetagheadersize + $lyrics3tagsize);
+			$this->fseek(0 - $id3v1tagsize - $apetagheadersize - $lyrics3tagsize, SEEK_END);
+			$APEfooterID3v1 = $this->fread($id3v1tagsize + $apetagheadersize + $lyrics3tagsize);
 
 			//if (preg_match('/APETAGEX.{24}TAG.{125}$/i', $APEfooterID3v1)) {
 			if (substr($APEfooterID3v1, strlen($APEfooterID3v1) - $id3v1tagsize - $apetagheadersize, 8) == 'APETAGEX') {
@@ -51,8 +68,8 @@ class getid3_apetag extends getid3_handler
 
 		} else {
 
-			fseek($this->getid3->fp, $this->overrideendoffset - $apetagheadersize, SEEK_SET);
-			if (fread($this->getid3->fp, 8) == 'APETAGEX') {
+			$this->fseek($this->overrideendoffset - $apetagheadersize);
+			if ($this->fread(8) == 'APETAGEX') {
 				$info['ape']['tag_offset_end'] = $this->overrideendoffset;
 			}
 
@@ -68,26 +85,26 @@ class getid3_apetag extends getid3_handler
 		// shortcut
 		$thisfile_ape = &$info['ape'];
 
-		fseek($this->getid3->fp, $thisfile_ape['tag_offset_end'] - $apetagheadersize, SEEK_SET);
-		$APEfooterData = fread($this->getid3->fp, 32);
+		$this->fseek($thisfile_ape['tag_offset_end'] - $apetagheadersize);
+		$APEfooterData = $this->fread(32);
 		if (!($thisfile_ape['footer'] = $this->parseAPEheaderFooter($APEfooterData))) {
-			$info['error'][] = 'Error parsing APE footer at offset '.$thisfile_ape['tag_offset_end'];
+			$this->error('Error parsing APE footer at offset '.$thisfile_ape['tag_offset_end']);
 			return false;
 		}
 
 		if (isset($thisfile_ape['footer']['flags']['header']) && $thisfile_ape['footer']['flags']['header']) {
-			fseek($this->getid3->fp, $thisfile_ape['tag_offset_end'] - $thisfile_ape['footer']['raw']['tagsize'] - $apetagheadersize, SEEK_SET);
-			$thisfile_ape['tag_offset_start'] = ftell($this->getid3->fp);
-			$APEtagData = fread($this->getid3->fp, $thisfile_ape['footer']['raw']['tagsize'] + $apetagheadersize);
+			$this->fseek($thisfile_ape['tag_offset_end'] - $thisfile_ape['footer']['raw']['tagsize'] - $apetagheadersize);
+			$thisfile_ape['tag_offset_start'] = $this->ftell();
+			$APEtagData = $this->fread($thisfile_ape['footer']['raw']['tagsize'] + $apetagheadersize);
 		} else {
 			$thisfile_ape['tag_offset_start'] = $thisfile_ape['tag_offset_end'] - $thisfile_ape['footer']['raw']['tagsize'];
-			fseek($this->getid3->fp, $thisfile_ape['tag_offset_start'], SEEK_SET);
-			$APEtagData = fread($this->getid3->fp, $thisfile_ape['footer']['raw']['tagsize']);
+			$this->fseek($thisfile_ape['tag_offset_start']);
+			$APEtagData = $this->fread($thisfile_ape['footer']['raw']['tagsize']);
 		}
 		$info['avdataend'] = $thisfile_ape['tag_offset_start'];
 
 		if (isset($info['id3v1']['tag_offset_start']) && ($info['id3v1']['tag_offset_start'] < $thisfile_ape['tag_offset_end'])) {
-			$info['warning'][] = 'ID3v1 tag information ignored since it appears to be a false synch in APEtag data';
+			$this->warning('ID3v1 tag information ignored since it appears to be a false synch in APEtag data');
 			unset($info['id3v1']);
 			foreach ($info['warning'] as $key => $value) {
 				if ($value == 'Some ID3v1 fields do not use NULL characters for padding') {
@@ -103,7 +120,7 @@ class getid3_apetag extends getid3_handler
 			if ($thisfile_ape['header'] = $this->parseAPEheaderFooter(substr($APEtagData, 0, $apetagheadersize))) {
 				$offset += $apetagheadersize;
 			} else {
-				$info['error'][] = 'Error parsing APE header at offset '.$thisfile_ape['tag_offset_start'];
+				$this->error('Error parsing APE header at offset '.$thisfile_ape['tag_offset_start']);
 				return false;
 			}
 		}
@@ -118,7 +135,7 @@ class getid3_apetag extends getid3_handler
 			$item_flags = getid3_lib::LittleEndian2Int(substr($APEtagData, $offset, 4));
 			$offset += 4;
 			if (strstr(substr($APEtagData, $offset), "\x00") === false) {
-				$info['error'][] = 'Cannot find null-byte (0x00) seperator between ItemKey #'.$i.' and value. ItemKey starts '.$offset.' bytes into the APE tag, at file offset '.($thisfile_ape['tag_offset_start'] + $offset);
+				$this->error('Cannot find null-byte (0x00) separator between ItemKey #'.$i.' and value. ItemKey starts '.$offset.' bytes into the APE tag, at file offset '.($thisfile_ape['tag_offset_start'] + $offset));
 				return false;
 			}
 			$ItemKeyLength = strpos($APEtagData, "\x00", $offset) - $offset;
@@ -137,64 +154,94 @@ class getid3_apetag extends getid3_handler
 			$thisfile_ape_items_current['flags'] = $this->parseAPEtagFlags($item_flags);
 			switch ($thisfile_ape_items_current['flags']['item_contents_raw']) {
 				case 0: // UTF-8
-				case 3: // Locator (URL, filename, etc), UTF-8 encoded
-					$thisfile_ape_items_current['data'] = explode("\x00", trim($thisfile_ape_items_current['data']));
+				case 2: // Locator (URL, filename, etc), UTF-8 encoded
+					$thisfile_ape_items_current['data'] = explode("\x00", $thisfile_ape_items_current['data']);
 					break;
 
-				default: // binary data
+				case 1:  // binary data
+				default:
 					break;
 			}
 
 			switch (strtolower($item_key)) {
+				// http://wiki.hydrogenaud.io/index.php?title=ReplayGain#MP3Gain
 				case 'replaygain_track_gain':
-					$thisfile_replaygain['track']['adjustment'] = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
-					$thisfile_replaygain['track']['originator'] = 'unspecified';
+					if (preg_match('#^([\\-\\+][0-9\\.,]{8})( dB)?$#', $thisfile_ape_items_current['data'][0], $matches)) {
+						$thisfile_replaygain['track']['adjustment'] = (float) str_replace(',', '.', $matches[1]); // float casting will see "0,95" as zero!
+						$thisfile_replaygain['track']['originator'] = 'unspecified';
+					} else {
+						$this->warning('MP3gainTrackGain value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"');
+					}
 					break;
 
 				case 'replaygain_track_peak':
-					$thisfile_replaygain['track']['peak']       = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
-					$thisfile_replaygain['track']['originator'] = 'unspecified';
-					if ($thisfile_replaygain['track']['peak'] <= 0) {
-						$info['warning'][] = 'ReplayGain Track peak from APEtag appears invalid: '.$thisfile_replaygain['track']['peak'].' (original value = "'.$thisfile_ape_items_current['data'][0].'")';
+					if (preg_match('#^([0-9\\.,]{8})$#', $thisfile_ape_items_current['data'][0], $matches)) {
+						$thisfile_replaygain['track']['peak']       = (float) str_replace(',', '.', $matches[1]); // float casting will see "0,95" as zero!
+						$thisfile_replaygain['track']['originator'] = 'unspecified';
+						if ($thisfile_replaygain['track']['peak'] <= 0) {
+							$this->warning('ReplayGain Track peak from APEtag appears invalid: '.$thisfile_replaygain['track']['peak'].' (original value = "'.$thisfile_ape_items_current['data'][0].'")');
+						}
+					} else {
+						$this->warning('MP3gainTrackPeak value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"');
 					}
 					break;
 
 				case 'replaygain_album_gain':
-					$thisfile_replaygain['album']['adjustment'] = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
-					$thisfile_replaygain['album']['originator'] = 'unspecified';
+					if (preg_match('#^([\\-\\+][0-9\\.,]{8})( dB)?$#', $thisfile_ape_items_current['data'][0], $matches)) {
+						$thisfile_replaygain['album']['adjustment'] = (float) str_replace(',', '.', $matches[1]); // float casting will see "0,95" as zero!
+						$thisfile_replaygain['album']['originator'] = 'unspecified';
+					} else {
+						$this->warning('MP3gainAlbumGain value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"');
+					}
 					break;
 
 				case 'replaygain_album_peak':
-					$thisfile_replaygain['album']['peak']       = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
-					$thisfile_replaygain['album']['originator'] = 'unspecified';
-					if ($thisfile_replaygain['album']['peak'] <= 0) {
-						$info['warning'][] = 'ReplayGain Album peak from APEtag appears invalid: '.$thisfile_replaygain['album']['peak'].' (original value = "'.$thisfile_ape_items_current['data'][0].'")';
+					if (preg_match('#^([0-9\\.,]{8})$#', $thisfile_ape_items_current['data'][0], $matches)) {
+						$thisfile_replaygain['album']['peak']       = (float) str_replace(',', '.', $matches[1]); // float casting will see "0,95" as zero!
+						$thisfile_replaygain['album']['originator'] = 'unspecified';
+						if ($thisfile_replaygain['album']['peak'] <= 0) {
+							$this->warning('ReplayGain Album peak from APEtag appears invalid: '.$thisfile_replaygain['album']['peak'].' (original value = "'.$thisfile_ape_items_current['data'][0].'")');
+						}
+					} else {
+						$this->warning('MP3gainAlbumPeak value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"');
 					}
 					break;
 
 				case 'mp3gain_undo':
-					list($mp3gain_undo_left, $mp3gain_undo_right, $mp3gain_undo_wrap) = explode(',', $thisfile_ape_items_current['data'][0]);
-					$thisfile_replaygain['mp3gain']['undo_left']  = intval($mp3gain_undo_left);
-					$thisfile_replaygain['mp3gain']['undo_right'] = intval($mp3gain_undo_right);
-					$thisfile_replaygain['mp3gain']['undo_wrap']  = (($mp3gain_undo_wrap == 'Y') ? true : false);
+					if (preg_match('#^[\\-\\+][0-9]{3},[\\-\\+][0-9]{3},[NW]$#', $thisfile_ape_items_current['data'][0])) {
+						list($mp3gain_undo_left, $mp3gain_undo_right, $mp3gain_undo_wrap) = explode(',', $thisfile_ape_items_current['data'][0]);
+						$thisfile_replaygain['mp3gain']['undo_left']  = intval($mp3gain_undo_left);
+						$thisfile_replaygain['mp3gain']['undo_right'] = intval($mp3gain_undo_right);
+						$thisfile_replaygain['mp3gain']['undo_wrap']  = (($mp3gain_undo_wrap == 'Y') ? true : false);
+					} else {
+						$this->warning('MP3gainUndo value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"');
+					}
 					break;
 
 				case 'mp3gain_minmax':
-					list($mp3gain_globalgain_min, $mp3gain_globalgain_max) = explode(',', $thisfile_ape_items_current['data'][0]);
-					$thisfile_replaygain['mp3gain']['globalgain_track_min'] = intval($mp3gain_globalgain_min);
-					$thisfile_replaygain['mp3gain']['globalgain_track_max'] = intval($mp3gain_globalgain_max);
+					if (preg_match('#^[0-9]{3},[0-9]{3}$#', $thisfile_ape_items_current['data'][0])) {
+						list($mp3gain_globalgain_min, $mp3gain_globalgain_max) = explode(',', $thisfile_ape_items_current['data'][0]);
+						$thisfile_replaygain['mp3gain']['globalgain_track_min'] = intval($mp3gain_globalgain_min);
+						$thisfile_replaygain['mp3gain']['globalgain_track_max'] = intval($mp3gain_globalgain_max);
+					} else {
+						$this->warning('MP3gainMinMax value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"');
+					}
 					break;
 
 				case 'mp3gain_album_minmax':
-					list($mp3gain_globalgain_album_min, $mp3gain_globalgain_album_max) = explode(',', $thisfile_ape_items_current['data'][0]);
-					$thisfile_replaygain['mp3gain']['globalgain_album_min'] = intval($mp3gain_globalgain_album_min);
-					$thisfile_replaygain['mp3gain']['globalgain_album_max'] = intval($mp3gain_globalgain_album_max);
+					if (preg_match('#^[0-9]{3},[0-9]{3}$#', $thisfile_ape_items_current['data'][0])) {
+						list($mp3gain_globalgain_album_min, $mp3gain_globalgain_album_max) = explode(',', $thisfile_ape_items_current['data'][0]);
+						$thisfile_replaygain['mp3gain']['globalgain_album_min'] = intval($mp3gain_globalgain_album_min);
+						$thisfile_replaygain['mp3gain']['globalgain_album_max'] = intval($mp3gain_globalgain_album_max);
+					} else {
+						$this->warning('MP3gainAlbumMinMax value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"');
+					}
 					break;
 
 				case 'tracknumber':
 					if (is_array($thisfile_ape_items_current['data'])) {
 						foreach ($thisfile_ape_items_current['data'] as $comment) {
-							$thisfile_ape['comments']['track'][] = $comment;
+							$thisfile_ape['comments']['track_number'][] = $comment;
 						}
 					}
 					break;
@@ -221,16 +268,24 @@ class getid3_apetag extends getid3_handler
 				case 'cover art (recording)':
 				case 'cover art (studio)':
 					// list of possible cover arts from http://taglib-sharp.sourcearchive.com/documentation/2.0.3.0-2/Ape_2Tag_8cs-source.html
+					if (is_array($thisfile_ape_items_current['data'])) {
+						$this->warning('APEtag "'.$item_key.'" should be flagged as Binary data, but was incorrectly flagged as UTF-8');
+						$thisfile_ape_items_current['data'] = implode("\x00", $thisfile_ape_items_current['data']);
+					}
 					list($thisfile_ape_items_current['filename'], $thisfile_ape_items_current['data']) = explode("\x00", $thisfile_ape_items_current['data'], 2);
 					$thisfile_ape_items_current['data_offset'] = $thisfile_ape_items_current['offset'] + strlen($thisfile_ape_items_current['filename']."\x00");
 					$thisfile_ape_items_current['data_length'] = strlen($thisfile_ape_items_current['data']);
 
-					$thisfile_ape_items_current['image_mime'] = '';
-					$imageinfo = array();
-					$imagechunkcheck = getid3_lib::GetDataImageSize($thisfile_ape_items_current['data'], $imageinfo);
-					$thisfile_ape_items_current['image_mime'] = image_type_to_mime_type($imagechunkcheck[2]);
-
 					do {
+						$thisfile_ape_items_current['image_mime'] = '';
+						$imageinfo = array();
+						$imagechunkcheck = getid3_lib::GetDataImageSize($thisfile_ape_items_current['data'], $imageinfo);
+						if (($imagechunkcheck === false) || !isset($imagechunkcheck[2])) {
+							$this->warning('APEtag "'.$item_key.'" contains invalid image data');
+							break;
+						}
+						$thisfile_ape_items_current['image_mime'] = image_type_to_mime_type($imagechunkcheck[2]);
+
 						if ($this->inline_attachments === false) {
 							// skip entirely
 							unset($thisfile_ape_items_current['data']);
@@ -241,15 +296,15 @@ class getid3_apetag extends getid3_handler
 						} elseif (is_int($this->inline_attachments)) {
 							if ($this->inline_attachments < $thisfile_ape_items_current['data_length']) {
 								// too big, skip
-								$info['warning'][] = 'attachment at '.$thisfile_ape_items_current['offset'].' is too large to process inline ('.number_format($thisfile_ape_items_current['data_length']).' bytes)';
+								$this->warning('attachment at '.$thisfile_ape_items_current['offset'].' is too large to process inline ('.number_format($thisfile_ape_items_current['data_length']).' bytes)');
 								unset($thisfile_ape_items_current['data']);
 								break;
 							}
 						} elseif (is_string($this->inline_attachments)) {
 							$this->inline_attachments = rtrim(str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $this->inline_attachments), DIRECTORY_SEPARATOR);
-							if (!is_dir($this->inline_attachments) || !is_writable($this->inline_attachments)) {
+							if (!is_dir($this->inline_attachments) || !getID3::is_writable($this->inline_attachments)) {
 								// cannot write, skip
-								$info['warning'][] = 'attachment at '.$thisfile_ape_items_current['offset'].' cannot be saved to "'.$this->inline_attachments.'" (not writable)';
+								$this->warning('attachment at '.$thisfile_ape_items_current['offset'].' cannot be saved to "'.$this->inline_attachments.'" (not writable)');
 								unset($thisfile_ape_items_current['data']);
 								break;
 							}
@@ -257,10 +312,10 @@ class getid3_apetag extends getid3_handler
 						// if we get this far, must be OK
 						if (is_string($this->inline_attachments)) {
 							$destination_filename = $this->inline_attachments.DIRECTORY_SEPARATOR.md5($info['filenamepath']).'_'.$thisfile_ape_items_current['data_offset'];
-							if (!file_exists($destination_filename) || is_writable($destination_filename)) {
+							if (!file_exists($destination_filename) || getID3::is_writable($destination_filename)) {
 								file_put_contents($destination_filename, $thisfile_ape_items_current['data']);
 							} else {
-								$info['warning'][] = 'attachment at '.$thisfile_ape_items_current['offset'].' cannot be saved to "'.$destination_filename.'" (not writable)';
+								$this->warning('attachment at '.$thisfile_ape_items_current['offset'].' cannot be saved to "'.$destination_filename.'" (not writable)');
 							}
 							$thisfile_ape_items_current['data_filename'] = $destination_filename;
 							unset($thisfile_ape_items_current['data']);
@@ -268,7 +323,14 @@ class getid3_apetag extends getid3_handler
 							if (!isset($info['ape']['comments']['picture'])) {
 								$info['ape']['comments']['picture'] = array();
 							}
-							$info['ape']['comments']['picture'][] = array('data'=>$thisfile_ape_items_current['data'], 'image_mime'=>$thisfile_ape_items_current['image_mime']);
+							$comments_picture_data = array();
+							foreach (array('data', 'image_mime', 'image_width', 'image_height', 'imagetype', 'picturetype', 'description', 'datalength') as $picture_key) {
+								if (isset($thisfile_ape_items_current[$picture_key])) {
+									$comments_picture_data[$picture_key] = $thisfile_ape_items_current[$picture_key];
+								}
+							}
+							$info['ape']['comments']['picture'][] = $comments_picture_data;
+							unset($comments_picture_data);
 						}
 					} while (false);
 					break;
@@ -289,6 +351,11 @@ class getid3_apetag extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $APEheaderFooterData
+	 *
+	 * @return array|false
+	 */
 	public function parseAPEheaderFooter($APEheaderFooterData) {
 		// http://www.uni-jena.de/~pfk/mpp/sv8/apeheader.html
 
@@ -313,10 +380,15 @@ class getid3_apetag extends getid3_handler
 		return $headerfooterinfo;
 	}
 
+	/**
+	 * @param int $rawflagint
+	 *
+	 * @return array
+	 */
 	public function parseAPEtagFlags($rawflagint) {
 		// "Note: APE Tags 1.0 do not use any of the APE Tag flags.
 		// All are set to zero on creation and ignored on reading."
-		// http://www.uni-jena.de/~pfk/mpp/sv8/apetagflags.html
+		// http://wiki.hydrogenaud.io/index.php?title=Ape_Tags_Flags
 		$flags['header']            = (bool) ($rawflagint & 0x80000000);
 		$flags['footer']            = (bool) ($rawflagint & 0x40000000);
 		$flags['this_is_header']    = (bool) ($rawflagint & 0x20000000);
@@ -328,6 +400,11 @@ class getid3_apetag extends getid3_handler
 		return $flags;
 	}
 
+	/**
+	 * @param int $contenttypeid
+	 *
+	 * @return string
+	 */
 	public function APEcontentTypeFlagLookup($contenttypeid) {
 		static $APEcontentTypeFlagLookup = array(
 			0 => 'utf-8',
@@ -338,6 +415,11 @@ class getid3_apetag extends getid3_handler
 		return (isset($APEcontentTypeFlagLookup[$contenttypeid]) ? $APEcontentTypeFlagLookup[$contenttypeid] : 'invalid');
 	}
 
+	/**
+	 * @param string $itemkey
+	 *
+	 * @return bool
+	 */
 	public function APEtagItemIsUTF8Lookup($itemkey) {
 		static $APEtagItemIsUTF8Lookup = array(
 			'title',

--- a/application/libraries/getid3/module.tag.id3v1.php
+++ b/application/libraries/getid3/module.tag.id3v1.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.tag.id3v1.php                                        //
@@ -13,21 +14,26 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 
 class getid3_id3v1 extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
 		if (!getid3_lib::intValueSupported($info['filesize'])) {
-			$info['warning'][] = 'Unable to check for ID3v1 because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB';
+			$this->warning('Unable to check for ID3v1 because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB');
 			return false;
 		}
 
-		fseek($this->getid3->fp, -256, SEEK_END);
-		$preid3v1 = fread($this->getid3->fp, 128);
-		$id3v1tag = fread($this->getid3->fp, 128);
+		$this->fseek(-256, SEEK_END);
+		$preid3v1 = $this->fread(128);
+		$id3v1tag = $this->fread(128);
 
 		if (substr($id3v1tag, 0, 3) == 'TAG') {
 
@@ -42,9 +48,9 @@ class getid3_id3v1 extends getid3_handler
 
 			// If second-last byte of comment field is null and last byte of comment field is non-null
 			// then this is ID3v1.1 and the comment field is 28 bytes long and the 30th byte is the track number
-			if (($id3v1tag{125} === "\x00") && ($id3v1tag{126} !== "\x00")) {
-				$ParsedID3v1['track']   = ord(substr($ParsedID3v1['comment'], 29,  1));
-				$ParsedID3v1['comment'] =     substr($ParsedID3v1['comment'],  0, 28);
+			if (($id3v1tag[125] === "\x00") && ($id3v1tag[126] !== "\x00")) {
+				$ParsedID3v1['track_number'] = ord(substr($ParsedID3v1['comment'], 29,  1));
+				$ParsedID3v1['comment']      =     substr($ParsedID3v1['comment'],  0, 28);
 			}
 			$ParsedID3v1['comment'] = $this->cutfield($ParsedID3v1['comment']);
 
@@ -59,6 +65,30 @@ class getid3_id3v1 extends getid3_handler
 			foreach ($ParsedID3v1 as $key => $value) {
 				$ParsedID3v1['comments'][$key][0] = $value;
 			}
+			$ID3v1encoding = $this->getid3->encoding_id3v1;
+			if ($this->getid3->encoding_id3v1_autodetect) {
+				// ID3v1 encoding detection hack START
+				// ID3v1 is defined as always using ISO-8859-1 encoding, but it is not uncommon to find files tagged with ID3v1 using Windows-1251 or other character sets
+				// Since ID3v1 has no concept of character sets there is no certain way to know we have the correct non-ISO-8859-1 character set, but we can guess
+				foreach ($ParsedID3v1['comments'] as $tag_key => $valuearray) {
+					foreach ($valuearray as $key => $value) {
+						if (preg_match('#^[\\x00-\\x40\\x80-\\xFF]+$#', $value) && !ctype_digit((string) $value)) { // check for strings with only characters above chr(128) and punctuation/numbers, but not just numeric strings (e.g. track numbers or years)
+							foreach (array('Windows-1251', 'KOI8-R') as $id3v1_bad_encoding) {
+								if (function_exists('mb_convert_encoding') && @mb_convert_encoding($value, $id3v1_bad_encoding, $id3v1_bad_encoding) === $value) {
+									$ID3v1encoding = $id3v1_bad_encoding;
+									$this->warning('ID3v1 detected as '.$id3v1_bad_encoding.' text encoding in '.$tag_key);
+									break 3;
+								} elseif (function_exists('iconv') && @iconv($id3v1_bad_encoding, $id3v1_bad_encoding, $value) === $value) {
+									$ID3v1encoding = $id3v1_bad_encoding;
+									$this->warning('ID3v1 detected as '.$id3v1_bad_encoding.' text encoding in '.$tag_key);
+									break 3;
+								}
+							}
+						}
+					}
+				}
+				// ID3v1 encoding detection hack END
+			}
 
 			// ID3v1 data is supposed to be padded with NULL characters, but some taggers pad with spaces
 			$GoodFormatID3v1tag = $this->GenerateID3v1Tag(
@@ -68,17 +98,18 @@ class getid3_id3v1 extends getid3_handler
 											$ParsedID3v1['year'],
 											(isset($ParsedID3v1['genre']) ? $this->LookupGenreID($ParsedID3v1['genre']) : false),
 											$ParsedID3v1['comment'],
-											(!empty($ParsedID3v1['track']) ? $ParsedID3v1['track'] : ''));
+											(!empty($ParsedID3v1['track_number']) ? $ParsedID3v1['track_number'] : ''));
 			$ParsedID3v1['padding_valid'] = true;
 			if ($id3v1tag !== $GoodFormatID3v1tag) {
 				$ParsedID3v1['padding_valid'] = false;
-				$info['warning'][] = 'Some ID3v1 fields do not use NULL characters for padding';
+				$this->warning('Some ID3v1 fields do not use NULL characters for padding');
 			}
 
 			$ParsedID3v1['tag_offset_end']   = $info['filesize'];
 			$ParsedID3v1['tag_offset_start'] = $ParsedID3v1['tag_offset_end'] - 128;
 
 			$info['id3v1'] = $ParsedID3v1;
+			$info['id3v1']['encoding'] = $ID3v1encoding;
 		}
 
 		if (substr($preid3v1, 0, 3) == 'TAG') {
@@ -94,7 +125,7 @@ class getid3_id3v1 extends getid3_handler
 				// a Lyrics3 tag footer was found before the last ID3v1, assume false "TAG" synch
 			} else {
 				// APE and Lyrics3 footers not found - assume double ID3v1
-				$info['warning'][] = 'Duplicate ID3v1 tag detected - this has been known to happen with iTunes';
+				$this->warning('Duplicate ID3v1 tag detected - this has been known to happen with iTunes');
 				$info['avdataend'] -= 128;
 			}
 		}
@@ -102,10 +133,20 @@ class getid3_id3v1 extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $str
+	 *
+	 * @return string
+	 */
 	public static function cutfield($str) {
 		return trim(substr($str, 0, strcspn($str, "\x00")));
 	}
 
+	/**
+	 * @param bool $allowSCMPXextended
+	 *
+	 * @return string[]
+	 */
 	public static function ArrayOfGenres($allowSCMPXextended=false) {
 		static $GenreLookup = array(
 			0    => 'Blues',
@@ -290,6 +331,12 @@ class getid3_id3v1 extends getid3_handler
 		return ($allowSCMPXextended ? $GenreLookupSCMPX : $GenreLookup);
 	}
 
+	/**
+	 * @param string $genreid
+	 * @param bool   $allowSCMPXextended
+	 *
+	 * @return string|false
+	 */
 	public static function LookupGenreName($genreid, $allowSCMPXextended=true) {
 		switch ($genreid) {
 			case 'RX':
@@ -306,6 +353,12 @@ class getid3_id3v1 extends getid3_handler
 		return (isset($GenreLookup[$genreid]) ? $GenreLookup[$genreid] : false);
 	}
 
+	/**
+	 * @param string $genre
+	 * @param bool   $allowSCMPXextended
+	 *
+	 * @return string|false
+	 */
 	public static function LookupGenreID($genre, $allowSCMPXextended=false) {
 		$GenreLookup = self::ArrayOfGenres($allowSCMPXextended);
 		$LowerCaseNoSpaceSearchTerm = strtolower(str_replace(' ', '', $genre));
@@ -317,6 +370,11 @@ class getid3_id3v1 extends getid3_handler
 		return false;
 	}
 
+	/**
+	 * @param string $OriginalGenre
+	 *
+	 * @return string|false
+	 */
 	public static function StandardiseID3v1GenreName($OriginalGenre) {
 		if (($GenreID = self::LookupGenreID($OriginalGenre)) !== false) {
 			return self::LookupGenreName($GenreID);
@@ -324,6 +382,17 @@ class getid3_id3v1 extends getid3_handler
 		return $OriginalGenre;
 	}
 
+	/**
+	 * @param string     $title
+	 * @param string     $artist
+	 * @param string     $album
+	 * @param string     $year
+	 * @param int        $genreid
+	 * @param string     $comment
+	 * @param int|string $track
+	 *
+	 * @return string
+	 */
 	public static function GenerateID3v1Tag($title, $artist, $album, $year, $genreid, $comment, $track='') {
 		$ID3v1Tag  = 'TAG';
 		$ID3v1Tag .= str_pad(trim(substr($title,  0, 30)), 30, "\x00", STR_PAD_RIGHT);

--- a/application/libraries/getid3/module.tag.id3v2.php
+++ b/application/libraries/getid3/module.tag.id3v2.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 ///                                                            //
 // module.tag.id3v2.php                                        //
@@ -13,12 +14,18 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.id3v1.php', __FILE__, true);
 
 class getid3_id3v2 extends getid3_handler
 {
 	public $StartingOffset = 0;
 
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
@@ -51,12 +58,12 @@ class getid3_id3v2 extends getid3_handler
 		$thisfile_id3v2_flags            = &$thisfile_id3v2['flags'];
 
 
-		fseek($this->getid3->fp, $this->StartingOffset, SEEK_SET);
-		$header = fread($this->getid3->fp, 10);
+		$this->fseek($this->StartingOffset);
+		$header = $this->fread(10);
 		if (substr($header, 0, 3) == 'ID3'  &&  strlen($header) == 10) {
 
-			$thisfile_id3v2['majorversion'] = ord($header{3});
-			$thisfile_id3v2['minorversion'] = ord($header{4});
+			$thisfile_id3v2['majorversion'] = ord($header[3]);
+			$thisfile_id3v2['minorversion'] = ord($header[4]);
 
 			// shortcut
 			$id3v2_majorversion = &$thisfile_id3v2['majorversion'];
@@ -70,12 +77,12 @@ class getid3_id3v2 extends getid3_handler
 
 		if ($id3v2_majorversion > 4) { // this script probably won't correctly parse ID3v2.5.x and above (if it ever exists)
 
-			$info['error'][] = 'this script only parses up to ID3v2.4.x - this tag is ID3v2.'.$id3v2_majorversion.'.'.$thisfile_id3v2['minorversion'];
+			$this->error('this script only parses up to ID3v2.4.x - this tag is ID3v2.'.$id3v2_majorversion.'.'.$thisfile_id3v2['minorversion']);
 			return false;
 
 		}
 
-		$id3_flags = ord($header{5});
+		$id3_flags = ord($header[5]);
 		switch ($id3v2_majorversion) {
 			case 2:
 				// %ab000000 in v2.2
@@ -131,7 +138,7 @@ class getid3_id3v2 extends getid3_handler
 		}
 		if ($sizeofframes > 0) {
 
-			$framedata = fread($this->getid3->fp, $sizeofframes); // read all frames from file into $framedata variable
+			$framedata = $this->fread($sizeofframes); // read all frames from file into $framedata variable
 
 			//    if entire frame data is unsynched, de-unsynch it now (ID3v2.3.x)
 			if (!empty($thisfile_id3v2_flags['unsynch']) && ($id3v2_majorversion <= 3)) {
@@ -240,7 +247,7 @@ class getid3_id3v2 extends getid3_handler
 					}
 
 					if ($thisfile_id3v2['exthead']['length'] != $extended_header_offset) {
-						$info['warning'][] = 'ID3v2.4 extended header length mismatch (expecting '.intval($thisfile_id3v2['exthead']['length']).', found '.intval($extended_header_offset).')';
+						$this->warning('ID3v2.4 extended header length mismatch (expecting '.intval($thisfile_id3v2['exthead']['length']).', found '.intval($extended_header_offset).')');
 					}
 				}
 
@@ -256,15 +263,19 @@ class getid3_id3v2 extends getid3_handler
 					$thisfile_id3v2['padding']['length'] = strlen($framedata);
 					$thisfile_id3v2['padding']['valid']  = true;
 					for ($i = 0; $i < $thisfile_id3v2['padding']['length']; $i++) {
-						if ($framedata{$i} != "\x00") {
+						if ($framedata[$i] != "\x00") {
 							$thisfile_id3v2['padding']['valid'] = false;
 							$thisfile_id3v2['padding']['errorpos'] = $thisfile_id3v2['padding']['start'] + $i;
-							$info['warning'][] = 'Invalid ID3v2 padding found at offset '.$thisfile_id3v2['padding']['errorpos'].' (the remaining '.($thisfile_id3v2['padding']['length'] - $i).' bytes are considered invalid)';
+							$this->warning('Invalid ID3v2 padding found at offset '.$thisfile_id3v2['padding']['errorpos'].' (the remaining '.($thisfile_id3v2['padding']['length'] - $i).' bytes are considered invalid)');
 							break;
 						}
 					}
 					break; // skip rest of ID3v2 header
 				}
+				$frame_header = null;
+				$frame_name   = null;
+				$frame_size   = null;
+				$frame_flags  = null;
 				if ($id3v2_majorversion == 2) {
 					// Frame ID  $xx xx xx (three characters)
 					// Size      $xx xx xx (24-bit integer)
@@ -299,7 +310,7 @@ class getid3_id3v2 extends getid3_handler
 						} elseif (($frame_name == "\x00".'MP3') || ($frame_name == "\x00\x00".'MP') || ($frame_name == ' MP3') || ($frame_name == 'MP3e')) {
 							// MP3ext known broken frames - "ok" for the purposes of this test
 						} elseif (($id3v2_majorversion == 4) && ($this->IsValidID3v2FrameName(substr($framedata, getid3_lib::BigEndian2Int(substr($frame_header, 4, 4), 0), 4), 3))) {
-							$info['warning'][] = 'ID3v2 tag written as ID3v2.4, but with non-synchsafe integers (ID3v2.3 style). Older versions of (Helium2; iTunes) are known culprits of this. Tag has been parsed as ID3v2.3';
+							$this->warning('ID3v2 tag written as ID3v2.4, but with non-synchsafe integers (ID3v2.3 style). Older versions of (Helium2; iTunes) are known culprits of this. Tag has been parsed as ID3v2.3');
 							$id3v2_majorversion = 3;
 							$frame_size = getid3_lib::BigEndian2Int(substr($frame_header, 4, 4), 0); // 32-bit integer
 						}
@@ -318,19 +329,19 @@ class getid3_id3v2 extends getid3_handler
 
 					$len = strlen($framedata);
 					for ($i = 0; $i < $len; $i++) {
-						if ($framedata{$i} != "\x00") {
+						if ($framedata[$i] != "\x00") {
 							$thisfile_id3v2['padding']['valid'] = false;
 							$thisfile_id3v2['padding']['errorpos'] = $thisfile_id3v2['padding']['start'] + $i;
-							$info['warning'][] = 'Invalid ID3v2 padding found at offset '.$thisfile_id3v2['padding']['errorpos'].' (the remaining '.($thisfile_id3v2['padding']['length'] - $i).' bytes are considered invalid)';
+							$this->warning('Invalid ID3v2 padding found at offset '.$thisfile_id3v2['padding']['errorpos'].' (the remaining '.($thisfile_id3v2['padding']['length'] - $i).' bytes are considered invalid)');
 							break;
 						}
 					}
 					break; // skip rest of ID3v2 header
 				}
 
-				if ($frame_name == 'COM ') {
-					$info['warning'][] = 'error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag). (ERROR: IsValidID3v2FrameName("'.str_replace("\x00", ' ', $frame_name).'", '.$id3v2_majorversion.'))). [Note: this particular error has been known to happen with tags edited by iTunes (versions "X v2.0.3", "v3.0.1" are known-guilty, probably others too)]';
-					$frame_name = 'COMM';
+				if ($iTunesBrokenFrameNameFixed = self::ID3v22iTunesBrokenFrameName($frame_name)) {
+					$this->warning('error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag). (ERROR: IsValidID3v2FrameName("'.str_replace("\x00", ' ', $frame_name).'", '.$id3v2_majorversion.'))). [Note: this particular error has been known to happen with tags edited by iTunes (versions "X v2.0.3", "v3.0.1", "v7.0.0.70" are known-guilty, probably others too)]. Translated frame name from "'.str_replace("\x00", ' ', $frame_name).'" to "'.$iTunesBrokenFrameNameFixed.'" for parsing.');
+					$frame_name = $iTunesBrokenFrameNameFixed;
 				}
 				if (($frame_size <= strlen($framedata)) && ($this->IsValidID3v2FrameName($frame_name, $id3v2_majorversion))) {
 
@@ -354,28 +365,28 @@ class getid3_id3v2 extends getid3_handler
 
 							// next frame is valid, just skip the current frame
 							$framedata = substr($framedata, $frame_size);
-							$info['warning'][] = 'Next ID3v2 frame is valid, skipping current frame.';
+							$this->warning('Next ID3v2 frame is valid, skipping current frame.');
 
 						} else {
 
 							// next frame is invalid too, abort processing
 							//unset($framedata);
 							$framedata = null;
-							$info['error'][] = 'Next ID3v2 frame is also invalid, aborting processing.';
+							$this->error('Next ID3v2 frame is also invalid, aborting processing.');
 
 						}
 
 					} elseif ($frame_size == strlen($framedata)) {
 
 						// this is the last frame, just skip
-						$info['warning'][] = 'This was the last ID3v2 frame.';
+						$this->warning('This was the last ID3v2 frame.');
 
 					} else {
 
 						// next frame is invalid too, abort processing
 						//unset($framedata);
 						$framedata = null;
-						$info['warning'][] = 'Invalid ID3v2 frame size, aborting.';
+						$this->warning('Invalid ID3v2 frame size, aborting.');
 
 					}
 					if (!$this->IsValidID3v2FrameName($frame_name, $id3v2_majorversion)) {
@@ -388,21 +399,21 @@ class getid3_id3v2 extends getid3_handler
 							case "\x00".'MP':
 							case ' MP':
 							case 'MP3':
-								$info['warning'][] = 'error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag). (ERROR: !IsValidID3v2FrameName("'.str_replace("\x00", ' ', $frame_name).'", '.$id3v2_majorversion.'))). [Note: this particular error has been known to happen with tags edited by "MP3ext (www.mutschler.de/mp3ext/)"]';
+								$this->warning('error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag). (ERROR: !IsValidID3v2FrameName("'.str_replace("\x00", ' ', $frame_name).'", '.$id3v2_majorversion.'))). [Note: this particular error has been known to happen with tags edited by "MP3ext (www.mutschler.de/mp3ext/)"]');
 								break;
 
 							default:
-								$info['warning'][] = 'error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag). (ERROR: !IsValidID3v2FrameName("'.str_replace("\x00", ' ', $frame_name).'", '.$id3v2_majorversion.'))).';
+								$this->warning('error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag). (ERROR: !IsValidID3v2FrameName("'.str_replace("\x00", ' ', $frame_name).'", '.$id3v2_majorversion.'))).');
 								break;
 						}
 
 					} elseif (!isset($framedata) || ($frame_size > strlen($framedata))) {
 
-						$info['error'][] = 'error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag). (ERROR: $frame_size ('.$frame_size.') > strlen($framedata) ('.(isset($framedata) ? strlen($framedata) : 'null').')).';
+						$this->error('error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag). (ERROR: $frame_size ('.$frame_size.') > strlen($framedata) ('.(isset($framedata) ? strlen($framedata) : 'null').')).');
 
 					} else {
 
-						$info['error'][] = 'error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag).';
+						$this->error('error parsing "'.$frame_name.'" ('.$framedataoffset.' bytes into the ID3v2.'.$id3v2_majorversion.' tag).');
 
 					}
 
@@ -423,14 +434,14 @@ class getid3_id3v2 extends getid3_handler
 	//        ID3v2 size             4 * %0xxxxxxx
 
 		if (isset($thisfile_id3v2_flags['isfooter']) && $thisfile_id3v2_flags['isfooter']) {
-			$footer = fread($this->getid3->fp, 10);
+			$footer = $this->fread(10);
 			if (substr($footer, 0, 3) == '3DI') {
 				$thisfile_id3v2['footer'] = true;
-				$thisfile_id3v2['majorversion_footer'] = ord($footer{3});
-				$thisfile_id3v2['minorversion_footer'] = ord($footer{4});
+				$thisfile_id3v2['majorversion_footer'] = ord($footer[3]);
+				$thisfile_id3v2['minorversion_footer'] = ord($footer[4]);
 			}
 			if ($thisfile_id3v2['majorversion_footer'] <= 4) {
-				$id3_flags = ord(substr($footer{5}));
+				$id3_flags = ord($footer[5]);
 				$thisfile_id3v2_flags['unsynch_footer']  = (bool) ($id3_flags & 0x80);
 				$thisfile_id3v2_flags['extfoot_footer']  = (bool) ($id3_flags & 0x40);
 				$thisfile_id3v2_flags['experim_footer']  = (bool) ($id3_flags & 0x20);
@@ -441,16 +452,20 @@ class getid3_id3v2 extends getid3_handler
 		} // end footer
 
 		if (isset($thisfile_id3v2['comments']['genre'])) {
+			$genres = array();
 			foreach ($thisfile_id3v2['comments']['genre'] as $key => $value) {
-				unset($thisfile_id3v2['comments']['genre'][$key]);
-				$thisfile_id3v2['comments'] = getid3_lib::array_merge_noclobber($thisfile_id3v2['comments'], array('genre'=>$this->ParseID3v2GenreString($value)));
+				foreach ($this->ParseID3v2GenreString($value) as $genre) {
+					$genres[] = $genre;
+				}
 			}
+			$thisfile_id3v2['comments']['genre'] = array_unique($genres);
+			unset($key, $value, $genres, $genre);
 		}
 
-		if (isset($thisfile_id3v2['comments']['track'])) {
-			foreach ($thisfile_id3v2['comments']['track'] as $key => $value) {
+		if (isset($thisfile_id3v2['comments']['track_number'])) {
+			foreach ($thisfile_id3v2['comments']['track_number'] as $key => $value) {
 				if (strstr($value, '/')) {
-					list($thisfile_id3v2['comments']['tracknum'][$key], $thisfile_id3v2['comments']['totaltracks'][$key]) = explode('/', $thisfile_id3v2['comments']['track'][$key]);
+					list($thisfile_id3v2['comments']['track_number'][$key], $thisfile_id3v2['comments']['totaltracks'][$key]) = explode('/', $thisfile_id3v2['comments']['track_number'][$key]);
 				}
 			}
 		}
@@ -493,20 +508,50 @@ class getid3_id3v2 extends getid3_handler
 		return true;
 	}
 
-
+	/**
+	 * @param string $genrestring
+	 *
+	 * @return array
+	 */
 	public function ParseID3v2GenreString($genrestring) {
 		// Parse genres into arrays of genreName and genreID
 		// ID3v2.2.x, ID3v2.3.x: '(21)' or '(4)Eurodisco' or '(51)(39)' or '(55)((I think...)'
 		// ID3v2.4.x: '21' $00 'Eurodisco' $00
 		$clean_genres = array();
+
+		// hack-fixes for some badly-written ID3v2.3 taggers, while trying not to break correctly-written tags
+		if (($this->getid3->info['id3v2']['majorversion'] == 3) && !preg_match('#[\x00]#', $genrestring)) {
+			// note: MusicBrainz Picard incorrectly stores plaintext genres separated by "/" when writing in ID3v2.3 mode, hack-fix here:
+			// replace / with NULL, then replace back the two ID3v1 genres that legitimately have "/" as part of the single genre name
+			if (strpos($genrestring, '/') !== false) {
+				$LegitimateSlashedGenreList = array(  // https://github.com/JamesHeinrich/getID3/issues/223
+					'Pop/Funk',    // ID3v1 genre #62 - https://en.wikipedia.org/wiki/ID3#standard
+					'Cut-up/DJ',   // Discogs - https://www.discogs.com/style/cut-up/dj
+					'RnB/Swing',   // Discogs - https://www.discogs.com/style/rnb/swing
+					'Funk / Soul', // Discogs (note spaces) - https://www.discogs.com/genre/funk+%2F+soul
+				);
+				$genrestring = str_replace('/', "\x00", $genrestring);
+				foreach ($LegitimateSlashedGenreList as $SlashedGenre) {
+					$genrestring = str_ireplace(str_replace('/', "\x00", $SlashedGenre), $SlashedGenre, $genrestring);
+				}
+			}
+
+			// some other taggers separate multiple genres with semicolon, e.g. "Heavy Metal;Thrash Metal;Metal"
+			if (strpos($genrestring, ';') !== false) {
+				$genrestring = str_replace(';', "\x00", $genrestring);
+			}
+		}
+
+
 		if (strpos($genrestring, "\x00") === false) {
 			$genrestring = preg_replace('#\(([0-9]{1,3})\)#', '$1'."\x00", $genrestring);
 		}
+
 		$genre_elements = explode("\x00", $genrestring);
 		foreach ($genre_elements as $element) {
 			$element = trim($element);
 			if ($element) {
-				if (preg_match('#^[0-9]{1,3}#', $element)) {
+				if (preg_match('#^[0-9]{1,3}$#', $element)) {
 					$clean_genres[] = getid3_id3v1::LookupGenreName($element);
 				} else {
 					$clean_genres[] = str_replace('((', '(', $element);
@@ -516,7 +561,11 @@ class getid3_id3v2 extends getid3_handler
 		return $clean_genres;
 	}
 
-
+	/**
+	 * @param array $parsedFrame
+	 *
+	 * @return bool
+	 */
 	public function ParseID3v2Frame(&$parsedFrame) {
 
 		// shortcuts
@@ -570,14 +619,14 @@ class getid3_id3v2 extends getid3_handler
 			if ($parsedFrame['flags']['compression']) {
 				$parsedFrame['decompressed_size'] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], 0, 4));
 				if (!function_exists('gzuncompress')) {
-					$info['warning'][] = 'gzuncompress() support required to decompress ID3v2 frame "'.$parsedFrame['frame_name'].'"';
+					$this->warning('gzuncompress() support required to decompress ID3v2 frame "'.$parsedFrame['frame_name'].'"');
 				} else {
 					if ($decompresseddata = @gzuncompress(substr($parsedFrame['data'], 4))) {
 					//if ($decompresseddata = @gzuncompress($parsedFrame['data'])) {
 						$parsedFrame['data'] = $decompresseddata;
 						unset($decompresseddata);
 					} else {
-						$info['warning'][] = 'gzuncompress() failed on compressed contents of ID3v2 frame "'.$parsedFrame['frame_name'].'"';
+						$this->warning('gzuncompress() failed on compressed contents of ID3v2 frame "'.$parsedFrame['frame_name'].'"');
 					}
 				}
 			}
@@ -585,7 +634,7 @@ class getid3_id3v2 extends getid3_handler
 
 		if (!empty($parsedFrame['flags']['DataLengthIndicator'])) {
 			if ($parsedFrame['data_length_indicator'] != strlen($parsedFrame['data'])) {
-				$info['warning'][] = 'ID3v2 frame "'.$parsedFrame['frame_name'].'" should be '.$parsedFrame['data_length_indicator'].' bytes long according to DataLengthIndicator, but found '.strlen($parsedFrame['data']).' bytes of data';
+				$this->warning('ID3v2 frame "'.$parsedFrame['frame_name'].'" should be '.$parsedFrame['data_length_indicator'].' bytes long according to DataLengthIndicator, but found '.strlen($parsedFrame['data']).' bytes of data');
 			}
 		}
 
@@ -600,7 +649,7 @@ class getid3_id3v2 extends getid3_handler
 				default:
 					break;
 			}
-			$info['warning'][] = $warning;
+			$this->warning($warning);
 
 		} elseif ((($id3v2_majorversion >= 3) && ($parsedFrame['frame_name'] == 'UFID')) || // 4.1   UFID Unique file identifier
 			(($id3v2_majorversion == 2) && ($parsedFrame['frame_name'] == 'UFI'))) {  // 4.1   UFI  Unique file identifier
@@ -624,30 +673,35 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
-
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
+				$frame_textencoding_terminator = "\x00";
 			}
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
-			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
-				$frame_description = '';
-			}
+			$parsedFrame['description'] = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
+			$parsedFrame['description'] = $this->MakeUTF16emptyStringEmpty($parsedFrame['description']);
 			$parsedFrame['encodingid']  = $frame_textencoding;
 			$parsedFrame['encoding']    = $this->TextEncodingNameLookup($frame_textencoding);
 
-			$parsedFrame['description'] = $frame_description;
-			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
+			$parsedFrame['description'] = trim(getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['description']));
+			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator));
+			$parsedFrame['data'] = $this->RemoveStringTerminator($parsedFrame['data'], $frame_textencoding_terminator);
 			if (!empty($parsedFrame['framenameshort']) && !empty($parsedFrame['data'])) {
-				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = trim(getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['data']));
+				$commentkey = ($parsedFrame['description'] ? $parsedFrame['description'] : (isset($info['id3v2']['comments'][$parsedFrame['framenameshort']]) ? count($info['id3v2']['comments'][$parsedFrame['framenameshort']]) : 0));
+				if (!isset($info['id3v2']['comments'][$parsedFrame['framenameshort']]) || !array_key_exists($commentkey, $info['id3v2']['comments'][$parsedFrame['framenameshort']])) {
+					$info['id3v2']['comments'][$parsedFrame['framenameshort']][$commentkey] = trim(getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['data']));
+				} else {
+					$info['id3v2']['comments'][$parsedFrame['framenameshort']][]            = trim(getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['data']));
+				}
 			}
 			//unset($parsedFrame['data']); do not unset, may be needed elsewhere, e.g. for replaygain
 
 
-		} elseif ($parsedFrame['frame_name']{0} == 'T') { // 4.2. T??[?] Text information frame
+		} elseif ($parsedFrame['frame_name'][0] == 'T') { // 4.2. T??[?] Text information frame
 			//   There may only be one text information frame of its kind in an tag.
 			// <Header for 'Text information frame', ID: 'T000' - 'TZZZ',
 			// excluding 'TXXX' described in 4.2.6.>
@@ -657,19 +711,47 @@ class getid3_id3v2 extends getid3_handler
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
 			}
 
 			$parsedFrame['data'] = (string) substr($parsedFrame['data'], $frame_offset);
+			$parsedFrame['data'] = $this->RemoveStringTerminator($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding));
 
 			$parsedFrame['encodingid'] = $frame_textencoding;
 			$parsedFrame['encoding']   = $this->TextEncodingNameLookup($frame_textencoding);
-
 			if (!empty($parsedFrame['framenameshort']) && !empty($parsedFrame['data'])) {
-				$string = getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['data']);
-				$string = rtrim($string, "\x00"); // remove possible terminating null (put by encoding id or software bug)
-				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = $string;
-				unset($string);
+				// ID3v2.3 specs say that TPE1 (and others) can contain multiple artist values separated with /
+				// This of course breaks when an artist name contains slash character, e.g. "AC/DC"
+				// MP3tag (maybe others) implement alternative system where multiple artists are null-separated, which makes more sense
+				// getID3 will split null-separated artists into multiple artists and leave slash-separated ones to the user
+				switch ($parsedFrame['encoding']) {
+					case 'UTF-16':
+					case 'UTF-16BE':
+					case 'UTF-16LE':
+						$wordsize = 2;
+						break;
+					case 'ISO-8859-1':
+					case 'UTF-8':
+					default:
+						$wordsize = 1;
+						break;
+				}
+				$Txxx_elements = array();
+				$Txxx_elements_start_offset = 0;
+				for ($i = 0; $i < strlen($parsedFrame['data']); $i += $wordsize) {
+					if (substr($parsedFrame['data'], $i, $wordsize) == str_repeat("\x00", $wordsize)) {
+						$Txxx_elements[] = substr($parsedFrame['data'], $Txxx_elements_start_offset, $i - $Txxx_elements_start_offset);
+						$Txxx_elements_start_offset = $i + $wordsize;
+					}
+				}
+				$Txxx_elements[] = substr($parsedFrame['data'], $Txxx_elements_start_offset, $i - $Txxx_elements_start_offset);
+				foreach ($Txxx_elements as $Txxx_element) {
+					$string = getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $Txxx_element);
+					if (!empty($string)) {
+						$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = $string;
+					}
+				}
+				unset($string, $wordsize, $i, $Txxx_elements, $Txxx_element, $Txxx_elements_start_offset);
 			}
 
 		} elseif ((($id3v2_majorversion >= 3) && ($parsedFrame['frame_name'] == 'WXXX')) || // 4.3.2 WXXX User defined URL link frame
@@ -683,54 +765,38 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
+				$frame_textencoding_terminator = "\x00";
 			}
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
-			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-
-			if (ord($frame_description) === 0) {
-				$frame_description = '';
-			}
-			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
-
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding));
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
-				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
-			}
-			if ($frame_terminatorpos) {
-				// there are null bytes after the data - this is not according to spec
-				// only use data up to first null byte
-				$frame_urldata = (string) substr($parsedFrame['data'], 0, $frame_terminatorpos);
-			} else {
-				// no null bytes following data, just use all data
-				$frame_urldata = (string) $parsedFrame['data'];
-			}
-
 			$parsedFrame['encodingid']  = $frame_textencoding;
 			$parsedFrame['encoding']    = $this->TextEncodingNameLookup($frame_textencoding);
+			$parsedFrame['description'] = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);           // according to the frame text encoding
+			$parsedFrame['url']         = substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator)); // always ISO-8859-1
+			$parsedFrame['description'] = $this->RemoveStringTerminator($parsedFrame['description'], $frame_textencoding_terminator);
+			$parsedFrame['description'] = $this->MakeUTF16emptyStringEmpty($parsedFrame['description']);
 
-			$parsedFrame['url']         = $frame_urldata;
-			$parsedFrame['description'] = $frame_description;
 			if (!empty($parsedFrame['framenameshort']) && $parsedFrame['url']) {
-				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['url']);
+				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = getid3_lib::iconv_fallback('ISO-8859-1', $info['id3v2']['encoding'], $parsedFrame['url']);
 			}
 			unset($parsedFrame['data']);
 
 
-		} elseif ($parsedFrame['frame_name']{0} == 'W') { // 4.3. W??? URL link frames
+		} elseif ($parsedFrame['frame_name'][0] == 'W') { // 4.3. W??? URL link frames
 			//   There may only be one URL link frame of its kind in a tag,
 			//   except when stated otherwise in the frame description
 			// <Header for 'URL link frame', ID: 'W000' - 'WZZZ', excluding 'WXXX'
 			// described in 4.3.2.>
 			// URL              <text string>
 
-			$parsedFrame['url'] = trim($parsedFrame['data']);
+			$parsedFrame['url'] = trim($parsedFrame['data']); // always ISO-8859-1
 			if (!empty($parsedFrame['framenameshort']) && $parsedFrame['url']) {
-				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = $parsedFrame['url'];
+				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = getid3_lib::iconv_fallback('ISO-8859-1', $info['id3v2']['encoding'], $parsedFrame['url']);
 			}
 			unset($parsedFrame['data']);
 
@@ -746,13 +812,13 @@ class getid3_id3v2 extends getid3_handler
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
 			}
 			$parsedFrame['encodingid'] = $frame_textencoding;
 			$parsedFrame['encoding']   = $this->TextEncodingNameLookup($parsedFrame['encodingid']);
 			$parsedFrame['data_raw']   = (string) substr($parsedFrame['data'], $frame_offset);
 
-			// http://www.getid3.org/phpBB3/viewtopic.php?t=1369
+			// https://www.getid3.org/phpBB3/viewtopic.php?t=1369
 			// "this tag typically contains null terminated strings, which are associated in pairs"
 			// "there are users that use the tag incorrectly"
 			$IPLS_parts = array();
@@ -872,6 +938,7 @@ class getid3_id3v2 extends getid3_handler
 			$parsedFrame['bitsforbytesdeviation']   = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], 8, 1));
 			$parsedFrame['bitsformsdeviation']      = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], 9, 1));
 			$parsedFrame['data'] = substr($parsedFrame['data'], 10);
+			$deviationbitstream = '';
 			while ($frame_offset < strlen($parsedFrame['data'])) {
 				$deviationbitstream .= getid3_lib::BigEndian2Bin(substr($parsedFrame['data'], $frame_offset++, 1));
 			}
@@ -922,28 +989,27 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
+				$frame_textencoding_terminator = "\x00";
 			}
 			$frame_language = substr($parsedFrame['data'], $frame_offset, 3);
 			$frame_offset += 3;
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
-			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
-				$frame_description = '';
-			}
-			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
+			$parsedFrame['description'] = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
+			$parsedFrame['description'] = $this->MakeUTF16emptyStringEmpty($parsedFrame['description']);
+			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator));
+			$parsedFrame['data'] = $this->RemoveStringTerminator($parsedFrame['data'], $frame_textencoding_terminator);
 
 			$parsedFrame['encodingid']   = $frame_textencoding;
 			$parsedFrame['encoding']     = $this->TextEncodingNameLookup($frame_textencoding);
 
-			$parsedFrame['data']         = $parsedFrame['data'];
 			$parsedFrame['language']     = $frame_language;
 			$parsedFrame['languagename'] = $this->LanguageLookup($frame_language, false);
-			$parsedFrame['description']  = $frame_description;
 			if (!empty($parsedFrame['framenameshort']) && !empty($parsedFrame['data'])) {
 				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['data']);
 			}
@@ -968,8 +1034,10 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
+				$frame_textencoding_terminator = "\x00";
 			}
 			$frame_language = substr($parsedFrame['data'], $frame_offset, 3);
 			$frame_offset += 3;
@@ -986,17 +1054,17 @@ class getid3_id3v2 extends getid3_handler
 			$frame_remainingdata = substr($parsedFrame['data'], $frame_offset);
 			while (strlen($frame_remainingdata)) {
 				$frame_offset = 0;
-				$frame_terminatorpos = strpos($frame_remainingdata, $this->TextEncodingTerminatorLookup($frame_textencoding));
+				$frame_terminatorpos = strpos($frame_remainingdata, $frame_textencoding_terminator);
 				if ($frame_terminatorpos === false) {
 					$frame_remainingdata = '';
 				} else {
-					if (ord(substr($frame_remainingdata, $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+					if (ord(substr($frame_remainingdata, $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 						$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 					}
 					$parsedFrame['lyrics'][$timestampindex]['data'] = substr($frame_remainingdata, $frame_offset, $frame_terminatorpos - $frame_offset);
 
-					$frame_remainingdata = substr($frame_remainingdata, $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
-					if (($timestampindex == 0) && (ord($frame_remainingdata{0}) != 0)) {
+					$frame_remainingdata = substr($frame_remainingdata, $frame_terminatorpos + strlen($frame_textencoding_terminator));
+					if (($timestampindex == 0) && (ord($frame_remainingdata[0]) != 0)) {
 						// timestamp probably omitted for first data item
 					} else {
 						$parsedFrame['lyrics'][$timestampindex]['timestamp'] = getid3_lib::BigEndian2Int(substr($frame_remainingdata, 0, 4));
@@ -1020,36 +1088,41 @@ class getid3_id3v2 extends getid3_handler
 
 			if (strlen($parsedFrame['data']) < 5) {
 
-				$info['warning'][] = 'Invalid data (too short) for "'.$parsedFrame['frame_name'].'" frame at offset '.$parsedFrame['dataoffset'];
+				$this->warning('Invalid data (too short) for "'.$parsedFrame['frame_name'].'" frame at offset '.$parsedFrame['dataoffset']);
 
 			} else {
 
 				$frame_offset = 0;
 				$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+				$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 				if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-					$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+					$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
+					$frame_textencoding_terminator = "\x00";
 				}
 				$frame_language = substr($parsedFrame['data'], $frame_offset, 3);
 				$frame_offset += 3;
-				$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-				if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+				$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+				if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 					$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 				}
-				$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-				if (ord($frame_description) === 0) {
-					$frame_description = '';
-				}
-				$frame_text = (string) substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
+				$parsedFrame['description'] = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
+				$parsedFrame['description'] = $this->MakeUTF16emptyStringEmpty($parsedFrame['description']);
+				$frame_text = (string) substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator));
+				$frame_text = $this->RemoveStringTerminator($frame_text, $frame_textencoding_terminator);
 
 				$parsedFrame['encodingid']   = $frame_textencoding;
 				$parsedFrame['encoding']     = $this->TextEncodingNameLookup($frame_textencoding);
 
 				$parsedFrame['language']     = $frame_language;
 				$parsedFrame['languagename'] = $this->LanguageLookup($frame_language, false);
-				$parsedFrame['description']  = $frame_description;
 				$parsedFrame['data']         = $frame_text;
 				if (!empty($parsedFrame['framenameshort']) && !empty($parsedFrame['data'])) {
-					$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['data']);
+					$commentkey = ($parsedFrame['description'] ? $parsedFrame['description'] : (!empty($info['id3v2']['comments'][$parsedFrame['framenameshort']]) ? count($info['id3v2']['comments'][$parsedFrame['framenameshort']]) : 0));
+					if (!isset($info['id3v2']['comments'][$parsedFrame['framenameshort']]) || !array_key_exists($commentkey, $info['id3v2']['comments'][$parsedFrame['framenameshort']])) {
+						$info['id3v2']['comments'][$parsedFrame['framenameshort']][$commentkey] = getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['data']);
+					} else {
+						$info['id3v2']['comments'][$parsedFrame['framenameshort']][]            = getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['data']);
+					}
 				}
 
 			}
@@ -1084,7 +1157,7 @@ class getid3_id3v2 extends getid3_handler
 				$frame_offset += 2;
 				$parsedFrame[$RVA2channelcounter]['bitspeakvolume'] = ord(substr($frame_remainingdata, $frame_offset++, 1));
 				if (($parsedFrame[$RVA2channelcounter]['bitspeakvolume'] < 1) || ($parsedFrame[$RVA2channelcounter]['bitspeakvolume'] > 4)) {
-					$info['warning'][] = 'ID3v2::RVA2 frame['.$RVA2channelcounter.'] contains invalid '.$parsedFrame[$RVA2channelcounter]['bitspeakvolume'].'-byte bits-representing-peak value';
+					$this->warning('ID3v2::RVA2 frame['.$RVA2channelcounter.'] contains invalid '.$parsedFrame[$RVA2channelcounter]['bitspeakvolume'].'-byte bits-representing-peak value');
 					break;
 				}
 				$frame_bytespeakvolume = ceil($parsedFrame[$RVA2channelcounter]['bitspeakvolume'] / 8);
@@ -1291,15 +1364,17 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
+				$frame_textencoding_terminator = "\x00";
 			}
 
 			if ($id3v2_majorversion == 2 && strlen($parsedFrame['data']) > $frame_offset) {
 				$frame_imagetype = substr($parsedFrame['data'], $frame_offset, 3);
 				if (strtolower($frame_imagetype) == 'ima') {
 					// complete hack for mp3Rage (www.chaoticsoftware.com) that puts ID3v2.3-formatted
-					// MIME type instead of 3-char ID3v2.2-format image type  (thanks xbhoffØpacbell*net)
+					// MIME type instead of 3-char ID3v2.2-format image type  (thanks xbhoffÃ˜pacbell*net)
 					$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
 					$frame_mimetype = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
 					if (ord($frame_mimetype) === 0) {
@@ -1326,40 +1401,38 @@ class getid3_id3v2 extends getid3_handler
 			$frame_picturetype = ord(substr($parsedFrame['data'], $frame_offset++, 1));
 
 			if ($frame_offset >= $parsedFrame['datalength']) {
-				$info['warning'][] = 'data portion of APIC frame is missing at offset '.($parsedFrame['dataoffset'] + 8 + $frame_offset);
+				$this->warning('data portion of APIC frame is missing at offset '.($parsedFrame['dataoffset'] + 8 + $frame_offset));
 			} else {
-				$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-				if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+				$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+				if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 					$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 				}
-				$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-				if (ord($frame_description) === 0) {
-					$frame_description = '';
-				}
-				$parsedFrame['encodingid']       = $frame_textencoding;
-				$parsedFrame['encoding']         = $this->TextEncodingNameLookup($frame_textencoding);
+				$parsedFrame['description']   = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
+				$parsedFrame['description']   = $this->MakeUTF16emptyStringEmpty($parsedFrame['description']);
+				$parsedFrame['encodingid']    = $frame_textencoding;
+				$parsedFrame['encoding']      = $this->TextEncodingNameLookup($frame_textencoding);
 
 				if ($id3v2_majorversion == 2) {
-					$parsedFrame['imagetype']    = $frame_imagetype;
+					$parsedFrame['imagetype'] = isset($frame_imagetype) ? $frame_imagetype : null;
 				} else {
-					$parsedFrame['mime']         = $frame_mimetype;
+					$parsedFrame['mime']      = isset($frame_mimetype) ? $frame_mimetype : null;
 				}
-				$parsedFrame['picturetypeid']    = $frame_picturetype;
-				$parsedFrame['picturetype']      = $this->APICPictureTypeLookup($frame_picturetype);
-				$parsedFrame['description']      = $frame_description;
-				$parsedFrame['data']             = substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
-				$parsedFrame['datalength']       = strlen($parsedFrame['data']);
+				$parsedFrame['picturetypeid'] = $frame_picturetype;
+				$parsedFrame['picturetype']   = $this->APICPictureTypeLookup($frame_picturetype);
+				$parsedFrame['data']          = substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator));
+				$parsedFrame['datalength']    = strlen($parsedFrame['data']);
 
-				$parsedFrame['image_mime'] = '';
+				$parsedFrame['image_mime']    = '';
 				$imageinfo = array();
-				$imagechunkcheck = getid3_lib::GetDataImageSize($parsedFrame['data'], $imageinfo);
-				if (($imagechunkcheck[2] >= 1) && ($imagechunkcheck[2] <= 3)) {
-					$parsedFrame['image_mime']       = 'image/'.getid3_lib::ImageTypesLookup($imagechunkcheck[2]);
-					if ($imagechunkcheck[0]) {
-						$parsedFrame['image_width']  = $imagechunkcheck[0];
-					}
-					if ($imagechunkcheck[1]) {
-						$parsedFrame['image_height'] = $imagechunkcheck[1];
+				if ($imagechunkcheck = getid3_lib::GetDataImageSize($parsedFrame['data'], $imageinfo)) {
+					if (($imagechunkcheck[2] >= 1) && ($imagechunkcheck[2] <= 3)) {
+						$parsedFrame['image_mime']       = image_type_to_mime_type($imagechunkcheck[2]);
+						if ($imagechunkcheck[0]) {
+							$parsedFrame['image_width']  = $imagechunkcheck[0];
+						}
+						if ($imagechunkcheck[1]) {
+							$parsedFrame['image_height'] = $imagechunkcheck[1];
+						}
 					}
 				}
 
@@ -1369,22 +1442,23 @@ class getid3_id3v2 extends getid3_handler
 						unset($parsedFrame['data']);
 						break;
 					}
+					$dir = '';
 					if ($this->getid3->option_save_attachments === true) {
 						// great
 /*
 					} elseif (is_int($this->getid3->option_save_attachments)) {
 						if ($this->getid3->option_save_attachments < $parsedFrame['data_length']) {
 							// too big, skip
-							$info['warning'][] = 'attachment at '.$frame_offset.' is too large to process inline ('.number_format($parsedFrame['data_length']).' bytes)';
+							$this->warning('attachment at '.$frame_offset.' is too large to process inline ('.number_format($parsedFrame['data_length']).' bytes)');
 							unset($parsedFrame['data']);
 							break;
 						}
 */
 					} elseif (is_string($this->getid3->option_save_attachments)) {
 						$dir = rtrim(str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $this->getid3->option_save_attachments), DIRECTORY_SEPARATOR);
-						if (!is_dir($dir) || !is_writable($dir)) {
+						if (!is_dir($dir) || !getID3::is_writable($dir)) {
 							// cannot write, skip
-							$info['warning'][] = 'attachment at '.$frame_offset.' cannot be saved to "'.$dir.'" (not writable)';
+							$this->warning('attachment at '.$frame_offset.' cannot be saved to "'.$dir.'" (not writable)');
 							unset($parsedFrame['data']);
 							break;
 						}
@@ -1392,10 +1466,10 @@ class getid3_id3v2 extends getid3_handler
 					// if we get this far, must be OK
 					if (is_string($this->getid3->option_save_attachments)) {
 						$destination_filename = $dir.DIRECTORY_SEPARATOR.md5($info['filenamepath']).'_'.$frame_offset;
-						if (!file_exists($destination_filename) || is_writable($destination_filename)) {
+						if (!file_exists($destination_filename) || getID3::is_writable($destination_filename)) {
 							file_put_contents($destination_filename, $parsedFrame['data']);
 						} else {
-							$info['warning'][] = 'attachment at '.$frame_offset.' cannot be saved to "'.$destination_filename.'" (not writable)';
+							$this->warning('attachment at '.$frame_offset.' cannot be saved to "'.$destination_filename.'" (not writable)');
 						}
 						$parsedFrame['data_filename'] = $destination_filename;
 						unset($parsedFrame['data']);
@@ -1404,7 +1478,14 @@ class getid3_id3v2 extends getid3_handler
 							if (!isset($info['id3v2']['comments']['picture'])) {
 								$info['id3v2']['comments']['picture'] = array();
 							}
-							$info['id3v2']['comments']['picture'][] = array('data'=>$parsedFrame['data'], 'image_mime'=>$parsedFrame['image_mime']);
+							$comments_picture_data = array();
+							foreach (array('data', 'image_mime', 'image_width', 'image_height', 'imagetype', 'picturetype', 'description', 'datalength') as $picture_key) {
+								if (isset($parsedFrame[$picture_key])) {
+									$comments_picture_data[$picture_key] = $parsedFrame[$picture_key];
+								}
+							}
+							$info['id3v2']['comments']['picture'][] = $comments_picture_data;
+							unset($comments_picture_data);
 						}
 					}
 				} while (false);
@@ -1423,8 +1504,10 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
+				$frame_textencoding_terminator = "\x00";
 			}
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
 			$frame_mimetype = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
@@ -1433,25 +1516,23 @@ class getid3_id3v2 extends getid3_handler
 			}
 			$frame_offset = $frame_terminatorpos + strlen("\x00");
 
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			$frame_filename = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
 			if (ord($frame_filename) === 0) {
 				$frame_filename = '';
 			}
-			$frame_offset = $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding));
+			$frame_offset = $frame_terminatorpos + strlen($frame_textencoding_terminator);
 
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
-			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
-				$frame_description = '';
-			}
-			$frame_offset = $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding));
+			$parsedFrame['description'] = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
+			$parsedFrame['description'] = $this->MakeUTF16emptyStringEmpty($parsedFrame['description']);
+			$frame_offset = $frame_terminatorpos + strlen($frame_textencoding_terminator);
 
 			$parsedFrame['objectdata']  = (string) substr($parsedFrame['data'], $frame_offset);
 			$parsedFrame['encodingid']  = $frame_textencoding;
@@ -1459,7 +1540,6 @@ class getid3_id3v2 extends getid3_handler
 
 			$parsedFrame['mime']        = $frame_mimetype;
 			$parsedFrame['filename']    = $frame_filename;
-			$parsedFrame['description'] = $frame_description;
 			unset($parsedFrame['data']);
 
 
@@ -1529,15 +1609,12 @@ class getid3_id3v2 extends getid3_handler
 			$frame_offset = $frame_terminatorpos + strlen("\x00");
 
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
-			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
-				$frame_description = '';
-			}
+			$parsedFrame['description'] = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
+			$parsedFrame['description'] = $this->MakeUTF16emptyStringEmpty($parsedFrame['description']);
 			$frame_offset = $frame_terminatorpos + strlen("\x00");
 
 			$parsedFrame['ownerid']     = $frame_ownerid;
 			$parsedFrame['data']        = (string) substr($parsedFrame['data'], $frame_offset);
-			$parsedFrame['description'] = $frame_description;
 			unset($parsedFrame['data']);
 
 
@@ -1555,7 +1632,7 @@ class getid3_id3v2 extends getid3_handler
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
 			$frame_ownerid = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
 			if (ord($frame_ownerid) === 0) {
-				$frame_ownerid == '';
+				$frame_ownerid = '';
 			}
 			$frame_offset = $frame_terminatorpos + strlen("\x00");
 			$parsedFrame['ownerid'] = $frame_ownerid;
@@ -1568,7 +1645,7 @@ class getid3_id3v2 extends getid3_handler
 
 
 		} elseif ((($id3v2_majorversion >= 3) && ($parsedFrame['frame_name'] == 'LINK')) || // 4.20  LINK Linked information
-				(($id3v2_majorversion == 2) && ($parsedFrame['frame_name'] == 'LNK'))) {     // 4.22  LNK  Linked information
+				(($id3v2_majorversion == 2) && ($parsedFrame['frame_name'] == 'LNK'))) {    // 4.22  LNK  Linked information
 			//   There may be more than one 'LINK' frame in a tag,
 			//   but only one with the same contents
 			// <Header for 'Linked information', ID: 'LINK'>
@@ -1596,7 +1673,7 @@ class getid3_id3v2 extends getid3_handler
 
 			$parsedFrame['additionaldata'] = (string) substr($parsedFrame['data'], $frame_offset);
 			if (!empty($parsedFrame['framenameshort']) && $parsedFrame['url']) {
-				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = utf8_encode($parsedFrame['url']);
+				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = getid3_lib::iconv_fallback_iso88591_utf8($parsedFrame['url']);
 			}
 			unset($parsedFrame['data']);
 
@@ -1624,7 +1701,7 @@ class getid3_id3v2 extends getid3_handler
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
 			}
 			$frame_language = substr($parsedFrame['data'], $frame_offset, 3);
 			$frame_offset += 3;
@@ -1633,7 +1710,8 @@ class getid3_id3v2 extends getid3_handler
 			$parsedFrame['encodingid']   = $frame_textencoding;
 			$parsedFrame['encoding']     = $this->TextEncodingNameLookup($frame_textencoding);
 
-			$parsedFrame['data']         = (string) substr($parsedFrame['data'], $frame_offset);
+			$parsedFrame['data'] = (string) substr($parsedFrame['data'], $frame_offset);
+			$parsedFrame['data'] = $this->RemoveStringTerminator($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding));
 			if (!empty($parsedFrame['framenameshort']) && !empty($parsedFrame['data'])) {
 				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $parsedFrame['data']);
 			}
@@ -1651,7 +1729,7 @@ class getid3_id3v2 extends getid3_handler
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
 			}
 			$parsedFrame['encodingid'] = $frame_textencoding;
 			$parsedFrame['encoding']   = $this->TextEncodingNameLookup($frame_textencoding);
@@ -1665,12 +1743,13 @@ class getid3_id3v2 extends getid3_handler
 			$parsedFrame['pricepaid']['value']      = substr($frame_pricepaid, 3);
 
 			$parsedFrame['purchasedate'] = substr($parsedFrame['data'], $frame_offset, 8);
-			if (!$this->IsValidDateStampString($parsedFrame['purchasedate'])) {
+			if ($this->IsValidDateStampString($parsedFrame['purchasedate'])) {
 				$parsedFrame['purchasedateunix'] = mktime (0, 0, 0, substr($parsedFrame['purchasedate'], 4, 2), substr($parsedFrame['purchasedate'], 6, 2), substr($parsedFrame['purchasedate'], 0, 4));
 			}
 			$frame_offset += 8;
 
 			$parsedFrame['seller'] = (string) substr($parsedFrame['data'], $frame_offset);
+			$parsedFrame['seller'] = $this->RemoveStringTerminator($parsedFrame['seller'], $this->TextEncodingTerminatorLookup($frame_textencoding));
 			unset($parsedFrame['data']);
 
 
@@ -1690,8 +1769,10 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
-				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$this->warning('Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding');
+				$frame_textencoding_terminator = "\x00";
 			}
 
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
@@ -1713,25 +1794,23 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_receivedasid = ord(substr($parsedFrame['data'], $frame_offset++, 1));
 
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			$frame_sellername = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
 			if (ord($frame_sellername) === 0) {
 				$frame_sellername = '';
 			}
-			$frame_offset = $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding));
+			$frame_offset = $frame_terminatorpos + strlen($frame_textencoding_terminator);
 
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
-			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
-				$frame_description = '';
-			}
-			$frame_offset = $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding));
+			$parsedFrame['description'] = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
+			$parsedFrame['description'] = $this->MakeUTF16emptyStringEmpty($parsedFrame['description']);
+			$frame_offset = $frame_terminatorpos + strlen($frame_textencoding_terminator);
 
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
 			$frame_mimetype = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
@@ -1747,7 +1826,6 @@ class getid3_id3v2 extends getid3_handler
 			$parsedFrame['receivedasid']      = $frame_receivedasid;
 			$parsedFrame['receivedas']        = $this->COMRReceivedAsLookup($frame_receivedasid);
 			$parsedFrame['sellername']        = $frame_sellername;
-			$parsedFrame['description']       = $frame_description;
 			$parsedFrame['mime']              = $frame_mimetype;
 			$parsedFrame['logo']              = $frame_sellerlogo;
 			unset($parsedFrame['data']);
@@ -1857,7 +1935,7 @@ class getid3_id3v2 extends getid3_handler
 			$frame_offset += 2;
 			$parsedFrame['bitsperpoint'] = ord(substr($parsedFrame['data'], $frame_offset++, 1));
 			$frame_bytesperpoint = ceil($parsedFrame['bitsperpoint'] / 8);
-			for ($i = 0; $i < $frame_indexpoints; $i++) {
+			for ($i = 0; $i < $parsedFrame['indexpoints']; $i++) {
 				$parsedFrame['indexes'][$i] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, $frame_bytesperpoint));
 				$frame_offset += $frame_bytesperpoint;
 			}
@@ -1905,16 +1983,234 @@ class getid3_id3v2 extends getid3_handler
 
 			unset($parsedFrame['data']);
 
+		} elseif (($id3v2_majorversion >= 3) && ($parsedFrame['frame_name'] == 'CHAP')) { // CHAP Chapters frame (ID3v2.3+ only)
+			// http://id3.org/id3v2-chapters-1.0
+			// <ID3v2.3 or ID3v2.4 frame header, ID: "CHAP">           (10 bytes)
+			// Element ID      <text string> $00
+			// Start time      $xx xx xx xx
+			// End time        $xx xx xx xx
+			// Start offset    $xx xx xx xx
+			// End offset      $xx xx xx xx
+			// <Optional embedded sub-frames>
+
+			$frame_offset = 0;
+			@list($parsedFrame['element_id']) = explode("\x00", $parsedFrame['data'], 2);
+			$frame_offset += strlen($parsedFrame['element_id']."\x00");
+			$parsedFrame['time_begin'] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+			$frame_offset += 4;
+			$parsedFrame['time_end']   = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+			$frame_offset += 4;
+			if (substr($parsedFrame['data'], $frame_offset, 4) != "\xFF\xFF\xFF\xFF") {
+				// "If these bytes are all set to 0xFF then the value should be ignored and the start time value should be utilized."
+				$parsedFrame['offset_begin'] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+			}
+			$frame_offset += 4;
+			if (substr($parsedFrame['data'], $frame_offset, 4) != "\xFF\xFF\xFF\xFF") {
+				// "If these bytes are all set to 0xFF then the value should be ignored and the start time value should be utilized."
+				$parsedFrame['offset_end']   = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+			}
+			$frame_offset += 4;
+
+			if ($frame_offset < strlen($parsedFrame['data'])) {
+				$parsedFrame['subframes'] = array();
+				while ($frame_offset < strlen($parsedFrame['data'])) {
+					// <Optional embedded sub-frames>
+					$subframe = array();
+					$subframe['name']      =                           substr($parsedFrame['data'], $frame_offset, 4);
+					$frame_offset += 4;
+					$subframe['size']      = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+					$frame_offset += 4;
+					$subframe['flags_raw'] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 2));
+					$frame_offset += 2;
+					if ($subframe['size'] > (strlen($parsedFrame['data']) - $frame_offset)) {
+						$this->warning('CHAP subframe "'.$subframe['name'].'" at frame offset '.$frame_offset.' claims to be "'.$subframe['size'].'" bytes, which is more than the available data ('.(strlen($parsedFrame['data']) - $frame_offset).' bytes)');
+						break;
+					}
+					$subframe_rawdata = substr($parsedFrame['data'], $frame_offset, $subframe['size']);
+					$frame_offset += $subframe['size'];
+
+					$subframe['encodingid'] = ord(substr($subframe_rawdata, 0, 1));
+					$subframe['text']       =     substr($subframe_rawdata, 1);
+					$subframe['encoding']   = $this->TextEncodingNameLookup($subframe['encodingid']);
+					$encoding_converted_text = trim(getid3_lib::iconv_fallback($subframe['encoding'], $info['encoding'], $subframe['text']));
+					switch (substr($encoding_converted_text, 0, 2)) {
+						case "\xFF\xFE":
+						case "\xFE\xFF":
+							switch (strtoupper($info['id3v2']['encoding'])) {
+								case 'ISO-8859-1':
+								case 'UTF-8':
+									$encoding_converted_text = substr($encoding_converted_text, 2);
+									// remove unwanted byte-order-marks
+									break;
+								default:
+									// ignore
+									break;
+							}
+							break;
+						default:
+							// do not remove BOM
+							break;
+					}
+
+					switch ($subframe['name']) {
+						case 'TIT2':
+							$parsedFrame['chapter_name']        = $encoding_converted_text;
+							$parsedFrame['subframes'][] = $subframe;
+							break;
+						case 'TIT3':
+							$parsedFrame['chapter_description'] = $encoding_converted_text;
+							$parsedFrame['subframes'][] = $subframe;
+							break;
+						case 'WXXX':
+							list($subframe['chapter_url_description'], $subframe['chapter_url']) = explode("\x00", $encoding_converted_text, 2);
+							$parsedFrame['chapter_url'][$subframe['chapter_url_description']] = $subframe['chapter_url'];
+							$parsedFrame['subframes'][] = $subframe;
+							break;
+						case 'APIC':
+							if (preg_match('#^([^\\x00]+)*\\x00(.)([^\\x00]+)*\\x00(.+)$#s', $subframe['text'], $matches)) {
+								list($dummy, $subframe_apic_mime, $subframe_apic_picturetype, $subframe_apic_description, $subframe_apic_picturedata) = $matches;
+								$subframe['image_mime']   = trim(getid3_lib::iconv_fallback($subframe['encoding'], $info['encoding'], $subframe_apic_mime));
+								$subframe['picture_type'] = $this->APICPictureTypeLookup($subframe_apic_picturetype);
+								$subframe['description']  = trim(getid3_lib::iconv_fallback($subframe['encoding'], $info['encoding'], $subframe_apic_description));
+								if (strlen($this->TextEncodingTerminatorLookup($subframe['encoding'])) == 2) {
+									// the null terminator between "description" and "picture data" could be either 1 byte (ISO-8859-1, UTF-8) or two bytes (UTF-16)
+									// the above regex assumes one byte, if it's actually two then strip the second one here
+									$subframe_apic_picturedata = substr($subframe_apic_picturedata, 1);
+								}
+								$subframe['data'] = $subframe_apic_picturedata;
+								unset($dummy, $subframe_apic_mime, $subframe_apic_picturetype, $subframe_apic_description, $subframe_apic_picturedata);
+								unset($subframe['text'], $parsedFrame['text']);
+								$parsedFrame['subframes'][] = $subframe;
+								$parsedFrame['picture_present'] = true;
+							} else {
+								$this->warning('ID3v2.CHAP subframe #'.(count($parsedFrame['subframes']) + 1).' "'.$subframe['name'].'" not in expected format');
+							}
+							break;
+						default:
+							$this->warning('ID3v2.CHAP subframe "'.$subframe['name'].'" not handled (supported: TIT2, TIT3, WXXX, APIC)');
+							break;
+					}
+				}
+				unset($subframe_rawdata, $subframe, $encoding_converted_text);
+				unset($parsedFrame['data']); // debatable whether this this be here, without it the returned structure may contain a large amount of duplicate data if chapters contain APIC
+			}
+
+			$id3v2_chapter_entry = array();
+			foreach (array('id', 'time_begin', 'time_end', 'offset_begin', 'offset_end', 'chapter_name', 'chapter_description', 'chapter_url', 'picture_present') as $id3v2_chapter_key) {
+				if (isset($parsedFrame[$id3v2_chapter_key])) {
+					$id3v2_chapter_entry[$id3v2_chapter_key] = $parsedFrame[$id3v2_chapter_key];
+				}
+			}
+			if (!isset($info['id3v2']['chapters'])) {
+				$info['id3v2']['chapters'] = array();
+			}
+			$info['id3v2']['chapters'][] = $id3v2_chapter_entry;
+			unset($id3v2_chapter_entry, $id3v2_chapter_key);
+
+
+		} elseif (($id3v2_majorversion >= 3) && ($parsedFrame['frame_name'] == 'CTOC')) { // CTOC Chapters Table Of Contents frame (ID3v2.3+ only)
+			// http://id3.org/id3v2-chapters-1.0
+			// <ID3v2.3 or ID3v2.4 frame header, ID: "CTOC">           (10 bytes)
+			// Element ID      <text string> $00
+			// CTOC flags        %xx
+			// Entry count       $xx
+			// Child Element ID  <string>$00   /* zero or more child CHAP or CTOC entries */
+			// <Optional embedded sub-frames>
+
+			$frame_offset = 0;
+			@list($parsedFrame['element_id']) = explode("\x00", $parsedFrame['data'], 2);
+			$frame_offset += strlen($parsedFrame['element_id']."\x00");
+			$ctoc_flags_raw = ord(substr($parsedFrame['data'], $frame_offset, 1));
+			$frame_offset += 1;
+			$parsedFrame['entry_count'] = ord(substr($parsedFrame['data'], $frame_offset, 1));
+			$frame_offset += 1;
+
+			$terminator_position = null;
+			for ($i = 0; $i < $parsedFrame['entry_count']; $i++) {
+				$terminator_position = strpos($parsedFrame['data'], "\x00", $frame_offset);
+				$parsedFrame['child_element_ids'][$i] = substr($parsedFrame['data'], $frame_offset, $terminator_position - $frame_offset);
+				$frame_offset = $terminator_position + 1;
+			}
+
+			$parsedFrame['ctoc_flags']['ordered']   = (bool) ($ctoc_flags_raw & 0x01);
+			$parsedFrame['ctoc_flags']['top_level'] = (bool) ($ctoc_flags_raw & 0x03);
+
+			unset($ctoc_flags_raw, $terminator_position);
+
+			if ($frame_offset < strlen($parsedFrame['data'])) {
+				$parsedFrame['subframes'] = array();
+				while ($frame_offset < strlen($parsedFrame['data'])) {
+					// <Optional embedded sub-frames>
+					$subframe = array();
+					$subframe['name']      =                           substr($parsedFrame['data'], $frame_offset, 4);
+					$frame_offset += 4;
+					$subframe['size']      = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+					$frame_offset += 4;
+					$subframe['flags_raw'] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 2));
+					$frame_offset += 2;
+					if ($subframe['size'] > (strlen($parsedFrame['data']) - $frame_offset)) {
+						$this->warning('CTOS subframe "'.$subframe['name'].'" at frame offset '.$frame_offset.' claims to be "'.$subframe['size'].'" bytes, which is more than the available data ('.(strlen($parsedFrame['data']) - $frame_offset).' bytes)');
+						break;
+					}
+					$subframe_rawdata = substr($parsedFrame['data'], $frame_offset, $subframe['size']);
+					$frame_offset += $subframe['size'];
+
+					$subframe['encodingid'] = ord(substr($subframe_rawdata, 0, 1));
+					$subframe['text']       =     substr($subframe_rawdata, 1);
+					$subframe['encoding']   = $this->TextEncodingNameLookup($subframe['encodingid']);
+					$encoding_converted_text = trim(getid3_lib::iconv_fallback($subframe['encoding'], $info['encoding'], $subframe['text']));;
+					switch (substr($encoding_converted_text, 0, 2)) {
+						case "\xFF\xFE":
+						case "\xFE\xFF":
+							switch (strtoupper($info['id3v2']['encoding'])) {
+								case 'ISO-8859-1':
+								case 'UTF-8':
+									$encoding_converted_text = substr($encoding_converted_text, 2);
+									// remove unwanted byte-order-marks
+									break;
+								default:
+									// ignore
+									break;
+							}
+							break;
+						default:
+							// do not remove BOM
+							break;
+					}
+
+					if (($subframe['name'] == 'TIT2') || ($subframe['name'] == 'TIT3')) {
+						if ($subframe['name'] == 'TIT2') {
+							$parsedFrame['toc_name']        = $encoding_converted_text;
+						} elseif ($subframe['name'] == 'TIT3') {
+							$parsedFrame['toc_description'] = $encoding_converted_text;
+						}
+						$parsedFrame['subframes'][] = $subframe;
+					} else {
+						$this->warning('ID3v2.CTOC subframe "'.$subframe['name'].'" not handled (only TIT2 and TIT3)');
+					}
+				}
+				unset($subframe_rawdata, $subframe, $encoding_converted_text);
+			}
+
 		}
 
 		return true;
 	}
 
-
+	/**
+	 * @param string $data
+	 *
+	 * @return string
+	 */
 	public function DeUnsynchronise($data) {
 		return str_replace("\xFF\x00", "\xFF", $data);
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public function LookupExtendedHeaderRestrictionsTagSizeLimits($index) {
 		static $LookupExtendedHeaderRestrictionsTagSizeLimits = array(
 			0x00 => 'No more than 128 frames and 1 MB total tag size',
@@ -1925,6 +2221,11 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($LookupExtendedHeaderRestrictionsTagSizeLimits[$index]) ? $LookupExtendedHeaderRestrictionsTagSizeLimits[$index] : '');
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public function LookupExtendedHeaderRestrictionsTextEncodings($index) {
 		static $LookupExtendedHeaderRestrictionsTextEncodings = array(
 			0x00 => 'No restrictions',
@@ -1933,6 +2234,11 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($LookupExtendedHeaderRestrictionsTextEncodings[$index]) ? $LookupExtendedHeaderRestrictionsTextEncodings[$index] : '');
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public function LookupExtendedHeaderRestrictionsTextFieldSize($index) {
 		static $LookupExtendedHeaderRestrictionsTextFieldSize = array(
 			0x00 => 'No restrictions',
@@ -1943,6 +2249,11 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($LookupExtendedHeaderRestrictionsTextFieldSize[$index]) ? $LookupExtendedHeaderRestrictionsTextFieldSize[$index] : '');
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public function LookupExtendedHeaderRestrictionsImageEncoding($index) {
 		static $LookupExtendedHeaderRestrictionsImageEncoding = array(
 			0x00 => 'No restrictions',
@@ -1951,6 +2262,11 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($LookupExtendedHeaderRestrictionsImageEncoding[$index]) ? $LookupExtendedHeaderRestrictionsImageEncoding[$index] : '');
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public function LookupExtendedHeaderRestrictionsImageSizeSize($index) {
 		static $LookupExtendedHeaderRestrictionsImageSizeSize = array(
 			0x00 => 'No restrictions',
@@ -1961,6 +2277,11 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($LookupExtendedHeaderRestrictionsImageSizeSize[$index]) ? $LookupExtendedHeaderRestrictionsImageSizeSize[$index] : '');
 	}
 
+	/**
+	 * @param string $currencyid
+	 *
+	 * @return string
+	 */
 	public function LookupCurrencyUnits($currencyid) {
 
 		$begin = __LINE__;
@@ -2157,7 +2478,11 @@ class getid3_id3v2 extends getid3_handler
 		return getid3_lib::EmbeddedLookup($currencyid, $begin, __LINE__, __FILE__, 'id3v2-currency-units');
 	}
 
-
+	/**
+	 * @param string $currencyid
+	 *
+	 * @return string
+	 */
 	public function LookupCurrencyCountry($currencyid) {
 
 		$begin = __LINE__;
@@ -2310,7 +2635,7 @@ class getid3_id3v2 extends getid3_handler
 			SOS	Somalia
 			SPL	Seborga
 			SRG	Suriname
-			STD	São Tome and Principe
+			STD	SÃ£o Tome and Principe
 			SVC	El Salvador
 			SYP	Syria
 			SZL	Swaziland
@@ -2334,13 +2659,13 @@ class getid3_id3v2 extends getid3_handler
 			VND	Viet Nam
 			VUV	Vanuatu
 			WST	Samoa
-			XAF	Communauté Financière Africaine
+			XAF	CommunautÃ© FinanciÃ¨re Africaine
 			XAG	Silver
 			XAU	Gold
 			XCD	East Caribbean
 			XDR	International Monetary Fund
 			XPD	Palladium
-			XPF	Comptoirs Français du Pacifique
+			XPF	Comptoirs FranÃ§ais du Pacifique
 			XPT	Platinum
 			YER	Yemen
 			YUM	Yugoslavia
@@ -2353,8 +2678,12 @@ class getid3_id3v2 extends getid3_handler
 		return getid3_lib::EmbeddedLookup($currencyid, $begin, __LINE__, __FILE__, 'id3v2-currency-country');
 	}
 
-
-
+	/**
+	 * @param string $languagecode
+	 * @param bool   $casesensitive
+	 *
+	 * @return string
+	 */
 	public static function LanguageLookup($languagecode, $casesensitive=false) {
 
 		if (!$casesensitive) {
@@ -2784,7 +3113,7 @@ class getid3_id3v2 extends getid3_handler
 			vai	Vai
 			ven	Venda
 			vie	Vietnamese
-			vol	Volapük
+			vol	VolapÃ¼k
 			vot	Votic
 			wak	Wakashan Languages
 			wal	Walamo
@@ -2810,7 +3139,11 @@ class getid3_id3v2 extends getid3_handler
 		return getid3_lib::EmbeddedLookup($languagecode, $begin, __LINE__, __FILE__, 'id3v2-languagecode');
 	}
 
-
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public static function ETCOEventLookup($index) {
 		if (($index >= 0x17) && ($index <= 0xDF)) {
 			return 'reserved for future use';
@@ -2854,6 +3187,11 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($EventLookup[$index]) ? $EventLookup[$index] : '');
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public static function SYTLContentTypeLookup($index) {
 		static $SYTLContentTypeLookup = array(
 			0x00 => 'other',
@@ -2870,6 +3208,12 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($SYTLContentTypeLookup[$index]) ? $SYTLContentTypeLookup[$index] : '');
 	}
 
+	/**
+	 * @param int   $index
+	 * @param bool $returnarray
+	 *
+	 * @return array|string
+	 */
 	public static function APICPictureTypeLookup($index, $returnarray=false) {
 		static $APICPictureTypeLookup = array(
 			0x00 => 'Other',
@@ -2900,6 +3244,11 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($APICPictureTypeLookup[$index]) ? $APICPictureTypeLookup[$index] : '');
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public static function COMRReceivedAsLookup($index) {
 		static $COMRReceivedAsLookup = array(
 			0x00 => 'Other',
@@ -2916,6 +3265,11 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($COMRReceivedAsLookup[$index]) ? $COMRReceivedAsLookup[$index] : '');
 	}
 
+	/**
+	 * @param int $index
+	 *
+	 * @return string
+	 */
 	public static function RVA2ChannelTypeLookup($index) {
 		static $RVA2ChannelTypeLookup = array(
 			0x00 => 'Other',
@@ -2932,6 +3286,11 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($RVA2ChannelTypeLookup[$index]) ? $RVA2ChannelTypeLookup[$index] : '');
 	}
 
+	/**
+	 * @param string $framename
+	 *
+	 * @return string
+	 */
 	public static function FrameNameLongLookup($framename) {
 
 		$begin = __LINE__;
@@ -3083,7 +3442,7 @@ class getid3_id3v2 extends getid3_handler
 			TYER	Year
 			UFI	Unique file identifier
 			UFID	Unique file identifier
-			ULT	Unsychronised lyric/text transcription
+			ULT	Unsynchronised lyric/text transcription
 			USER	Terms of use
 			USLT	Unsynchronised lyric/text transcription
 			WAF	Official audio file webpage
@@ -3115,7 +3474,11 @@ class getid3_id3v2 extends getid3_handler
 		// from http://privatewww.essex.ac.uk/~djmrob/replaygain/file_format_id3v2.html
 	}
 
-
+	/**
+	 * @param string $framename
+	 *
+	 * @return string
+	 */
 	public static function FrameNameShortLookup($framename) {
 
 		$begin = __LINE__;
@@ -3267,7 +3630,7 @@ class getid3_id3v2 extends getid3_handler
 			TYER	year
 			UFI	unique_file_identifier
 			UFID	unique_file_identifier
-			ULT	unsychronised_lyric
+			ULT	unsynchronised_lyric
 			USER	terms_of_use
 			USLT	unsynchronised_lyric
 			WAF	url_file
@@ -3295,6 +3658,11 @@ class getid3_id3v2 extends getid3_handler
 		return getid3_lib::EmbeddedLookup($framename, $begin, __LINE__, __FILE__, 'id3v2-framename_short');
 	}
 
+	/**
+	 * @param string $encoding
+	 *
+	 * @return string
+	 */
 	public static function TextEncodingTerminatorLookup($encoding) {
 		// http://www.id3.org/id3v2.4.0-structure.txt
 		// Frames that allow different types of text encoding contains a text encoding description byte. Possible encodings:
@@ -3305,9 +3673,14 @@ class getid3_id3v2 extends getid3_handler
 			3   => "\x00",     // $03  UTF-8 encoded Unicode. Terminated with $00.
 			255 => "\x00\x00"
 		);
-		return (isset($TextEncodingTerminatorLookup[$encoding]) ? $TextEncodingTerminatorLookup[$encoding] : '');
+		return (isset($TextEncodingTerminatorLookup[$encoding]) ? $TextEncodingTerminatorLookup[$encoding] : "\x00");
 	}
 
+	/**
+	 * @param int $encoding
+	 *
+	 * @return string
+	 */
 	public static function TextEncodingNameLookup($encoding) {
 		// http://www.id3.org/id3v2.4.0-structure.txt
 		// Frames that allow different types of text encoding contains a text encoding description byte. Possible encodings:
@@ -3321,26 +3694,66 @@ class getid3_id3v2 extends getid3_handler
 		return (isset($TextEncodingNameLookup[$encoding]) ? $TextEncodingNameLookup[$encoding] : 'ISO-8859-1');
 	}
 
+	/**
+	 * @param string $string
+	 * @param string $terminator
+	 *
+	 * @return string
+	 */
+	public static function RemoveStringTerminator($string, $terminator) {
+		// Null terminator at end of comment string is somewhat ambiguous in the specification, may or may not be implemented by various taggers. Remove terminator only if present.
+		// https://github.com/JamesHeinrich/getID3/issues/121
+		// https://community.mp3tag.de/t/x-trailing-nulls-in-id3v2-comments/19227
+		if (substr($string, -strlen($terminator), strlen($terminator)) === $terminator) {
+			$string = substr($string, 0, -strlen($terminator));
+		}
+		return $string;
+	}
+
+	/**
+	 * @param string $string
+	 *
+	 * @return string
+	 */
+	public static function MakeUTF16emptyStringEmpty($string) {
+		if (in_array($string, array("\x00", "\x00\x00", "\xFF\xFE", "\xFE\xFF"))) {
+			// if string only contains a BOM or terminator then make it actually an empty string
+			$string = '';
+		}
+		return $string;
+	}
+
+	/**
+	 * @param string $framename
+	 * @param int    $id3v2majorversion
+	 *
+	 * @return bool|int
+	 */
 	public static function IsValidID3v2FrameName($framename, $id3v2majorversion) {
 		switch ($id3v2majorversion) {
 			case 2:
 				return preg_match('#[A-Z][A-Z0-9]{2}#', $framename);
-				break;
 
 			case 3:
 			case 4:
 				return preg_match('#[A-Z][A-Z0-9]{3}#', $framename);
-				break;
 		}
 		return false;
 	}
 
+	/**
+	 * @param string $numberstring
+	 * @param bool   $allowdecimal
+	 * @param bool   $allownegative
+	 *
+	 * @return bool
+	 */
 	public static function IsANumber($numberstring, $allowdecimal=false, $allownegative=false) {
 		for ($i = 0; $i < strlen($numberstring); $i++) {
-			if ((chr($numberstring{$i}) < chr('0')) || (chr($numberstring{$i}) > chr('9'))) {
-				if (($numberstring{$i} == '.') && $allowdecimal) {
+			if ((chr($numberstring[$i]) < chr('0')) || (chr($numberstring[$i]) > chr('9'))) {
+				if (($numberstring[$i] == '.') && $allowdecimal) {
 					// allowed
-				} elseif (($numberstring{$i} == '-') && $allownegative && ($i == 0)) {
+				} elseif (($numberstring[$i] == '-') && $allownegative && ($i == 0)) {
 					// allowed
 				} else {
 					return false;
@@ -3350,6 +3763,11 @@ class getid3_id3v2 extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $datestamp
+	 *
+	 * @return bool
+	 */
 	public static function IsValidDateStampString($datestamp) {
 		if (strlen($datestamp) != 8) {
 			return false;
@@ -3378,8 +3796,103 @@ class getid3_id3v2 extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int $majorversion
+	 *
+	 * @return int
+	 */
 	public static function ID3v2HeaderLength($majorversion) {
 		return (($majorversion == 2) ? 6 : 10);
+	}
+
+	/**
+	 * @param string $frame_name
+	 *
+	 * @return string|false
+	 */
+	public static function ID3v22iTunesBrokenFrameName($frame_name) {
+		// iTunes (multiple versions) has been known to write ID3v2.3 style frames
+		// but use ID3v2.2 frame names, right-padded using either [space] or [null]
+		// to make them fit in the 4-byte frame name space of the ID3v2.3 frame.
+		// This function will detect and translate the corrupt frame name into ID3v2.3 standard.
+		static $ID3v22_iTunes_BrokenFrames = array(
+			'BUF' => 'RBUF', // Recommended buffer size
+			'CNT' => 'PCNT', // Play counter
+			'COM' => 'COMM', // Comments
+			'CRA' => 'AENC', // Audio encryption
+			'EQU' => 'EQUA', // Equalisation
+			'ETC' => 'ETCO', // Event timing codes
+			'GEO' => 'GEOB', // General encapsulated object
+			'IPL' => 'IPLS', // Involved people list
+			'LNK' => 'LINK', // Linked information
+			'MCI' => 'MCDI', // Music CD identifier
+			'MLL' => 'MLLT', // MPEG location lookup table
+			'PIC' => 'APIC', // Attached picture
+			'POP' => 'POPM', // Popularimeter
+			'REV' => 'RVRB', // Reverb
+			'RVA' => 'RVAD', // Relative volume adjustment
+			'SLT' => 'SYLT', // Synchronised lyric/text
+			'STC' => 'SYTC', // Synchronised tempo codes
+			'TAL' => 'TALB', // Album/Movie/Show title
+			'TBP' => 'TBPM', // BPM (beats per minute)
+			'TCM' => 'TCOM', // Composer
+			'TCO' => 'TCON', // Content type
+			'TCP' => 'TCMP', // Part of a compilation
+			'TCR' => 'TCOP', // Copyright message
+			'TDA' => 'TDAT', // Date
+			'TDY' => 'TDLY', // Playlist delay
+			'TEN' => 'TENC', // Encoded by
+			'TFT' => 'TFLT', // File type
+			'TIM' => 'TIME', // Time
+			'TKE' => 'TKEY', // Initial key
+			'TLA' => 'TLAN', // Language(s)
+			'TLE' => 'TLEN', // Length
+			'TMT' => 'TMED', // Media type
+			'TOA' => 'TOPE', // Original artist(s)/performer(s)
+			'TOF' => 'TOFN', // Original filename
+			'TOL' => 'TOLY', // Original lyricist(s)/text writer(s)
+			'TOR' => 'TORY', // Original release year
+			'TOT' => 'TOAL', // Original album/movie/show title
+			'TP1' => 'TPE1', // Lead performer(s)/Soloist(s)
+			'TP2' => 'TPE2', // Band/orchestra/accompaniment
+			'TP3' => 'TPE3', // Conductor/performer refinement
+			'TP4' => 'TPE4', // Interpreted, remixed, or otherwise modified by
+			'TPA' => 'TPOS', // Part of a set
+			'TPB' => 'TPUB', // Publisher
+			'TRC' => 'TSRC', // ISRC (international standard recording code)
+			'TRD' => 'TRDA', // Recording dates
+			'TRK' => 'TRCK', // Track number/Position in set
+			'TS2' => 'TSO2', // Album-Artist sort order
+			'TSA' => 'TSOA', // Album sort order
+			'TSC' => 'TSOC', // Composer sort order
+			'TSI' => 'TSIZ', // Size
+			'TSP' => 'TSOP', // Performer sort order
+			'TSS' => 'TSSE', // Software/Hardware and settings used for encoding
+			'TST' => 'TSOT', // Title sort order
+			'TT1' => 'TIT1', // Content group description
+			'TT2' => 'TIT2', // Title/songname/content description
+			'TT3' => 'TIT3', // Subtitle/Description refinement
+			'TXT' => 'TEXT', // Lyricist/Text writer
+			'TXX' => 'TXXX', // User defined text information frame
+			'TYE' => 'TYER', // Year
+			'UFI' => 'UFID', // Unique file identifier
+			'ULT' => 'USLT', // Unsynchronised lyric/text transcription
+			'WAF' => 'WOAF', // Official audio file webpage
+			'WAR' => 'WOAR', // Official artist/performer webpage
+			'WAS' => 'WOAS', // Official audio source webpage
+			'WCM' => 'WCOM', // Commercial information
+			'WCP' => 'WCOP', // Copyright/Legal information
+			'WPB' => 'WPUB', // Publishers official webpage
+			'WXX' => 'WXXX', // User defined URL link frame
+		);
+		if (strlen($frame_name) == 4) {
+			if ((substr($frame_name, 3, 1) == ' ') || (substr($frame_name, 3, 1) == "\x00")) {
+				if (isset($ID3v22_iTunes_BrokenFrames[substr($frame_name, 0, 3)])) {
+					return $ID3v22_iTunes_BrokenFrames[substr($frame_name, 0, 3)];
+				}
+			}
+		}
+		return false;
 	}
 
 }

--- a/application/libraries/getid3/module.tag.lyrics3.php
+++ b/application/libraries/getid3/module.tag.lyrics3.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 ///                                                            //
 // module.tag.lyrics3.php                                      //
@@ -13,23 +14,27 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
-
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 class getid3_lyrics3 extends getid3_handler
 {
-
+	/**
+	 * @return bool
+	 */
 	public function Analyze() {
 		$info = &$this->getid3->info;
 
 		// http://www.volweb.cz/str/tags.htm
 
 		if (!getid3_lib::intValueSupported($info['filesize'])) {
-			$info['warning'][] = 'Unable to check for Lyrics3 because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB';
+			$this->warning('Unable to check for Lyrics3 because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB');
 			return false;
 		}
 
-		fseek($this->getid3->fp, (0 - 128 - 9 - 6), SEEK_END);          // end - ID3v1 - "LYRICSEND" - [Lyrics3size]
-		$lyrics3_id3v1 = fread($this->getid3->fp, 128 + 9 + 6);
-		$lyrics3lsz    = substr($lyrics3_id3v1,  0,   6); // Lyrics3size
+		$this->fseek((0 - 128 - 9 - 6), SEEK_END);          // end - ID3v1 - "LYRICSEND" - [Lyrics3size]
+		$lyrics3_id3v1 = $this->fread(128 + 9 + 6);
+		$lyrics3lsz    = (int) substr($lyrics3_id3v1, 0, 6); // Lyrics3size
 		$lyrics3end    = substr($lyrics3_id3v1,  6,   9); // LYRICSEND or LYRICS200
 		$id3v1tag      = substr($lyrics3_id3v1, 15, 128); // ID3v1
 
@@ -60,7 +65,7 @@ class getid3_lyrics3 extends getid3_handler
 
 			// Lyrics3v2, no ID3v1, no APE
 
-			$lyrics3size    = strrev(substr(strrev($lyrics3_id3v1), 9, 6)) + 6 + strlen('LYRICS200'); // LSZ = lyrics + 'LYRICSBEGIN'; add 6-byte size field; add 'LYRICS200'
+			$lyrics3size    = (int) strrev(substr(strrev($lyrics3_id3v1), 9, 6)) + 6 + strlen('LYRICS200'); // LSZ = lyrics + 'LYRICSBEGIN'; add 6-byte size field; add 'LYRICS200'
 			$lyrics3offset  = $info['filesize'] - $lyrics3size;
 			$lyrics3version = 2;
 
@@ -68,9 +73,9 @@ class getid3_lyrics3 extends getid3_handler
 
 			if (isset($info['ape']['tag_offset_start']) && ($info['ape']['tag_offset_start'] > 15)) {
 
-				fseek($this->getid3->fp, $info['ape']['tag_offset_start'] - 15, SEEK_SET);
-				$lyrics3lsz = fread($this->getid3->fp, 6);
-				$lyrics3end = fread($this->getid3->fp, 9);
+				$this->fseek($info['ape']['tag_offset_start'] - 15);
+				$lyrics3lsz = $this->fread(6);
+				$lyrics3end = $this->fread(9);
 
 				if ($lyrics3end == 'LYRICSEND') {
 					// Lyrics3v1, APE, maybe ID3v1
@@ -79,7 +84,7 @@ class getid3_lyrics3 extends getid3_handler
 					$lyrics3offset  = $info['ape']['tag_offset_start'] - $lyrics3size;
 					$info['avdataend'] = $lyrics3offset;
 					$lyrics3version = 1;
-					$info['warning'][] = 'APE tag located after Lyrics3, will probably break Lyrics3 compatability';
+					$this->warning('APE tag located after Lyrics3, will probably break Lyrics3 compatability');
 
 				} elseif ($lyrics3end == 'LYRICS200') {
 					// Lyrics3v2, APE, maybe ID3v1
@@ -87,7 +92,7 @@ class getid3_lyrics3 extends getid3_handler
 					$lyrics3size    = $lyrics3lsz + 6 + strlen('LYRICS200'); // LSZ = lyrics + 'LYRICSBEGIN'; add 6-byte size field; add 'LYRICS200'
 					$lyrics3offset  = $info['ape']['tag_offset_start'] - $lyrics3size;
 					$lyrics3version = 2;
-					$info['warning'][] = 'APE tag located after Lyrics3, will probably break Lyrics3 compatability';
+					$this->warning('APE tag located after Lyrics3, will probably break Lyrics3 compatability');
 
 				}
 
@@ -95,15 +100,16 @@ class getid3_lyrics3 extends getid3_handler
 
 		}
 
-		if (isset($lyrics3offset)) {
+		if (isset($lyrics3offset) && isset($lyrics3version) && isset($lyrics3size)) {
 			$info['avdataend'] = $lyrics3offset;
 			$this->getLyrics3Data($lyrics3offset, $lyrics3version, $lyrics3size);
 
 			if (!isset($info['ape'])) {
-				$GETID3_ERRORARRAY = &$info['warning'];
-				if (getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.apetag.php', __FILE__, false)) {
+				if (isset($info['lyrics3']['tag_offset_start'])) {
+					$GETID3_ERRORARRAY = &$info['warning'];
+					getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.apetag.php', __FILE__, true);
 					$getid3_temp = new getID3();
-					$getid3_temp->openfile($this->getid3->filename);
+					$getid3_temp->openfile($this->getid3->filename, $this->getid3->info['filesize'], $this->getid3->fp);
 					$getid3_apetag = new getid3_apetag($getid3_temp);
 					$getid3_apetag->overrideendoffset = $info['lyrics3']['tag_offset_start'];
 					$getid3_apetag->Analyze();
@@ -114,6 +120,8 @@ class getid3_lyrics3 extends getid3_handler
 						$info['replay_gain'] = $getid3_temp->info['replay_gain'];
 					}
 					unset($getid3_temp, $getid3_apetag);
+				} else {
+					$this->warning('Lyrics3 and APE tags appear to have become entangled (most likely due to updating the APE tags with a non-Lyrics3-aware tagger)');
 				}
 			}
 
@@ -122,21 +130,30 @@ class getid3_lyrics3 extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param int $endoffset
+	 * @param int $version
+	 * @param int $length
+	 *
+	 * @return bool
+	 */
 	public function getLyrics3Data($endoffset, $version, $length) {
 		// http://www.volweb.cz/str/tags.htm
 
 		$info = &$this->getid3->info;
 
 		if (!getid3_lib::intValueSupported($endoffset)) {
-			$info['warning'][] = 'Unable to check for Lyrics3 because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB';
+			$this->warning('Unable to check for Lyrics3 because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB');
 			return false;
 		}
 
-		fseek($this->getid3->fp, $endoffset, SEEK_SET);
+		$this->fseek($endoffset);
 		if ($length <= 0) {
 			return false;
 		}
-		$rawdata = fread($this->getid3->fp, $length);
+		$rawdata = $this->fread($length);
+
+		$ParsedLyrics3 = array();
 
 		$ParsedLyrics3['raw']['lyrics3version'] = $version;
 		$ParsedLyrics3['raw']['lyrics3tagsize'] = $length;
@@ -146,7 +163,7 @@ class getid3_lyrics3 extends getid3_handler
 		if (substr($rawdata, 0, 11) != 'LYRICSBEGIN') {
 			if (strpos($rawdata, 'LYRICSBEGIN') !== false) {
 
-				$info['warning'][] = '"LYRICSBEGIN" expected at '.$endoffset.' but actually found at '.($endoffset + strpos($rawdata, 'LYRICSBEGIN')).' - this is invalid for Lyrics3 v'.$version;
+				$this->warning('"LYRICSBEGIN" expected at '.$endoffset.' but actually found at '.($endoffset + strpos($rawdata, 'LYRICSBEGIN')).' - this is invalid for Lyrics3 v'.$version);
 				$info['avdataend'] = $endoffset + strpos($rawdata, 'LYRICSBEGIN');
 				$rawdata = substr($rawdata, strpos($rawdata, 'LYRICSBEGIN'));
 				$length = strlen($rawdata);
@@ -155,7 +172,7 @@ class getid3_lyrics3 extends getid3_handler
 
 			} else {
 
-				$info['error'][] = '"LYRICSBEGIN" expected at '.$endoffset.' but found "'.substr($rawdata, 0, 11).'" instead';
+				$this->error('"LYRICSBEGIN" expected at '.$endoffset.' but found "'.substr($rawdata, 0, 11).'" instead');
 				return false;
 
 			}
@@ -169,7 +186,7 @@ class getid3_lyrics3 extends getid3_handler
 					$ParsedLyrics3['raw']['LYR'] = trim(substr($rawdata, 11, strlen($rawdata) - 11 - 9));
 					$this->Lyrics3LyricsTimestampParse($ParsedLyrics3);
 				} else {
-					$info['error'][] = '"LYRICSEND" expected at '.(ftell($this->getid3->fp) - 11 + $length - 9).' but found "'.substr($rawdata, strlen($rawdata) - 9, 9).'" instead';
+					$this->error('"LYRICSEND" expected at '.($this->ftell() - 11 + $length - 9).' but found "'.substr($rawdata, strlen($rawdata) - 9, 9).'" instead');
 					return false;
 				}
 				break;
@@ -217,20 +234,19 @@ class getid3_lyrics3 extends getid3_handler
 						$this->Lyrics3LyricsTimestampParse($ParsedLyrics3);
 					}
 				} else {
-					$info['error'][] = '"LYRICS200" expected at '.(ftell($this->getid3->fp) - 11 + $length - 9).' but found "'.substr($rawdata, strlen($rawdata) - 9, 9).'" instead';
+					$this->error('"LYRICS200" expected at '.($this->ftell() - 11 + $length - 9).' but found "'.substr($rawdata, strlen($rawdata) - 9, 9).'" instead');
 					return false;
 				}
 				break;
 
 			default:
-				$info['error'][] = 'Cannot process Lyrics3 version '.$version.' (only v1 and v2)';
+				$this->error('Cannot process Lyrics3 version '.$version.' (only v1 and v2)');
 				return false;
-				break;
 		}
 
 
 		if (isset($info['id3v1']['tag_offset_start']) && ($info['id3v1']['tag_offset_start'] <= $ParsedLyrics3['tag_offset_end'])) {
-			$info['warning'][] = 'ID3v1 tag information ignored since it appears to be a false synch in Lyrics3 tag data';
+			$this->warning('ID3v1 tag information ignored since it appears to be a false synch in Lyrics3 tag data');
 			unset($info['id3v1']);
 			foreach ($info['warning'] as $key => $value) {
 				if ($value == 'Some ID3v1 fields do not use NULL characters for padding') {
@@ -246,6 +262,11 @@ class getid3_lyrics3 extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $rawtimestamp
+	 *
+	 * @return int|false
+	 */
 	public function Lyrics3Timestamp2Seconds($rawtimestamp) {
 		if (preg_match('#^\\[([0-9]{2}):([0-9]{2})\\]$#', $rawtimestamp, $regs)) {
 			return (int) (($regs[1] * 60) + $regs[2]);
@@ -253,8 +274,14 @@ class getid3_lyrics3 extends getid3_handler
 		return false;
 	}
 
+	/**
+	 * @param array $Lyrics3data
+	 *
+	 * @return bool
+	 */
 	public function Lyrics3LyricsTimestampParse(&$Lyrics3data) {
 		$lyricsarray = explode("\r\n", $Lyrics3data['raw']['LYR']);
+		$notimestamplyricsarray = array();
 		foreach ($lyricsarray as $key => $lyricline) {
 			$regs = array();
 			unset($thislinetimestamps);
@@ -283,6 +310,11 @@ class getid3_lyrics3 extends getid3_handler
 		return true;
 	}
 
+	/**
+	 * @param string $char
+	 *
+	 * @return bool|null
+	 */
 	public function IntString2Bool($char) {
 		if ($char == '1') {
 			return true;

--- a/application/libraries/getid3/module.tag.xmp.php
+++ b/application/libraries/getid3/module.tag.xmp.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // module.tag.xmp.php                                          //
@@ -14,7 +15,7 @@
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // Module originally written [2009-Mar-26] by                  //
-//      Nigel Barnes <ngbarnesØhotmail*com>                    //
+//      Nigel Barnes <ngbarnesÃ˜hotmail*com>                    //
 // Bundled into getID3 with permission                         //
 //   called by getID3 in module.graphic.jpg.php                //
 //                                                            ///
@@ -80,8 +81,8 @@ class Image_XMP
 	* Reads all the JPEG header segments from an JPEG image file into an array
 	*
 	* @param string $filename - the filename of the JPEG file to read
-	* @return array $headerdata - Array of JPEG header segments
-	* @return boolean FALSE - if headers could not be read
+	* @return array|boolean  $headerdata - Array of JPEG header segments,
+	*                        FALSE - if headers could not be read
 	*/
 	public function _get_jpeg_header_data($filename)
 	{
@@ -113,7 +114,7 @@ class Image_XMP
 		$data = fread($filehnd, 2);
 
 		// Check that the third character is 0xFF (Start of first segment header)
-		if ($data{0} != "\xFF")
+		if ($data[0] != "\xFF")
 		{
 			// NO FF found - close file and return - JPEG is probably corrupted
 			fclose($filehnd);
@@ -123,15 +124,16 @@ class Image_XMP
 		// Flag that we havent yet hit the compressed image data
 		$hit_compressed_image_data = false;
 
+		$headerdata = array();
 		// Cycle through the file until, one of: 1) an EOI (End of image) marker is hit,
 		//                                       2) we have hit the compressed image data (no more headers are allowed after data)
 		//                                       3) or end of file is hit
 
-		while (($data{1} != "\xD9") && (!$hit_compressed_image_data) && (!feof($filehnd)))
+		while (($data[1] != "\xD9") && (!$hit_compressed_image_data) && (!feof($filehnd)))
 		{
 			// Found a segment to look at.
 			// Check that the segment marker is not a Restart marker - restart markers don't have size or data after them
-			if ((ord($data{1}) < 0xD0) || (ord($data{1}) > 0xD7))
+			if ((ord($data[1]) < 0xD0) || (ord($data[1]) > 0xD7))
 			{
 				// Segment isn't a Restart marker
 				// Read the next two bytes (size)
@@ -148,15 +150,15 @@ class Image_XMP
 
 				// Store the segment information in the output array
 				$headerdata[] = array(
-					'SegType'      => ord($data{1}),
-					'SegName'      => $GLOBALS['JPEG_Segment_Names'][ord($data{1})],
+					'SegType'      => ord($data[1]),
+					'SegName'      => $GLOBALS['JPEG_Segment_Names'][ord($data[1])],
 					'SegDataStart' => $segdatastart,
 					'SegData'      => $segdata,
 				);
 			}
 
 			// If this is a SOS (Start Of Scan) segment, then there is no more header data - the compressed image data follows
-			if ($data{1} == "\xDA")
+			if ($data[1] == "\xDA")
 			{
 				// Flag that we have hit the compressed image data - exit loop as no more headers available.
 				$hit_compressed_image_data = true;
@@ -167,7 +169,7 @@ class Image_XMP
 				$data = fread($filehnd, 2);
 
 				// Check that the first byte of the two is 0xFF as it should be for a marker
-				if ($data{0} != "\xFF")
+				if ($data[0] != "\xFF")
 				{
 					// NO FF found - close file and return - JPEG is probably corrupted
 					fclose($filehnd);
@@ -190,8 +192,8 @@ class Image_XMP
 	* Retrieves XMP information from an APP1 JPEG segment and returns the raw XML text as a string.
 	*
 	* @param string $filename - the filename of the JPEG file to read
-	* @return string $xmp_data - the string of raw XML text
-	* @return boolean FALSE - if an APP 1 XMP segment could not be found, or if an error occured
+	* @return string|boolean $xmp_data - the string of raw XML text,
+	*                        FALSE - if an APP 1 XMP segment could not be found, or if an error occured
 	*/
 	public function _get_XMP_text($filename)
 	{
@@ -211,7 +213,7 @@ class Image_XMP
 					// Return the XMP text
 					$xmp_data = substr($jpeg_header_data[$i]['SegData'], 29);
 
-					return trim($xmp_data); // trim() should not be neccesary, but some files found in the wild with null-terminated block (known samples from Apple Aperture) causes problems elsewhere (see http://www.getid3.org/phpBB3/viewtopic.php?f=4&t=1153)
+					return trim($xmp_data); // trim() should not be neccesary, but some files found in the wild with null-terminated block (known samples from Apple Aperture) causes problems elsewhere (see https://www.getid3.org/phpBB3/viewtopic.php?f=4&t=1153)
 				}
 			}
 		}
@@ -222,9 +224,9 @@ class Image_XMP
 	* Parses a string containing XMP data (XML), and returns an array
 	* which contains all the XMP (XML) information.
 	*
-	* @param string $xml_text - a string containing the XMP data (XML) to be parsed
-	* @return array $xmp_array - an array containing all xmp details retrieved.
-	* @return boolean FALSE - couldn't parse the XMP data
+	* @param string $xmltext - a string containing the XMP data (XML) to be parsed
+	* @return array|boolean $xmp_array - an array containing all xmp details retrieved,
+	*                       FALSE - couldn't parse the XMP data.
 	*/
 	public function read_XMP_array_from_text($xmltext)
 	{
@@ -303,17 +305,19 @@ class Image_XMP
 								{
 									// Check whether we want this details from this attribute
 //									if (in_array($key, $GLOBALS['XMP_tag_captions']))
-									if (true)
-									{
+//									if (true)
+//									{
 										// Attribute wanted
 										$xmp_array[$key] = $xml_elem['attributes'][$key];
-									}
+//									}
 								}
 							}
+							break;
 						case 'cdata':
 						case 'close':
 							break;
 					}
+					break;
 
 				case 'rdf:ID':
 				case 'rdf:nodeID':
@@ -361,8 +365,8 @@ class Image_XMP
 				default:
 					// Check whether we want the details from this attribute
 //					if (in_array($xml_elem['tag'], $GLOBALS['XMP_tag_captions']))
-					if (true)
-					{
+//					if (true)
+//					{
 						switch ($xml_elem['type'])
 						{
 							case 'open':
@@ -384,7 +388,7 @@ class Image_XMP
 								// ignore
 								break;
 						}
-					}
+//					}
 					break;
 			}
 
@@ -396,9 +400,9 @@ class Image_XMP
 	/**
 	* Constructor
 	*
-	* @param string - Name of the image file to access and extract XMP information from.
+	* @param string $sFilename - Name of the image file to access and extract XMP information from.
 	*/
-	public function Image_XMP($sFilename)
+	public function __construct($sFilename)
 	{
 		$this->_sFilename = $sFilename;
 
@@ -408,8 +412,11 @@ class Image_XMP
 			$xmp_data = $this->_get_XMP_text($sFilename);
 			if ($xmp_data)
 			{
-				$this->_aXMP = $this->read_XMP_array_from_text($xmp_data);
-				$this->_bXMPParse = true;
+				$aXMP = $this->read_XMP_array_from_text($xmp_data);
+				if ($aXMP !== false) {
+					$this->_aXMP = (array) $aXMP;
+					$this->_bXMPParse = true;
+				}
 			}
 		}
 	}

--- a/application/libraries/getid3/write.apetag.php
+++ b/application/libraries/getid3/write.apetag.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // write.apetag.php                                            //
@@ -13,22 +14,50 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
-
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.apetag.php', __FILE__, true);
 
 class getid3_write_apetag
 {
-
+	/**
+	 * @var string
+	 */
 	public $filename;
-	public $tag_data;
-	public $always_preserve_replaygain = true;    // ReplayGain / MP3gain tags will be copied from old tag even if not passed in data
-	public $warnings                   = array(); // any non-critical errors will be stored here
-	public $errors                     = array(); // any critical errors will be stored here
 
-	public function getid3_write_apetag() {
-		return true;
+	/**
+	 * @var array
+	 */
+	public $tag_data;
+
+	/**
+	 * ReplayGain / MP3gain tags will be copied from old tag even if not passed in data.
+	 *
+	 * @var bool
+	 */
+	public $always_preserve_replaygain = true;
+
+	/**
+	 * Any non-critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $warnings                   = array();
+
+	/**
+	 * Any critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $errors                     = array();
+
+	public function __construct() {
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function WriteAPEtag() {
 		// NOTE: All data passed to this function must be UTF-8 format
 
@@ -56,7 +85,7 @@ class getid3_write_apetag
 		}
 
 		if ($APEtag = $this->GenerateAPEtag()) {
-			if (is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'a+b'))) {
+			if (getID3::is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'a+b'))) {
 				$oldignoreuserabort = ignore_user_abort(true);
 				flock($fp, LOCK_EX);
 
@@ -67,15 +96,15 @@ class getid3_write_apetag
 				if (isset($ThisFileInfo['lyrics3']['tag_offset_start'])) {
 					$PostAPEdataOffset = max($PostAPEdataOffset, $ThisFileInfo['lyrics3']['tag_offset_start']);
 				}
-				fseek($fp, $PostAPEdataOffset, SEEK_SET);
+				fseek($fp, $PostAPEdataOffset);
 				$PostAPEdata = '';
 				if ($ThisFileInfo['filesize'] > $PostAPEdataOffset) {
 					$PostAPEdata = fread($fp, $ThisFileInfo['filesize'] - $PostAPEdataOffset);
 				}
 
-				fseek($fp, $PostAPEdataOffset, SEEK_SET);
+				fseek($fp, $PostAPEdataOffset);
 				if (isset($ThisFileInfo['ape']['tag_offset_start'])) {
-					fseek($fp, $ThisFileInfo['ape']['tag_offset_start'], SEEK_SET);
+					fseek($fp, $ThisFileInfo['ape']['tag_offset_start']);
 				}
 				ftruncate($fp, ftell($fp));
 				fwrite($fp, $APEtag, strlen($APEtag));
@@ -91,23 +120,26 @@ class getid3_write_apetag
 		return false;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function DeleteAPEtag() {
 		$getID3 = new getID3;
 		$ThisFileInfo = $getID3->analyze($this->filename);
 		if (isset($ThisFileInfo['ape']['tag_offset_start']) && isset($ThisFileInfo['ape']['tag_offset_end'])) {
-			if (is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'a+b'))) {
+			if (getID3::is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'a+b'))) {
 
 				flock($fp, LOCK_EX);
 				$oldignoreuserabort = ignore_user_abort(true);
 
-				fseek($fp, $ThisFileInfo['ape']['tag_offset_end'], SEEK_SET);
+				fseek($fp, $ThisFileInfo['ape']['tag_offset_end']);
 				$DataAfterAPE = '';
 				if ($ThisFileInfo['filesize'] > $ThisFileInfo['ape']['tag_offset_end']) {
 					$DataAfterAPE = fread($fp, $ThisFileInfo['filesize'] - $ThisFileInfo['ape']['tag_offset_end']);
 				}
 
 				ftruncate($fp, $ThisFileInfo['ape']['tag_offset_start']);
-				fseek($fp, $ThisFileInfo['ape']['tag_offset_start'], SEEK_SET);
+				fseek($fp, $ThisFileInfo['ape']['tag_offset_start']);
 
 				if (!empty($DataAfterAPE)) {
 					fwrite($fp, $DataAfterAPE, strlen($DataAfterAPE));
@@ -124,7 +156,9 @@ class getid3_write_apetag
 		return true;
 	}
 
-
+	/**
+	 * @return string|false
+	 */
 	public function GenerateAPEtag() {
 		// NOTE: All data passed to this function must be UTF-8 format
 
@@ -159,6 +193,12 @@ class getid3_write_apetag
 		return $this->GenerateAPEtagHeaderFooter($items, true).implode('', $items).$this->GenerateAPEtagHeaderFooter($items, false);
 	}
 
+	/**
+	 * @param array $items
+	 * @param bool  $isheader
+	 *
+	 * @return string
+	 */
 	public function GenerateAPEtagHeaderFooter(&$items, $isheader=false) {
 		$tagdatalength = 0;
 		foreach ($items as $itemdata) {
@@ -175,6 +215,15 @@ class getid3_write_apetag
 		return $APEheader;
 	}
 
+	/**
+	 * @param bool $header
+	 * @param bool $footer
+	 * @param bool $isheader
+	 * @param int  $encodingid
+	 * @param bool $readonly
+	 *
+	 * @return string
+	 */
 	public function GenerateAPEtagFlags($header=true, $footer=true, $isheader=false, $encodingid=0, $readonly=false) {
 		$APEtagFlags = array_fill(0, 4, 0);
 		if ($header) {
@@ -188,8 +237,8 @@ class getid3_write_apetag
 		}
 
 		// 0: Item contains text information coded in UTF-8
-		// 1: Item contains binary information �)
-		// 2: Item is a locator of external stored information 같)
+		// 1: Item contains binary information 째)
+		// 2: Item is a locator of external stored information 째째)
 		// 3: reserved
 		$APEtagFlags[3] |= ($encodingid << 1);
 
@@ -200,6 +249,11 @@ class getid3_write_apetag
 		return chr($APEtagFlags[3]).chr($APEtagFlags[2]).chr($APEtagFlags[1]).chr($APEtagFlags[0]);
 	}
 
+	/**
+	 * @param string $itemkey
+	 *
+	 * @return string
+	 */
 	public function CleanAPEtagItemKey($itemkey) {
 		$itemkey = preg_replace("#[^\x20-\x7E]#i", '', $itemkey);
 

--- a/application/libraries/getid3/write.id3v1.php
+++ b/application/libraries/getid3/write.id3v1.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // write.id3v1.php                                             //
@@ -13,23 +14,51 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.id3v1.php', __FILE__, true);
 
 class getid3_write_id3v1
 {
+	/**
+	 * @var string
+	 */
 	public $filename;
-	public $filesize;
-	public $tag_data;
-	public $warnings = array(); // any non-critical errors will be stored here
-	public $errors   = array(); // any critical errors will be stored here
 
-	public function getid3_write_id3v1() {
-		return true;
+	/**
+	 * @var int
+	 */
+	public $filesize;
+
+	/**
+	 * @var array
+	 */
+	public $tag_data;
+
+	/**
+	 * Any non-critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $warnings = array();
+
+	/**
+	 * Any critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $errors   = array();
+
+	public function __construct() {
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function WriteID3v1() {
 		// File MUST be writeable - CHMOD(646) at least
-		if (!empty($this->filename) && is_readable($this->filename) && is_writable($this->filename) && is_file($this->filename)) {
+		if (!empty($this->filename) && is_readable($this->filename) && getID3::is_writable($this->filename) && is_file($this->filename)) {
 			$this->setRealFileSize();
 			if (($this->filesize <= 0) || !getid3_lib::intValueSupported($this->filesize)) {
 				$this->errors[] = 'Unable to WriteID3v1('.$this->filename.') because filesize ('.$this->filesize.') is larger than '.round(PHP_INT_MAX / 1073741824).'GB';
@@ -42,16 +71,16 @@ class getid3_write_id3v1
 				} else {
 					fseek($fp_source, 0, SEEK_END);    // append new ID3v1 tag
 				}
-				$this->tag_data['track'] = (isset($this->tag_data['track']) ? $this->tag_data['track'] : (isset($this->tag_data['track_number']) ? $this->tag_data['track_number'] : (isset($this->tag_data['tracknumber']) ? $this->tag_data['tracknumber'] : '')));
+				$this->tag_data['track_number'] = (isset($this->tag_data['track_number']) ? $this->tag_data['track_number'] : '');
 
 				$new_id3v1_tag_data = getid3_id3v1::GenerateID3v1Tag(
-														(isset($this->tag_data['title']  ) ? $this->tag_data['title']   : ''),
-														(isset($this->tag_data['artist'] ) ? $this->tag_data['artist']  : ''),
-														(isset($this->tag_data['album']  ) ? $this->tag_data['album']   : ''),
-														(isset($this->tag_data['year']   ) ? $this->tag_data['year']    : ''),
-														(isset($this->tag_data['genreid']) ? $this->tag_data['genreid'] : ''),
-														(isset($this->tag_data['comment']) ? $this->tag_data['comment'] : ''),
-														(isset($this->tag_data['track']  ) ? $this->tag_data['track']   : ''));
+														(isset($this->tag_data['title']       ) ? $this->tag_data['title']        : ''),
+														(isset($this->tag_data['artist']      ) ? $this->tag_data['artist']       : ''),
+														(isset($this->tag_data['album']       ) ? $this->tag_data['album']        : ''),
+														(isset($this->tag_data['year']        ) ? $this->tag_data['year']         : ''),
+														(isset($this->tag_data['genreid']     ) ? $this->tag_data['genreid']      : ''),
+														(isset($this->tag_data['comment']     ) ? $this->tag_data['comment']      : ''),
+														(isset($this->tag_data['track_number']) ? $this->tag_data['track_number'] : ''));
 				fwrite($fp_source, $new_id3v1_tag_data, 128);
 				fclose($fp_source);
 				return true;
@@ -65,6 +94,9 @@ class getid3_write_id3v1
 		return false;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function FixID3v1Padding() {
 		// ID3v1 data is supposed to be padded with NULL characters, but some taggers incorrectly use spaces
 		// This function rewrites the ID3v1 tag with correct padding
@@ -78,6 +110,7 @@ class getid3_write_id3v1
 		$getID3->option_tag_id3v1  = true;
 		$ThisFileInfo = $getID3->analyze($this->filename);
 		if (isset($ThisFileInfo['tags']['id3v1'])) {
+			$id3v1data = array();
 			foreach ($ThisFileInfo['tags']['id3v1'] as $key => $value) {
 				$id3v1data[$key] = implode(',', $value);
 			}
@@ -87,9 +120,12 @@ class getid3_write_id3v1
 		return false;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function RemoveID3v1() {
 		// File MUST be writeable - CHMOD(646) at least
-		if (!empty($this->filename) && is_readable($this->filename) && is_writable($this->filename) && is_file($this->filename)) {
+		if (!empty($this->filename) && is_readable($this->filename) && getID3::is_writable($this->filename) && is_file($this->filename)) {
 			$this->setRealFileSize();
 			if (($this->filesize <= 0) || !getid3_lib::intValueSupported($this->filesize)) {
 				$this->errors[] = 'Unable to RemoveID3v1('.$this->filename.') because filesize ('.$this->filesize.') is larger than '.round(PHP_INT_MAX / 1073741824).'GB';
@@ -115,6 +151,9 @@ class getid3_write_id3v1
 		return false;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function setRealFileSize() {
 		if (PHP_INT_MAX > 2147483647) {
 			$this->filesize = filesize($this->filename);

--- a/application/libraries/getid3/write.id3v2.php
+++ b/application/libraries/getid3/write.id3v2.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 ///                                                            //
 // write.id3v2.php                                             //
@@ -13,37 +14,103 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
 getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.id3v2.php', __FILE__, true);
 
 class getid3_write_id3v2
 {
+	/**
+	 * @var string
+	 */
 	public $filename;
-	public $tag_data;
-	public $fread_buffer_size           = 32768;    // read buffer size in bytes
-	public $paddedlength                = 4096;     // minimum length of ID3v2 tag in bytes
-	public $majorversion                = 3;        // ID3v2 major version (2, 3 (recommended), 4)
-	public $minorversion                = 0;        // ID3v2 minor version - always 0
-	public $merge_existing_data         = false;    // if true, merge new data with existing tags; if false, delete old tag data and only write new tags
-	public $id3v2_default_encodingid    = 0;        // default text encoding (ISO-8859-1) if not explicitly passed
-	public $id3v2_use_unsynchronisation = false;    // the specs say it should be TRUE, but most other ID3v2-aware programs are broken if unsynchronization is used, so by default don't use it.
-	public $warnings                    = array();  // any non-critical errors will be stored here
-	public $errors                      = array();  // any critical errors will be stored here
 
-	public function getid3_write_id3v2() {
-		return true;
+	/**
+	 * @var array|null
+	 */
+	public $tag_data;
+
+	/**
+	 * Read buffer size in bytes.
+	 *
+	 * @var int
+	 */
+	public $fread_buffer_size           = 32768;
+
+	/**
+	 * Minimum length of ID3v2 tag in bytes.
+	 *
+	 * @var int
+	 */
+	public $paddedlength                = 4096;
+
+	/**
+	 * ID3v2 major version (2, 3 (recommended), 4).
+	 *
+	 * @var int
+	 */
+	public $majorversion                = 3;
+
+	/**
+	 * ID3v2 minor version - always 0.
+	 *
+	 * @var int
+	 */
+	public $minorversion                = 0;
+
+	/**
+	 * If true, merge new data with existing tags; if false, delete old tag data and only write new tags.
+	 *
+	 * @var bool
+	 */
+	public $merge_existing_data         = false;
+
+	/**
+	 * Default text encoding (ISO-8859-1) if not explicitly passed.
+	 *
+	 * @var int
+	 */
+	public $id3v2_default_encodingid    = 0;
+
+	/**
+	 * The specs say it should be TRUE, but most other ID3v2-aware programs are broken if unsynchronization is used,
+	 * so by default don't use it.
+	 *
+	 * @var bool
+	 */
+	public $id3v2_use_unsynchronisation = false;
+
+	/**
+	 * Any non-critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $warnings                    = array();
+
+	/**
+	 * Any critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $errors                      = array();
+
+	public function __construct() {
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function WriteID3v2() {
 		// File MUST be writeable - CHMOD(646) at least. It's best if the
 		// directory is also writeable, because that method is both faster and less susceptible to errors.
 
-		if (!empty($this->filename) && (is_writeable($this->filename) || (!file_exists($this->filename) && is_writeable(dirname($this->filename))))) {
+		if (!empty($this->filename) && (getID3::is_writable($this->filename) || (!file_exists($this->filename) && getID3::is_writable(dirname($this->filename))))) {
 			// Initialize getID3 engine
 			$getID3 = new getID3;
 			$OldThisFileInfo = $getID3->analyze($this->filename);
 			if (!getid3_lib::intValueSupported($OldThisFileInfo['filesize'])) {
 				$this->errors[] = 'Unable to write ID3v2 because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB';
-				fclose($fp_source);
 				return false;
 			}
 			if ($this->merge_existing_data) {
@@ -56,12 +123,12 @@ class getid3_write_id3v2
 
 			if ($NewID3v2Tag = $this->GenerateID3v2Tag()) {
 
-				if (file_exists($this->filename) && is_writeable($this->filename) && isset($OldThisFileInfo['id3v2']['headerlength']) && ($OldThisFileInfo['id3v2']['headerlength'] == strlen($NewID3v2Tag))) {
+				if (file_exists($this->filename) && getID3::is_writable($this->filename) && isset($OldThisFileInfo['id3v2']['headerlength']) && ($OldThisFileInfo['id3v2']['headerlength'] == strlen($NewID3v2Tag))) {
 
 					// best and fastest method - insert-overwrite existing tag (padded to length of old tag if neccesary)
 					if (file_exists($this->filename)) {
 
-						if (is_readable($this->filename) && is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'r+b'))) {
+						if (is_readable($this->filename) && getID3::is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'r+b'))) {
 							rewind($fp);
 							fwrite($fp, $NewID3v2Tag, strlen($NewID3v2Tag));
 							fclose($fp);
@@ -71,7 +138,7 @@ class getid3_write_id3v2
 
 					} else {
 
-						if (is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'wb'))) {
+						if (getID3::is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'wb'))) {
 							rewind($fp);
 							fwrite($fp, $NewID3v2Tag, strlen($NewID3v2Tag));
 							fclose($fp);
@@ -85,13 +152,13 @@ class getid3_write_id3v2
 
 					if ($tempfilename = tempnam(GETID3_TEMP_DIR, 'getID3')) {
 						if (is_readable($this->filename) && is_file($this->filename) && ($fp_source = fopen($this->filename, 'rb'))) {
-							if (is_writable($tempfilename) && is_file($tempfilename) && ($fp_temp = fopen($tempfilename, 'wb'))) {
+							if (getID3::is_writable($tempfilename) && is_file($tempfilename) && ($fp_temp = fopen($tempfilename, 'wb'))) {
 
 								fwrite($fp_temp, $NewID3v2Tag, strlen($NewID3v2Tag));
 
 								rewind($fp_source);
 								if (!empty($OldThisFileInfo['avdataoffset'])) {
-									fseek($fp_source, $OldThisFileInfo['avdataoffset'], SEEK_SET);
+									fseek($fp_source, $OldThisFileInfo['avdataoffset']);
 								}
 
 								while ($buffer = fread($fp_source, $this->fread_buffer_size)) {
@@ -133,10 +200,13 @@ class getid3_write_id3v2
 		return false;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function RemoveID3v2() {
 		// File MUST be writeable - CHMOD(646) at least. It's best if the
 		// directory is also writeable, because that method is both faster and less susceptible to errors.
-		if (is_writeable(dirname($this->filename))) {
+		if (getID3::is_writable(dirname($this->filename))) {
 
 			// preferred method - only one copying operation, minimal chance of corrupting
 			// original file if script is interrupted, but required directory to be writeable
@@ -152,9 +222,9 @@ class getid3_write_id3v2
 				}
 				rewind($fp_source);
 				if ($OldThisFileInfo['avdataoffset'] !== false) {
-					fseek($fp_source, $OldThisFileInfo['avdataoffset'], SEEK_SET);
+					fseek($fp_source, $OldThisFileInfo['avdataoffset']);
 				}
-				if (is_writable($this->filename) && is_file($this->filename) && ($fp_temp = fopen($this->filename.'getid3tmp', 'w+b'))) {
+				if (getID3::is_writable($this->filename) && is_file($this->filename) && ($fp_temp = fopen($this->filename.'getid3tmp', 'w+b'))) {
 					while ($buffer = fread($fp_source, $this->fread_buffer_size)) {
 						fwrite($fp_temp, $buffer, strlen($buffer));
 					}
@@ -171,7 +241,7 @@ class getid3_write_id3v2
 			}
 			rename($this->filename.'getid3tmp', $this->filename);
 
-		} elseif (is_writable($this->filename)) {
+		} elseif (getID3::is_writable($this->filename)) {
 
 			// less desirable alternate method - double-copies the file, overwrites original file
 			// and could corrupt source file if the script is interrupted or an error occurs.
@@ -187,14 +257,14 @@ class getid3_write_id3v2
 				}
 				rewind($fp_source);
 				if ($OldThisFileInfo['avdataoffset'] !== false) {
-					fseek($fp_source, $OldThisFileInfo['avdataoffset'], SEEK_SET);
+					fseek($fp_source, $OldThisFileInfo['avdataoffset']);
 				}
 				if ($fp_temp = tmpfile()) {
 					while ($buffer = fread($fp_source, $this->fread_buffer_size)) {
 						fwrite($fp_temp, $buffer, strlen($buffer));
 					}
 					fclose($fp_source);
-					if (is_writable($this->filename) && is_file($this->filename) && ($fp_source = fopen($this->filename, 'wb'))) {
+					if (getID3::is_writable($this->filename) && is_file($this->filename) && ($fp_source = fopen($this->filename, 'wb'))) {
 						rewind($fp_temp);
 						while ($buffer = fread($fp_temp, $this->fread_buffer_size)) {
 							fwrite($fp_source, $buffer, strlen($buffer));
@@ -224,8 +294,13 @@ class getid3_write_id3v2
 		return true;
 	}
 
-
+	/**
+	 * @param array $flags
+	 *
+	 * @return string|false
+	 */
 	public function GenerateID3v2TagFlags($flags) {
+		$flag = null;
 		switch ($this->majorversion) {
 			case 4:
 				// %abcd0000
@@ -253,13 +328,25 @@ class getid3_write_id3v2
 
 			default:
 				return false;
-				break;
 		}
 		return chr(bindec($flag));
 	}
 
-
+	/**
+	 * @param bool $TagAlter
+	 * @param bool $FileAlter
+	 * @param bool $ReadOnly
+	 * @param bool $Compression
+	 * @param bool $Encryption
+	 * @param bool $GroupingIdentity
+	 * @param bool $Unsynchronisation
+	 * @param bool $DataLengthIndicator
+	 *
+	 * @return string|false
+	 */
 	public function GenerateID3v2FrameFlags($TagAlter=false, $FileAlter=false, $ReadOnly=false, $Compression=false, $Encryption=false, $GroupingIdentity=false, $Unsynchronisation=false, $DataLengthIndicator=false) {
+		$flag1 = null;
+		$flag2 = null;
 		switch ($this->majorversion) {
 			case 4:
 				// %0abc0000 %0h00kmnp
@@ -293,12 +380,17 @@ class getid3_write_id3v2
 
 			default:
 				return false;
-				break;
 
 		}
 		return chr(bindec($flag1)).chr(bindec($flag2));
 	}
 
+	/**
+	 * @param string $frame_name
+	 * @param array  $source_data_array
+	 *
+	 * @return string|false
+	 */
 	public function GenerateID3v2FrameData($frame_name, $source_data_array) {
 		if (!getid3_id3v2::IsValidID3v2FrameName($frame_name, $this->majorversion)) {
 			return false;
@@ -330,7 +422,7 @@ class getid3_write_id3v2
 					// Description       <text string according to encoding> $00 (00)
 					// Value             <text string according to encoding>
 					$source_data_array['encodingid'] = (isset($source_data_array['encodingid']) ? $source_data_array['encodingid'] : $this->id3v2_default_encodingid);
-					if (!$this->ID3v2IsValidTextEncoding($source_data_array['encodingid'], $this->majorversion)) {
+					if (!$this->ID3v2IsValidTextEncoding($source_data_array['encodingid'])) {
 						$this->errors[] = 'Invalid Text Encoding in '.$frame_name.' ('.$source_data_array['encodingid'].') for ID3v2.'.$this->majorversion;
 					} else {
 						$framedata .= chr($source_data_array['encodingid']);
@@ -345,9 +437,9 @@ class getid3_write_id3v2
 					// Description       <text string according to encoding> $00 (00)
 					// URL               <text string>
 					$source_data_array['encodingid'] = (isset($source_data_array['encodingid']) ? $source_data_array['encodingid'] : $this->id3v2_default_encodingid);
-					if (!$this->ID3v2IsValidTextEncoding($source_data_array['encodingid'], $this->majorversion)) {
+					if (!$this->ID3v2IsValidTextEncoding($source_data_array['encodingid'])) {
 						$this->errors[] = 'Invalid Text Encoding in '.$frame_name.' ('.$source_data_array['encodingid'].') for ID3v2.'.$this->majorversion;
-					} elseif (!isset($source_data_array['data']) || !$this->IsValidURL($source_data_array['data'], false, false)) {
+					} elseif (!isset($source_data_array['data']) || !$this->IsValidURL($source_data_array['data'], false)) {
 						//$this->errors[] = 'Invalid URL in '.$frame_name.' ('.$source_data_array['data'].')';
 						// probably should be an error, need to rewrite IsValidURL() to handle other encodings
 						$this->warnings[] = 'Invalid URL in '.$frame_name.' ('.$source_data_array['data'].')';
@@ -363,7 +455,7 @@ class getid3_write_id3v2
 					// Text encoding     $xx
 					// People list strings    <textstrings>
 					$source_data_array['encodingid'] = (isset($source_data_array['encodingid']) ? $source_data_array['encodingid'] : $this->id3v2_default_encodingid);
-					if (!$this->ID3v2IsValidTextEncoding($source_data_array['encodingid'], $this->majorversion)) {
+					if (!$this->ID3v2IsValidTextEncoding($source_data_array['encodingid'])) {
 						$this->errors[] = 'Invalid Text Encoding in '.$frame_name.' ('.$source_data_array['encodingid'].') for ID3v2.'.$this->majorversion;
 					} else {
 						$framedata .= chr($source_data_array['encodingid']);
@@ -396,13 +488,14 @@ class getid3_write_id3v2
 							if (!$this->ID3v2IsValidETCOevent($val['typeid'])) {
 								$this->errors[] = 'Invalid Event Type byte in '.$frame_name.' ('.$val['typeid'].')';
 							} elseif (($key != 'timestampformat') && ($key != 'flags')) {
-								if (($val['timestamp'] > 0) && ($previousETCOtimestamp >= $val['timestamp'])) {
+								if (($val['timestamp'] > 0) && isset($previousETCOtimestamp) && ($previousETCOtimestamp >= $val['timestamp'])) {
 									//   The 'Time stamp' is set to zero if directly at the beginning of the sound
 									//   or after the previous event. All events MUST be sorted in chronological order.
 									$this->errors[] = 'Out-of-order timestamp in '.$frame_name.' ('.$val['timestamp'].') for Event Type ('.$val['typeid'].')';
 								} else {
 									$framedata .= chr($val['typeid']);
 									$framedata .= getid3_lib::BigEndian2String($val['timestamp'], 4, false);
+									$previousETCOtimestamp = $val['timestamp'];
 								}
 							}
 						}
@@ -452,6 +545,7 @@ class getid3_write_id3v2
 					} else {
 						$this->errors[] = 'Invalid Bits For Milliseconds Deviation in '.$frame_name.' ('.$source_data_array['bitsformsdeviation'].')';
 					}
+					$unwrittenbitstream = '';
 					foreach ($source_data_array as $key => $val) {
 						if (($key != 'framesbetweenreferences') && ($key != 'bytesbetweenreferences') && ($key != 'msbetweenreferences') && ($key != 'bitsforbytesdeviation') && ($key != 'bitsformsdeviation') && ($key != 'flags')) {
 							$unwrittenbitstream .= str_pad(getid3_lib::Dec2Bin($val['bytedeviation']), $source_data_array['bitsforbytesdeviation'], '0', STR_PAD_LEFT);
@@ -616,7 +710,7 @@ class getid3_write_id3v2
 					if (!$this->IsWithinBitRange($source_data_array['bitsvolume'], 8, false)) {
 						$this->errors[] = 'Invalid Bits For Volume Description byte in '.$frame_name.' ('.$source_data_array['bitsvolume'].') (range = 1 to 255)';
 					} else {
-						$incdecflag .= '00';
+						$incdecflag  = '00';
 						$incdecflag .= $source_data_array['incdec']['right']     ? '1' : '0';     // a - Relative volume change, right
 						$incdecflag .= $source_data_array['incdec']['left']      ? '1' : '0';      // b - Relative volume change, left
 						$incdecflag .= $source_data_array['incdec']['rightrear'] ? '1' : '0'; // c - Relative volume change, right back
@@ -759,9 +853,9 @@ class getid3_write_id3v2
 						$this->errors[] = 'Invalid Text Encoding in '.$frame_name.' ('.$source_data_array['encodingid'].') for ID3v2.'.$this->majorversion;
 					} elseif (!$this->ID3v2IsValidAPICpicturetype($source_data_array['picturetypeid'])) {
 						$this->errors[] = 'Invalid Picture Type byte in '.$frame_name.' ('.$source_data_array['picturetypeid'].') for ID3v2.'.$this->majorversion;
-					} elseif (($this->majorversion >= 3) && (!$this->ID3v2IsValidAPICimageformat($source_data_array['mime']))) {
+					} elseif ((!$this->ID3v2IsValidAPICimageformat($source_data_array['mime']))) {
 						$this->errors[] = 'Invalid MIME Type in '.$frame_name.' ('.$source_data_array['mime'].') for ID3v2.'.$this->majorversion;
-					} elseif (($source_data_array['mime'] == '-->') && (!$this->IsValidURL($source_data_array['data'], false, false))) {
+					} elseif (($source_data_array['mime'] == '-->') && (!$this->IsValidURL($source_data_array['data'], false))) {
 						//$this->errors[] = 'Invalid URL in '.$frame_name.' ('.$source_data_array['data'].')';
 						// probably should be an error, need to rewrite IsValidURL() to handle other encodings
 						$this->warnings[] = 'Invalid URL in '.$frame_name.' ('.$source_data_array['data'].')';
@@ -812,10 +906,14 @@ class getid3_write_id3v2
 					// Email to user   <text string> $00
 					// Rating          $xx
 					// Counter         $xx xx xx xx (xx ...)
+					if (!$this->IsValidEmail($source_data_array['email'])) {
+						// https://github.com/JamesHeinrich/getID3/issues/216
+						// https://en.wikipedia.org/wiki/ID3#ID3v2_rating_tag_issue
+						// ID3v2 specs say it should be an email address, but Windows instead uses string like "Windows Media Player 9 Series"
+						$this->warnings[] = 'Invalid Email in '.$frame_name.' ('.$source_data_array['email'].')';
+					}
 					if (!$this->IsWithinBitRange($source_data_array['rating'], 8, false)) {
 						$this->errors[] = 'Invalid Rating byte in '.$frame_name.' ('.$source_data_array['rating'].') (range = 0 to 255)';
-					} elseif (!IsValidEmail($source_data_array['email'])) {
-						$this->errors[] = 'Invalid Email in '.$frame_name.' ('.$source_data_array['email'].')';
 					} else {
 						$framedata .= str_replace("\x00", '', $source_data_array['email'])."\x00";
 						$framedata .= chr($source_data_array['rating']);
@@ -834,7 +932,7 @@ class getid3_write_id3v2
 						$this->errors[] = 'Invalid Offset To Next Tag in '.$frame_name;
 					} else {
 						$framedata .= getid3_lib::BigEndian2String($source_data_array['buffersize'], 3, false);
-						$flag .= '0000000';
+						$flag  = '0000000';
 						$flag .= $source_data_array['flags']['embededinfo'] ? '1' : '0';
 						$framedata .= chr(bindec($flag));
 						$framedata .= getid3_lib::BigEndian2String($source_data_array['nexttagoffset'], 4, false);
@@ -866,7 +964,7 @@ class getid3_write_id3v2
 					// ID and additional data         <text string(s)>
 					if (!getid3_id3v2::IsValidID3v2FrameName($source_data_array['frameid'], $this->majorversion)) {
 						$this->errors[] = 'Invalid Frame Identifier in '.$frame_name.' ('.$source_data_array['frameid'].')';
-					} elseif (!$this->IsValidURL($source_data_array['data'], true, false)) {
+					} elseif (!$this->IsValidURL($source_data_array['data'], true)) {
 						//$this->errors[] = 'Invalid URL in '.$frame_name.' ('.$source_data_array['data'].')';
 						// probably should be an error, need to rewrite IsValidURL() to handle other encodings
 						$this->warnings[] = 'Invalid URL in '.$frame_name.' ('.$source_data_array['data'].')';
@@ -913,6 +1011,7 @@ class getid3_write_id3v2
 								} else {
 									$this->errors[] = $source_data_array['frameid'].' is not a valid Frame Identifier in '.$frame_name.' (in ID3v2.'.$this->majorversion.')';
 								}
+								break;
 
 							default:
 								if ((substr($source_data_array['frameid'], 0, 1) == 'T') || (substr($source_data_array['frameid'], 0, 1) == 'W')) {
@@ -965,9 +1064,9 @@ class getid3_write_id3v2
 					$source_data_array['encodingid'] = (isset($source_data_array['encodingid']) ? $source_data_array['encodingid'] : $this->id3v2_default_encodingid);
 					if (!$this->ID3v2IsValidTextEncoding($source_data_array['encodingid'])) {
 						$this->errors[] = 'Invalid Text Encoding in '.$frame_name.' ('.$source_data_array['encodingid'].')';
-					} elseif (!$this->IsANumber($source_data_array['pricepaid']['value'], false)) {
+					} elseif (!getid3_id3v2::IsANumber($source_data_array['pricepaid']['value'], false)) {
 						$this->errors[] = 'Invalid Price Paid in '.$frame_name.' ('.$source_data_array['pricepaid']['value'].')';
-					} elseif (!$this->IsValidDateStampString($source_data_array['purchasedate'])) {
+					} elseif (!getid3_id3v2::IsValidDateStampString($source_data_array['purchasedate'])) {
 						$this->errors[] = 'Invalid Date Of Purchase in '.$frame_name.' ('.$source_data_array['purchasedate'].') (format = YYYYMMDD)';
 					} else {
 						$framedata .= chr($source_data_array['encodingid']);
@@ -991,9 +1090,9 @@ class getid3_write_id3v2
 					$source_data_array['encodingid'] = (isset($source_data_array['encodingid']) ? $source_data_array['encodingid'] : $this->id3v2_default_encodingid);
 					if (!$this->ID3v2IsValidTextEncoding($source_data_array['encodingid'])) {
 						$this->errors[] = 'Invalid Text Encoding in '.$frame_name.' ('.$source_data_array['encodingid'].')';
-					} elseif (!$this->IsValidDateStampString($source_data_array['pricevaliduntil'])) {
+					} elseif (!getid3_id3v2::IsValidDateStampString($source_data_array['pricevaliduntil'])) {
 						$this->errors[] = 'Invalid Valid Until date in '.$frame_name.' ('.$source_data_array['pricevaliduntil'].') (format = YYYYMMDD)';
-					} elseif (!$this->IsValidURL($source_data_array['contacturl'], false, true)) {
+					} elseif (!$this->IsValidURL($source_data_array['contacturl'], false)) {
 						$this->errors[] = 'Invalid Contact URL in '.$frame_name.' ('.$source_data_array['contacturl'].') (allowed schemes: http, https, ftp, mailto)';
 					} elseif (!$this->ID3v2IsValidCOMRreceivedAs($source_data_array['receivedasid'])) {
 						$this->errors[] = 'Invalid Received As byte in '.$frame_name.' ('.$source_data_array['contacturl'].') (range = 0 to 8)';
@@ -1001,7 +1100,7 @@ class getid3_write_id3v2
 						$this->errors[] = 'Invalid MIME Type in '.$frame_name.' ('.$source_data_array['mime'].')';
 					} else {
 						$framedata .= chr($source_data_array['encodingid']);
-						unset($pricestring);
+						$pricestrings = array();
 						foreach ($source_data_array['price'] as $key => $val) {
 							if ($this->ID3v2IsValidPriceString($key.$val['value'])) {
 								$pricestrings[] = $key.$val['value'];
@@ -1138,9 +1237,9 @@ class getid3_write_id3v2
 					break;
 
 				default:
-					if ((($this->majorversion == 2) && (strlen($frame_name) != 3)) || (($this->majorversion > 2) && (strlen($frame_name) != 4))) {
+					if (/*(($this->majorversion == 2) && (strlen($frame_name) != 3)) || (($this->majorversion > 2) && (*/strlen($frame_name) != 4/*))*/) {
 						$this->errors[] = 'Invalid frame name "'.$frame_name.'" for ID3v2.'.$this->majorversion;
-					} elseif ($frame_name{0} == 'T') {
+					} elseif ($frame_name[0] == 'T') {
 						// 4.2. T???  Text information frames
 						// Text encoding                $xx
 						// Information                  <text string(s) according to encoding>
@@ -1151,10 +1250,10 @@ class getid3_write_id3v2
 							$framedata .= chr($source_data_array['encodingid']);
 							$framedata .= $source_data_array['data'];
 						}
-					} elseif ($frame_name{0} == 'W') {
+					} elseif ($frame_name[0] == 'W') {
 						// 4.3. W???  URL link frames
 						// URL              <text string>
-						if (!$this->IsValidURL($source_data_array['data'], false, false)) {
+						if (!$this->IsValidURL($source_data_array['data'], false)) {
 							//$this->errors[] = 'Invalid URL in '.$frame_name.' ('.$source_data_array['data'].')';
 							// probably should be an error, need to rewrite IsValidURL() to handle other encodings
 							$this->warnings[] = 'Invalid URL in '.$frame_name.' ('.$source_data_array['data'].')';
@@ -1173,6 +1272,12 @@ class getid3_write_id3v2
 		return $framedata;
 	}
 
+	/**
+	 * @param string|null $frame_name
+	 * @param array       $source_data_array
+	 *
+	 * @return bool
+	 */
 	public function ID3v2FrameIsAllowed($frame_name, $source_data_array) {
 		static $PreviousFrames = array();
 
@@ -1182,7 +1287,6 @@ class getid3_write_id3v2
 			$PreviousFrames = array();
 			return true;
 		}
-
 		if ($this->majorversion == 4) {
 			switch ($frame_name) {
 				case 'UFID':
@@ -1302,7 +1406,7 @@ class getid3_write_id3v2
 					break;
 
 				default:
-					if (($frame_name{0} != 'T') && ($frame_name{0} != 'W')) {
+					if (($frame_name[0] != 'T') && ($frame_name[0] != 'W')) {
 						$this->errors[] = 'Frame not allowed in ID3v2.'.$this->majorversion.': '.$frame_name;
 					}
 					break;
@@ -1425,7 +1529,7 @@ class getid3_write_id3v2
 					break;
 
 				default:
-					if (($frame_name{0} != 'T') && ($frame_name{0} != 'W')) {
+					if (($frame_name[0] != 'T') && ($frame_name[0] != 'W')) {
 						$this->errors[] = 'Frame not allowed in ID3v2.'.$this->majorversion.': '.$frame_name;
 					}
 					break;
@@ -1517,7 +1621,7 @@ class getid3_write_id3v2
 					break;
 
 				default:
-					if (($frame_name{0} != 'T') && ($frame_name{0} != 'W')) {
+					if (($frame_name[0] != 'T') && ($frame_name[0] != 'W')) {
 						$this->errors[] = 'Frame not allowed in ID3v2.'.$this->majorversion.': '.$frame_name;
 					}
 					break;
@@ -1530,6 +1634,11 @@ class getid3_write_id3v2
 		return true;
 	}
 
+	/**
+	 * @param bool $noerrorsonly
+	 *
+	 * @return string|false
+	 */
 	public function GenerateID3v2Tag($noerrorsonly=true) {
 		$this->ID3v2FrameIsAllowed(null, ''); // clear static array in case this isn't the first call to $this->GenerateID3v2Tag()
 
@@ -1542,6 +1651,9 @@ class getid3_write_id3v2
 						unset($frame_flags);
 						$frame_data = false;
 						if ($this->ID3v2FrameIsAllowed($frame_name, $source_data_array)) {
+							if(array_key_exists('description', $source_data_array) && array_key_exists('encodingid', $source_data_array) && array_key_exists('encoding', $this->tag_data)) {
+								$source_data_array['description'] = getid3_lib::iconv_fallback($this->tag_data['encoding'], $source_data_array['encoding'], $source_data_array['description']);
+							}
 							if ($frame_data = $this->GenerateID3v2FrameData($frame_name, $source_data_array)) {
 								$FrameUnsynchronisation = false;
 								if ($this->majorversion >= 4) {
@@ -1580,18 +1692,18 @@ class getid3_write_id3v2
 							if ($noerrorsonly) {
 								return false;
 							} else {
-								unset($frame_name);
+								$frame_name = null;
 							}
 						}
 					} else {
 						// ignore any invalid frame names, including 'title', 'header', etc
 						$this->warnings[] = 'Ignoring invalid ID3v2 frame type: "'.$frame_name.'"';
-						unset($frame_name);
+						$frame_name = null;
 						unset($frame_length);
 						unset($frame_flags);
 						unset($frame_data);
 					}
-					if (isset($frame_name) && isset($frame_length) && isset($frame_flags) && isset($frame_data)) {
+					if (null !== $frame_name && isset($frame_length) && isset($frame_flags) && isset($frame_data)) {
 						$tagstring .= $frame_name.$frame_length.$frame_flags.$frame_data;
 					}
 				}
@@ -1615,7 +1727,7 @@ class getid3_write_id3v2
 			}
 
 			$footer = false; // ID3v2 footers not yet supported in getID3()
-			if (!$footer && ($this->paddedlength > (strlen($tagstring) + getid3_id3v2::ID3v2HeaderLength($this->majorversion)))) {
+			if (/*!$footer && */($this->paddedlength > (strlen($tagstring) + getid3_id3v2::ID3v2HeaderLength($this->majorversion)))) {
 				// pad up to $paddedlength bytes if unpadded tag is shorter than $paddedlength
 				// "Furthermore it MUST NOT have any padding when a tag footer is added to the tag."
 				if (($this->paddedlength - strlen($tagstring) - getid3_id3v2::ID3v2HeaderLength($this->majorversion)) > 0) {
@@ -1641,20 +1753,31 @@ class getid3_write_id3v2
 		return false;
 	}
 
+	/**
+	 * @param string $pricestring
+	 *
+	 * @return bool
+	 */
 	public function ID3v2IsValidPriceString($pricestring) {
 		if (getid3_id3v2::LanguageLookup(substr($pricestring, 0, 3), true) == '') {
 			return false;
-		} elseif (!$this->IsANumber(substr($pricestring, 3), true)) {
+		} elseif (!getid3_id3v2::IsANumber(substr($pricestring, 3), true)) {
 			return false;
 		}
 		return true;
 	}
 
+	/**
+	 * @param string $framename
+	 *
+	 * @return bool
+	 */
 	public function ID3v2FrameFlagsLookupTagAlter($framename) {
 		// unfinished
 		switch ($framename) {
 			case 'RGAD':
 				$allow = true;
+				break;
 			default:
 				$allow = false;
 				break;
@@ -1662,19 +1785,27 @@ class getid3_write_id3v2
 		return $allow;
 	}
 
+	/**
+	 * @param string $framename
+	 *
+	 * @return bool
+	 */
 	public function ID3v2FrameFlagsLookupFileAlter($framename) {
 		// unfinished
 		switch ($framename) {
 			case 'RGAD':
 				return false;
-				break;
 
 			default:
 				return false;
-				break;
 		}
 	}
 
+	/**
+	 * @param int $eventid
+	 *
+	 * @return bool
+	 */
 	public function ID3v2IsValidETCOevent($eventid) {
 		if (($eventid < 0) || ($eventid > 0xFF)) {
 			// outside range of 1 byte
@@ -1695,6 +1826,11 @@ class getid3_write_id3v2
 		return true;
 	}
 
+	/**
+	 * @param int $contenttype
+	 *
+	 * @return bool
+	 */
 	public function ID3v2IsValidSYLTtype($contenttype) {
 		if (($contenttype >= 0) && ($contenttype <= 8) && ($this->majorversion == 4)) {
 			return true;
@@ -1704,6 +1840,11 @@ class getid3_write_id3v2
 		return false;
 	}
 
+	/**
+	 * @param int $channeltype
+	 *
+	 * @return bool
+	 */
 	public function ID3v2IsValidRVA2channeltype($channeltype) {
 		if (($channeltype >= 0) && ($channeltype <= 8) && ($this->majorversion == 4)) {
 			return true;
@@ -1711,6 +1852,11 @@ class getid3_write_id3v2
 		return false;
 	}
 
+	/**
+	 * @param int $picturetype
+	 *
+	 * @return bool
+	 */
 	public function ID3v2IsValidAPICpicturetype($picturetype) {
 		if (($picturetype >= 0) && ($picturetype <= 0x14) && ($this->majorversion >= 2) && ($this->majorversion <= 4)) {
 			return true;
@@ -1718,6 +1864,11 @@ class getid3_write_id3v2
 		return false;
 	}
 
+	/**
+	 * @param int|string $imageformat
+	 *
+	 * @return bool
+	 */
 	public function ID3v2IsValidAPICimageformat($imageformat) {
 		if ($imageformat == '-->') {
 			return true;
@@ -1733,6 +1884,11 @@ class getid3_write_id3v2
 		return false;
 	}
 
+	/**
+	 * @param int $receivedas
+	 *
+	 * @return bool
+	 */
 	public function ID3v2IsValidCOMRreceivedAs($receivedas) {
 		if (($this->majorversion >= 3) && ($receivedas >= 0) && ($receivedas <= 8)) {
 			return true;
@@ -1740,29 +1896,54 @@ class getid3_write_id3v2
 		return false;
 	}
 
-	public function ID3v2IsValidRGADname($RGADname) {
+	/**
+	 * @param int $RGADname
+	 *
+	 * @return bool
+	 */
+	public static function ID3v2IsValidRGADname($RGADname) {
 		if (($RGADname >= 0) && ($RGADname <= 2)) {
 			return true;
 		}
 		return false;
 	}
 
-	public function ID3v2IsValidRGADoriginator($RGADoriginator) {
+	/**
+	 * @param int $RGADoriginator
+	 *
+	 * @return bool
+	 */
+	public static function ID3v2IsValidRGADoriginator($RGADoriginator) {
 		if (($RGADoriginator >= 0) && ($RGADoriginator <= 3)) {
 			return true;
 		}
 		return false;
 	}
 
+	/**
+	 * @param int $textencodingbyte
+	 *
+	 * @return bool
+	 */
 	public function ID3v2IsValidTextEncoding($textencodingbyte) {
+		// 0 = ISO-8859-1
+		// 1 = UTF-16 with BOM
+		// 2 = UTF-16BE without BOM
+		// 3 = UTF-8
 		static $ID3v2IsValidTextEncoding_cache = array(
-			2 => array(true, true),
-			3 => array(true, true),
-			4 => array(true, true, true, true));
+			2 => array(true, true),              // ID3v2.2 - allow 0=ISO-8859-1, 1=UTF-16
+			3 => array(true, true),              // ID3v2.3 - allow 0=ISO-8859-1, 1=UTF-16
+			4 => array(true, true, true, true),  // ID3v2.4 - allow 0=ISO-8859-1, 1=UTF-16, 2=UTF-16BE, 3=UTF-8
+		);
 		return isset($ID3v2IsValidTextEncoding_cache[$this->majorversion][$textencodingbyte]);
 	}
 
-	public function Unsynchronise($data) {
+	/**
+	 * @param string $data
+	 *
+	 * @return string
+	 */
+	public static function Unsynchronise($data) {
 		// Whenever a false synchronisation is found within the tag, one zeroed
 		// byte is inserted after the first false synchronisation byte. The
 		// format of a correct sync that should be altered by ID3 encoders is as
@@ -1779,10 +1960,10 @@ class getid3_write_id3v2
 		$unsyncheddata = '';
 		$datalength = strlen($data);
 		for ($i = 0; $i < $datalength; $i++) {
-			$thischar = $data{$i};
+			$thischar = $data[$i];
 			$unsyncheddata .= $thischar;
 			if ($thischar == "\xFF") {
-				$nextchar = ord($data{$i + 1});
+				$nextchar = ord($data[$i + 1]);
 				if (($nextchar & 0xE0) == 0xE0) {
 					// previous byte = 11111111, this byte = 111?????
 					$unsyncheddata .= "\x00";
@@ -1792,8 +1973,13 @@ class getid3_write_id3v2
 		return $unsyncheddata;
 	}
 
+	/**
+	 * @param mixed $var
+	 *
+	 * @return bool
+	 */
 	public function is_hash($var) {
-		// written by dev-nullØchristophe*vg
+		// written by dev-nullÃ˜christophe*vg
 		// taken from http://www.php.net/manual/en/function.array-merge-recursive.php
 		if (is_array($var)) {
 			$keys = array_keys($var);
@@ -1807,8 +1993,14 @@ class getid3_write_id3v2
 		return false;
 	}
 
+	/**
+	 * @param mixed $arr1
+	 * @param mixed $arr2
+	 *
+	 * @return array
+	 */
 	public function array_join_merge($arr1, $arr2) {
-		// written by dev-nullØchristophe*vg
+		// written by dev-nullÃ˜christophe*vg
 		// taken from http://www.php.net/manual/en/function.array-merge-recursive.php
 		if (is_array($arr1) && is_array($arr2)) {
 			// the same -> merge
@@ -1831,14 +2023,23 @@ class getid3_write_id3v2
 		}
 	}
 
-	public function IsValidMIMEstring($mimestring) {
-		if ((strlen($mimestring) >= 3) && (strpos($mimestring, '/') > 0) && (strpos($mimestring, '/') < (strlen($mimestring) - 1))) {
-			return true;
-		}
-		return false;
+	/**
+	 * @param string $mimestring
+	 *
+	 * @return false|int
+	 */
+	public static function IsValidMIMEstring($mimestring) {
+		return preg_match('#^.+/.+$#', $mimestring);
 	}
 
-	public function IsWithinBitRange($number, $maxbits, $signed=false) {
+	/**
+	 * @param int  $number
+	 * @param int  $maxbits
+	 * @param bool $signed
+	 *
+	 * @return bool
+	 */
+	public static function IsWithinBitRange($number, $maxbits, $signed=false) {
 		if ($signed) {
 			if (($number > (0 - pow(2, $maxbits - 1))) && ($number <= pow(2, $maxbits - 1))) {
 				return true;
@@ -1851,18 +2052,26 @@ class getid3_write_id3v2
 		return false;
 	}
 
-	public function safe_parse_url($url) {
-		$parts = @parse_url($url);
-		$parts['scheme'] = (isset($parts['scheme']) ? $parts['scheme'] : '');
-		$parts['host']   = (isset($parts['host'])   ? $parts['host']   : '');
-		$parts['user']   = (isset($parts['user'])   ? $parts['user']   : '');
-		$parts['pass']   = (isset($parts['pass'])   ? $parts['pass']   : '');
-		$parts['path']   = (isset($parts['path'])   ? $parts['path']   : '');
-		$parts['query']  = (isset($parts['query'])  ? $parts['query']  : '');
-		return $parts;
+	/**
+	 * @param string $email
+	 *
+	 * @return false|int|mixed
+	 */
+	public static function IsValidEmail($email) {
+		if (function_exists('filter_var')) {
+			return filter_var($email, FILTER_VALIDATE_EMAIL);
+		}
+		// VERY crude email validation
+		return preg_match('#^[^ ]+@[a-z\\-\\.]+\\.[a-z]{2,}$#', $email);
 	}
 
-	public function IsValidURL($url, $allowUserPass=false) {
+	/**
+	 * @param string $url
+	 * @param bool   $allowUserPass
+	 *
+	 * @return bool
+	 */
+	public static function IsValidURL($url, $allowUserPass=false) {
 		if ($url == '') {
 			return false;
 		}
@@ -1873,6 +2082,10 @@ class getid3_write_id3v2
 				return false;
 			}
 		}
+		// 2016-06-08: relax URL checking to avoid falsely rejecting valid URLs, leave URL validation to the user
+		// https://www.getid3.org/phpBB3/viewtopic.php?t=1926
+		return true;
+		/*
 		if ($parts = $this->safe_parse_url($url)) {
 			if (($parts['scheme'] != 'http') && ($parts['scheme'] != 'https') && ($parts['scheme'] != 'ftp') && ($parts['scheme'] != 'gopher')) {
 				return false;
@@ -1891,155 +2104,221 @@ class getid3_write_id3v2
 			}
 		}
 		return false;
+		*/
 	}
 
+	/**
+	 * @param string $url
+	 *
+	 * @return array
+	 */
+	public static function safe_parse_url($url) {
+		$parts = @parse_url($url);
+		$parts['scheme'] = (isset($parts['scheme']) ? $parts['scheme'] : '');
+		$parts['host']   = (isset($parts['host'])   ? $parts['host']   : '');
+		$parts['user']   = (isset($parts['user'])   ? $parts['user']   : '');
+		$parts['pass']   = (isset($parts['pass'])   ? $parts['pass']   : '');
+		$parts['path']   = (isset($parts['path'])   ? $parts['path']   : '');
+		$parts['query']  = (isset($parts['query'])  ? $parts['query']  : '');
+		return $parts;
+	}
+
+	/**
+	 * @param int    $majorversion
+	 * @param string $long_description
+	 *
+	 * @return string
+	 */
 	public static function ID3v2ShortFrameNameLookup($majorversion, $long_description) {
 		$long_description = str_replace(' ', '_', strtolower(trim($long_description)));
 		static $ID3v2ShortFrameNameLookup = array();
 		if (empty($ID3v2ShortFrameNameLookup)) {
 
 			// The following are unique to ID3v2.2
-			$ID3v2ShortFrameNameLookup[2]['comment']                                          = 'COM';
-			$ID3v2ShortFrameNameLookup[2]['album']                                            = 'TAL';
-			$ID3v2ShortFrameNameLookup[2]['beats_per_minute']                                 = 'TBP';
-			$ID3v2ShortFrameNameLookup[2]['composer']                                         = 'TCM';
-			$ID3v2ShortFrameNameLookup[2]['genre']                                            = 'TCO';
-			$ID3v2ShortFrameNameLookup[2]['itunescompilation']                                = 'TCP';
-			$ID3v2ShortFrameNameLookup[2]['copyright']                                        = 'TCR';
-			$ID3v2ShortFrameNameLookup[2]['encoded_by']                                       = 'TEN';
-			$ID3v2ShortFrameNameLookup[2]['language']                                         = 'TLA';
-			$ID3v2ShortFrameNameLookup[2]['length']                                           = 'TLE';
-			$ID3v2ShortFrameNameLookup[2]['original_artist']                                  = 'TOA';
-			$ID3v2ShortFrameNameLookup[2]['original_filename']                                = 'TOF';
-			$ID3v2ShortFrameNameLookup[2]['original_lyricist']                                = 'TOL';
-			$ID3v2ShortFrameNameLookup[2]['original_album_title']                             = 'TOT';
-			$ID3v2ShortFrameNameLookup[2]['artist']                                           = 'TP1';
-			$ID3v2ShortFrameNameLookup[2]['band']                                             = 'TP2';
-			$ID3v2ShortFrameNameLookup[2]['conductor']                                        = 'TP3';
-			$ID3v2ShortFrameNameLookup[2]['remixer']                                          = 'TP4';
-			$ID3v2ShortFrameNameLookup[2]['publisher']                                        = 'TPB';
-			$ID3v2ShortFrameNameLookup[2]['isrc']                                             = 'TRC';
-			$ID3v2ShortFrameNameLookup[2]['tracknumber']                                      = 'TRK';
-			$ID3v2ShortFrameNameLookup[2]['size']                                             = 'TSI';
-			$ID3v2ShortFrameNameLookup[2]['encoder_settings']                                 = 'TSS';
-			$ID3v2ShortFrameNameLookup[2]['description']                                      = 'TT1';
-			$ID3v2ShortFrameNameLookup[2]['title']                                            = 'TT2';
-			$ID3v2ShortFrameNameLookup[2]['subtitle']                                         = 'TT3';
-			$ID3v2ShortFrameNameLookup[2]['lyricist']                                         = 'TXT';
-			$ID3v2ShortFrameNameLookup[2]['user_text']                                        = 'TXX';
-			$ID3v2ShortFrameNameLookup[2]['year']                                             = 'TYE';
-			$ID3v2ShortFrameNameLookup[2]['unique_file_identifier']                           = 'UFI';
-			$ID3v2ShortFrameNameLookup[2]['unsynchronised_lyrics']                            = 'ULT';
-			$ID3v2ShortFrameNameLookup[2]['url_file']                                         = 'WAF';
-			$ID3v2ShortFrameNameLookup[2]['url_artist']                                       = 'WAR';
-			$ID3v2ShortFrameNameLookup[2]['url_source']                                       = 'WAS';
-			$ID3v2ShortFrameNameLookup[2]['copyright_information']                            = 'WCP';
-			$ID3v2ShortFrameNameLookup[2]['url_publisher']                                    = 'WPB';
-			$ID3v2ShortFrameNameLookup[2]['url_user']                                         = 'WXX';
+			$ID3v2ShortFrameNameLookup[2]['recommended_buffer_size']           = 'BUF';
+			$ID3v2ShortFrameNameLookup[2]['comment']                           = 'COM';
+			$ID3v2ShortFrameNameLookup[2]['audio_encryption']                  = 'CRA';
+			$ID3v2ShortFrameNameLookup[2]['encrypted_meta_frame']              = 'CRM';
+			$ID3v2ShortFrameNameLookup[2]['equalisation']                      = 'EQU';
+			$ID3v2ShortFrameNameLookup[2]['event_timing_codes']                = 'ETC';
+			$ID3v2ShortFrameNameLookup[2]['general_encapsulated_object']       = 'GEO';
+			$ID3v2ShortFrameNameLookup[2]['involved_people_list']              = 'IPL';
+			$ID3v2ShortFrameNameLookup[2]['linked_information']                = 'LNK';
+			$ID3v2ShortFrameNameLookup[2]['music_cd_identifier']               = 'MCI';
+			$ID3v2ShortFrameNameLookup[2]['mpeg_location_lookup_table']        = 'MLL';
+			$ID3v2ShortFrameNameLookup[2]['attached_picture']                  = 'PIC';
+			$ID3v2ShortFrameNameLookup[2]['popularimeter']                     = 'POP';
+			$ID3v2ShortFrameNameLookup[2]['reverb']                            = 'REV';
+			$ID3v2ShortFrameNameLookup[2]['relative_volume_adjustment']        = 'RVA';
+			$ID3v2ShortFrameNameLookup[2]['synchronised_lyric']                = 'SLT';
+			$ID3v2ShortFrameNameLookup[2]['synchronised_tempo_codes']          = 'STC';
+			$ID3v2ShortFrameNameLookup[2]['album']                             = 'TAL';
+			$ID3v2ShortFrameNameLookup[2]['beats_per_minute']                  = 'TBP';
+			$ID3v2ShortFrameNameLookup[2]['bpm']                               = 'TBP';
+			$ID3v2ShortFrameNameLookup[2]['composer']                          = 'TCM';
+			$ID3v2ShortFrameNameLookup[2]['genre']                             = 'TCO';
+			$ID3v2ShortFrameNameLookup[2]['part_of_a_compilation']             = 'TCP';
+			$ID3v2ShortFrameNameLookup[2]['copyright_message']                 = 'TCR';
+			$ID3v2ShortFrameNameLookup[2]['date']                              = 'TDA';
+			$ID3v2ShortFrameNameLookup[2]['playlist_delay']                    = 'TDY';
+			$ID3v2ShortFrameNameLookup[2]['encoded_by']                        = 'TEN';
+			$ID3v2ShortFrameNameLookup[2]['file_type']                         = 'TFT';
+			$ID3v2ShortFrameNameLookup[2]['time']                              = 'TIM';
+			$ID3v2ShortFrameNameLookup[2]['initial_key']                       = 'TKE';
+			$ID3v2ShortFrameNameLookup[2]['language']                          = 'TLA';
+			$ID3v2ShortFrameNameLookup[2]['length']                            = 'TLE';
+			$ID3v2ShortFrameNameLookup[2]['media_type']                        = 'TMT';
+			$ID3v2ShortFrameNameLookup[2]['original_artist']                   = 'TOA';
+			$ID3v2ShortFrameNameLookup[2]['original_filename']                 = 'TOF';
+			$ID3v2ShortFrameNameLookup[2]['original_lyricist']                 = 'TOL';
+			$ID3v2ShortFrameNameLookup[2]['original_year']                     = 'TOR';
+			$ID3v2ShortFrameNameLookup[2]['original_album']                    = 'TOT';
+			$ID3v2ShortFrameNameLookup[2]['artist']                            = 'TP1';
+			$ID3v2ShortFrameNameLookup[2]['band']                              = 'TP2';
+			$ID3v2ShortFrameNameLookup[2]['conductor']                         = 'TP3';
+			$ID3v2ShortFrameNameLookup[2]['remixer']                           = 'TP4';
+			$ID3v2ShortFrameNameLookup[2]['part_of_a_set']                     = 'TPA';
+			$ID3v2ShortFrameNameLookup[2]['publisher']                         = 'TPB';
+			$ID3v2ShortFrameNameLookup[2]['isrc']                              = 'TRC';
+			$ID3v2ShortFrameNameLookup[2]['recording_dates']                   = 'TRD';
+			$ID3v2ShortFrameNameLookup[2]['tracknumber']                       = 'TRK';
+			$ID3v2ShortFrameNameLookup[2]['track_number']                      = 'TRK';
+			$ID3v2ShortFrameNameLookup[2]['album_artist_sort_order']           = 'TS2';
+			$ID3v2ShortFrameNameLookup[2]['album_sort_order']                  = 'TSA';
+			$ID3v2ShortFrameNameLookup[2]['composer_sort_order']               = 'TSC';
+			$ID3v2ShortFrameNameLookup[2]['size']                              = 'TSI';
+			$ID3v2ShortFrameNameLookup[2]['performer_sort_order']              = 'TSP';
+			$ID3v2ShortFrameNameLookup[2]['encoder_settings']                  = 'TSS';
+			$ID3v2ShortFrameNameLookup[2]['title_sort_order']                  = 'TST';
+			$ID3v2ShortFrameNameLookup[2]['content_group_description']         = 'TT1';
+			$ID3v2ShortFrameNameLookup[2]['title']                             = 'TT2';
+			$ID3v2ShortFrameNameLookup[2]['subtitle']                          = 'TT3';
+			$ID3v2ShortFrameNameLookup[2]['lyricist']                          = 'TXT';
+			$ID3v2ShortFrameNameLookup[2]['text']                              = 'TXX';
+			$ID3v2ShortFrameNameLookup[2]['year']                              = 'TYE';
+			$ID3v2ShortFrameNameLookup[2]['unique_file_identifier']            = 'UFI';
+			$ID3v2ShortFrameNameLookup[2]['unsynchronised_lyric']              = 'ULT';
+			$ID3v2ShortFrameNameLookup[2]['url_file']                          = 'WAF';
+			$ID3v2ShortFrameNameLookup[2]['url_artist']                        = 'WAR';
+			$ID3v2ShortFrameNameLookup[2]['url_source']                        = 'WAS';
+			$ID3v2ShortFrameNameLookup[2]['commercial_information']            = 'WCM';
+			$ID3v2ShortFrameNameLookup[2]['copyright']                         = 'WCP';
+			$ID3v2ShortFrameNameLookup[2]['url_publisher']                     = 'WPB';
+			$ID3v2ShortFrameNameLookup[2]['url_user']                          = 'WXX';
 
 			// The following are common to ID3v2.3 and ID3v2.4
-			$ID3v2ShortFrameNameLookup[3]['audio_encryption']                                 = 'AENC';
-			$ID3v2ShortFrameNameLookup[3]['attached_picture']                                 = 'APIC';
-			$ID3v2ShortFrameNameLookup[3]['comment']                                          = 'COMM';
-			$ID3v2ShortFrameNameLookup[3]['commercial']                                       = 'COMR';
-			$ID3v2ShortFrameNameLookup[3]['encryption_method_registration']                   = 'ENCR';
-			$ID3v2ShortFrameNameLookup[3]['event_timing_codes']                               = 'ETCO';
-			$ID3v2ShortFrameNameLookup[3]['general_encapsulated_object']                      = 'GEOB';
-			$ID3v2ShortFrameNameLookup[3]['group_identification_registration']                = 'GRID';
-			$ID3v2ShortFrameNameLookup[3]['linked_information']                               = 'LINK';
-			$ID3v2ShortFrameNameLookup[3]['music_cd_identifier']                              = 'MCDI';
-			$ID3v2ShortFrameNameLookup[3]['mpeg_location_lookup_table']                       = 'MLLT';
-			$ID3v2ShortFrameNameLookup[3]['ownership']                                        = 'OWNE';
-			$ID3v2ShortFrameNameLookup[3]['play_counter']                                     = 'PCNT';
-			$ID3v2ShortFrameNameLookup[3]['popularimeter']                                    = 'POPM';
-			$ID3v2ShortFrameNameLookup[3]['position_synchronisation']                         = 'POSS';
-			$ID3v2ShortFrameNameLookup[3]['private']                                          = 'PRIV';
-			$ID3v2ShortFrameNameLookup[3]['recommended_buffer_size']                          = 'RBUF';
-			$ID3v2ShortFrameNameLookup[3]['reverb']                                           = 'RVRB';
-			$ID3v2ShortFrameNameLookup[3]['synchronised_lyrics']                              = 'SYLT';
-			$ID3v2ShortFrameNameLookup[3]['synchronised_tempo_codes']                         = 'SYTC';
-			$ID3v2ShortFrameNameLookup[3]['album']                                            = 'TALB';
-			$ID3v2ShortFrameNameLookup[3]['beats_per_minute']                                 = 'TBPM';
-			$ID3v2ShortFrameNameLookup[3]['itunescompilation']                                = 'TCMP';
-			$ID3v2ShortFrameNameLookup[3]['composer']                                         = 'TCOM';
-			$ID3v2ShortFrameNameLookup[3]['genre']                                            = 'TCON';
-			$ID3v2ShortFrameNameLookup[3]['copyright']                                        = 'TCOP';
-			$ID3v2ShortFrameNameLookup[3]['playlist_delay']                                   = 'TDLY';
-			$ID3v2ShortFrameNameLookup[3]['encoded_by']                                       = 'TENC';
-			$ID3v2ShortFrameNameLookup[3]['lyricist']                                         = 'TEXT';
-			$ID3v2ShortFrameNameLookup[3]['file_type']                                        = 'TFLT';
-			$ID3v2ShortFrameNameLookup[3]['content_group_description']                        = 'TIT1';
-			$ID3v2ShortFrameNameLookup[3]['title']                                            = 'TIT2';
-			$ID3v2ShortFrameNameLookup[3]['subtitle']                                         = 'TIT3';
-			$ID3v2ShortFrameNameLookup[3]['initial_key']                                      = 'TKEY';
-			$ID3v2ShortFrameNameLookup[3]['language']                                         = 'TLAN';
-			$ID3v2ShortFrameNameLookup[3]['length']                                           = 'TLEN';
-			$ID3v2ShortFrameNameLookup[3]['media_type']                                       = 'TMED';
-			$ID3v2ShortFrameNameLookup[3]['original_album_title']                             = 'TOAL';
-			$ID3v2ShortFrameNameLookup[3]['original_filename']                                = 'TOFN';
-			$ID3v2ShortFrameNameLookup[3]['original_lyricist']                                = 'TOLY';
-			$ID3v2ShortFrameNameLookup[3]['original_artist']                                  = 'TOPE';
-			$ID3v2ShortFrameNameLookup[3]['file_owner']                                       = 'TOWN';
-			$ID3v2ShortFrameNameLookup[3]['artist']                                           = 'TPE1';
-			$ID3v2ShortFrameNameLookup[3]['band']                                             = 'TPE2';
-			$ID3v2ShortFrameNameLookup[3]['conductor']                                        = 'TPE3';
-			$ID3v2ShortFrameNameLookup[3]['remixer']                                          = 'TPE4';
-			$ID3v2ShortFrameNameLookup[3]['part_of_a_set']                                    = 'TPOS';
-			$ID3v2ShortFrameNameLookup[3]['publisher']                                        = 'TPUB';
-			$ID3v2ShortFrameNameLookup[3]['tracknumber']                                      = 'TRCK';
-			$ID3v2ShortFrameNameLookup[3]['internet_radio_station_name']                      = 'TRSN';
-			$ID3v2ShortFrameNameLookup[3]['internet_radio_station_owner']                     = 'TRSO';
-			$ID3v2ShortFrameNameLookup[3]['isrc']                                             = 'TSRC';
-			$ID3v2ShortFrameNameLookup[3]['encoder_settings']                                 = 'TSSE';
-			$ID3v2ShortFrameNameLookup[3]['user_text']                                        = 'TXXX';
-			$ID3v2ShortFrameNameLookup[3]['unique_file_identifier']                           = 'UFID';
-			$ID3v2ShortFrameNameLookup[3]['terms_of_use']                                     = 'USER';
-			$ID3v2ShortFrameNameLookup[3]['unsynchronised_lyrics']                            = 'USLT';
-			$ID3v2ShortFrameNameLookup[3]['commercial']                                       = 'WCOM';
-			$ID3v2ShortFrameNameLookup[3]['copyright_information']                            = 'WCOP';
-			$ID3v2ShortFrameNameLookup[3]['url_file']                                         = 'WOAF';
-			$ID3v2ShortFrameNameLookup[3]['url_artist']                                       = 'WOAR';
-			$ID3v2ShortFrameNameLookup[3]['url_source']                                       = 'WOAS';
-			$ID3v2ShortFrameNameLookup[3]['url_station']                                      = 'WORS';
-			$ID3v2ShortFrameNameLookup[3]['payment']                                          = 'WPAY';
-			$ID3v2ShortFrameNameLookup[3]['url_publisher']                                    = 'WPUB';
-			$ID3v2ShortFrameNameLookup[3]['url_user']                                         = 'WXXX';
+			$ID3v2ShortFrameNameLookup[3]['audio_encryption']                  = 'AENC';
+			$ID3v2ShortFrameNameLookup[3]['attached_picture']                  = 'APIC';
+			$ID3v2ShortFrameNameLookup[3]['picture']                           = 'APIC';
+			$ID3v2ShortFrameNameLookup[3]['comment']                           = 'COMM';
+			$ID3v2ShortFrameNameLookup[3]['commercial_frame']                  = 'COMR';
+			$ID3v2ShortFrameNameLookup[3]['encryption_method_registration']    = 'ENCR';
+			$ID3v2ShortFrameNameLookup[3]['event_timing_codes']                = 'ETCO';
+			$ID3v2ShortFrameNameLookup[3]['general_encapsulated_object']       = 'GEOB';
+			$ID3v2ShortFrameNameLookup[3]['group_identification_registration'] = 'GRID';
+			$ID3v2ShortFrameNameLookup[3]['linked_information']                = 'LINK';
+			$ID3v2ShortFrameNameLookup[3]['music_cd_identifier']               = 'MCDI';
+			$ID3v2ShortFrameNameLookup[3]['mpeg_location_lookup_table']        = 'MLLT';
+			$ID3v2ShortFrameNameLookup[3]['ownership_frame']                   = 'OWNE';
+			$ID3v2ShortFrameNameLookup[3]['play_counter']                      = 'PCNT';
+			$ID3v2ShortFrameNameLookup[3]['popularimeter']                     = 'POPM';
+			$ID3v2ShortFrameNameLookup[3]['position_synchronisation_frame']    = 'POSS';
+			$ID3v2ShortFrameNameLookup[3]['private_frame']                     = 'PRIV';
+			$ID3v2ShortFrameNameLookup[3]['recommended_buffer_size']           = 'RBUF';
+			$ID3v2ShortFrameNameLookup[3]['replay_gain_adjustment']            = 'RGAD';
+			$ID3v2ShortFrameNameLookup[3]['reverb']                            = 'RVRB';
+			$ID3v2ShortFrameNameLookup[3]['synchronised_lyric']                = 'SYLT';
+			$ID3v2ShortFrameNameLookup[3]['synchronised_tempo_codes']          = 'SYTC';
+			$ID3v2ShortFrameNameLookup[3]['album']                             = 'TALB';
+			$ID3v2ShortFrameNameLookup[3]['beats_per_minute']                  = 'TBPM';
+			$ID3v2ShortFrameNameLookup[3]['bpm']                               = 'TBPM';
+			$ID3v2ShortFrameNameLookup[3]['part_of_a_compilation']             = 'TCMP';
+			$ID3v2ShortFrameNameLookup[3]['composer']                          = 'TCOM';
+			$ID3v2ShortFrameNameLookup[3]['genre']                             = 'TCON';
+			$ID3v2ShortFrameNameLookup[3]['copyright_message']                 = 'TCOP';
+			$ID3v2ShortFrameNameLookup[3]['playlist_delay']                    = 'TDLY';
+			$ID3v2ShortFrameNameLookup[3]['encoded_by']                        = 'TENC';
+			$ID3v2ShortFrameNameLookup[3]['lyricist']                          = 'TEXT';
+			$ID3v2ShortFrameNameLookup[3]['file_type']                         = 'TFLT';
+			$ID3v2ShortFrameNameLookup[3]['content_group_description']         = 'TIT1';
+			$ID3v2ShortFrameNameLookup[3]['title']                             = 'TIT2';
+			$ID3v2ShortFrameNameLookup[3]['subtitle']                          = 'TIT3';
+			$ID3v2ShortFrameNameLookup[3]['initial_key']                       = 'TKEY';
+			$ID3v2ShortFrameNameLookup[3]['language']                          = 'TLAN';
+			$ID3v2ShortFrameNameLookup[3]['length']                            = 'TLEN';
+			$ID3v2ShortFrameNameLookup[3]['media_type']                        = 'TMED';
+			$ID3v2ShortFrameNameLookup[3]['original_album']                    = 'TOAL';
+			$ID3v2ShortFrameNameLookup[3]['original_filename']                 = 'TOFN';
+			$ID3v2ShortFrameNameLookup[3]['original_lyricist']                 = 'TOLY';
+			$ID3v2ShortFrameNameLookup[3]['original_artist']                   = 'TOPE';
+			$ID3v2ShortFrameNameLookup[3]['file_owner']                        = 'TOWN';
+			$ID3v2ShortFrameNameLookup[3]['artist']                            = 'TPE1';
+			$ID3v2ShortFrameNameLookup[3]['band']                              = 'TPE2';
+			$ID3v2ShortFrameNameLookup[3]['conductor']                         = 'TPE3';
+			$ID3v2ShortFrameNameLookup[3]['remixer']                           = 'TPE4';
+			$ID3v2ShortFrameNameLookup[3]['part_of_a_set']                     = 'TPOS';
+			$ID3v2ShortFrameNameLookup[3]['publisher']                         = 'TPUB';
+			$ID3v2ShortFrameNameLookup[3]['tracknumber']                       = 'TRCK';
+			$ID3v2ShortFrameNameLookup[3]['track_number']                      = 'TRCK';
+			$ID3v2ShortFrameNameLookup[3]['internet_radio_station_name']       = 'TRSN';
+			$ID3v2ShortFrameNameLookup[3]['internet_radio_station_owner']      = 'TRSO';
+			$ID3v2ShortFrameNameLookup[3]['album_artist_sort_order']           = 'TSO2';
+			$ID3v2ShortFrameNameLookup[3]['album_sort_order']                  = 'TSOA';
+			$ID3v2ShortFrameNameLookup[3]['composer_sort_order']               = 'TSOC';
+			$ID3v2ShortFrameNameLookup[3]['performer_sort_order']              = 'TSOP';
+			$ID3v2ShortFrameNameLookup[3]['title_sort_order']                  = 'TSOT';
+			$ID3v2ShortFrameNameLookup[3]['isrc']                              = 'TSRC';
+			$ID3v2ShortFrameNameLookup[3]['encoder_settings']                  = 'TSSE';
+			$ID3v2ShortFrameNameLookup[3]['text']                              = 'TXXX';
+			$ID3v2ShortFrameNameLookup[3]['unique_file_identifier']            = 'UFID';
+			$ID3v2ShortFrameNameLookup[3]['terms_of_use']                      = 'USER';
+			$ID3v2ShortFrameNameLookup[3]['unsynchronised_lyric']              = 'USLT';
+			$ID3v2ShortFrameNameLookup[3]['commercial_information']            = 'WCOM';
+			$ID3v2ShortFrameNameLookup[3]['copyright']                         = 'WCOP';
+			$ID3v2ShortFrameNameLookup[3]['url_file']                          = 'WOAF';
+			$ID3v2ShortFrameNameLookup[3]['url_artist']                        = 'WOAR';
+			$ID3v2ShortFrameNameLookup[3]['url_source']                        = 'WOAS';
+			$ID3v2ShortFrameNameLookup[3]['url_station']                       = 'WORS';
+			$ID3v2ShortFrameNameLookup[3]['url_payment']                       = 'WPAY';
+			$ID3v2ShortFrameNameLookup[3]['url_publisher']                     = 'WPUB';
+			$ID3v2ShortFrameNameLookup[3]['url_user']                          = 'WXXX';
 
 			// The above are common to ID3v2.3 and ID3v2.4
 			// so copy them to ID3v2.4 before adding specifics for 2.3 and 2.4
 			$ID3v2ShortFrameNameLookup[4] = $ID3v2ShortFrameNameLookup[3];
 
 			// The following are unique to ID3v2.3
-			$ID3v2ShortFrameNameLookup[3]['equalisation']                                     = 'EQUA';
-			$ID3v2ShortFrameNameLookup[3]['involved_people_list']                             = 'IPLS';
-			$ID3v2ShortFrameNameLookup[3]['relative_volume_adjustment']                       = 'RVAD';
-			$ID3v2ShortFrameNameLookup[3]['date']                                             = 'TDAT';
-			$ID3v2ShortFrameNameLookup[3]['time']                                             = 'TIME';
-			$ID3v2ShortFrameNameLookup[3]['original_release_year']                            = 'TORY';
-			$ID3v2ShortFrameNameLookup[3]['recording_dates']                                  = 'TRDA';
-			$ID3v2ShortFrameNameLookup[3]['size']                                             = 'TSIZ';
-			$ID3v2ShortFrameNameLookup[3]['year']                                             = 'TYER';
+			$ID3v2ShortFrameNameLookup[3]['equalisation']                      = 'EQUA';
+			$ID3v2ShortFrameNameLookup[3]['involved_people_list']              = 'IPLS';
+			$ID3v2ShortFrameNameLookup[3]['relative_volume_adjustment']        = 'RVAD';
+			$ID3v2ShortFrameNameLookup[3]['date']                              = 'TDAT';
+			$ID3v2ShortFrameNameLookup[3]['time']                              = 'TIME';
+			$ID3v2ShortFrameNameLookup[3]['original_year']                     = 'TORY';
+			$ID3v2ShortFrameNameLookup[3]['recording_dates']                   = 'TRDA';
+			$ID3v2ShortFrameNameLookup[3]['size']                              = 'TSIZ';
+			$ID3v2ShortFrameNameLookup[3]['year']                              = 'TYER';
 
 
 			// The following are unique to ID3v2.4
-			$ID3v2ShortFrameNameLookup[4]['audio_seek_point_index']                           = 'ASPI';
-			$ID3v2ShortFrameNameLookup[4]['equalisation']                                     = 'EQU2';
-			$ID3v2ShortFrameNameLookup[4]['relative_volume_adjustment']                       = 'RVA2';
-			$ID3v2ShortFrameNameLookup[4]['seek']                                             = 'SEEK';
-			$ID3v2ShortFrameNameLookup[4]['signature']                                        = 'SIGN';
-			$ID3v2ShortFrameNameLookup[4]['encoding_time']                                    = 'TDEN';
-			$ID3v2ShortFrameNameLookup[4]['original_release_time']                            = 'TDOR';
-			$ID3v2ShortFrameNameLookup[4]['recording_time']                                   = 'TDRC';
-			$ID3v2ShortFrameNameLookup[4]['release_time']                                     = 'TDRL';
-			$ID3v2ShortFrameNameLookup[4]['tagging_time']                                     = 'TDTG';
-			$ID3v2ShortFrameNameLookup[4]['involved_people_list']                             = 'TIPL';
-			$ID3v2ShortFrameNameLookup[4]['musician_credits_list']                            = 'TMCL';
-			$ID3v2ShortFrameNameLookup[4]['mood']                                             = 'TMOO';
-			$ID3v2ShortFrameNameLookup[4]['produced_notice']                                  = 'TPRO';
-			$ID3v2ShortFrameNameLookup[4]['album_sort_order']                                 = 'TSOA';
-			$ID3v2ShortFrameNameLookup[4]['performer_sort_order']                             = 'TSOP';
-			$ID3v2ShortFrameNameLookup[4]['title_sort_order']                                 = 'TSOT';
-			$ID3v2ShortFrameNameLookup[4]['set_subtitle']                                     = 'TSST';
+			$ID3v2ShortFrameNameLookup[4]['audio_seek_point_index']            = 'ASPI';
+			$ID3v2ShortFrameNameLookup[4]['equalisation']                      = 'EQU2';
+			$ID3v2ShortFrameNameLookup[4]['relative_volume_adjustment']        = 'RVA2';
+			$ID3v2ShortFrameNameLookup[4]['seek_frame']                        = 'SEEK';
+			$ID3v2ShortFrameNameLookup[4]['signature_frame']                   = 'SIGN';
+			$ID3v2ShortFrameNameLookup[4]['encoding_time']                     = 'TDEN';
+			$ID3v2ShortFrameNameLookup[4]['original_release_time']             = 'TDOR';
+			$ID3v2ShortFrameNameLookup[4]['recording_time']                    = 'TDRC';
+			$ID3v2ShortFrameNameLookup[4]['release_time']                      = 'TDRL';
+			$ID3v2ShortFrameNameLookup[4]['tagging_time']                      = 'TDTG';
+			$ID3v2ShortFrameNameLookup[4]['involved_people_list']              = 'TIPL';
+			$ID3v2ShortFrameNameLookup[4]['musician_credits_list']             = 'TMCL';
+			$ID3v2ShortFrameNameLookup[4]['mood']                              = 'TMOO';
+			$ID3v2ShortFrameNameLookup[4]['produced_notice']                   = 'TPRO';
+			$ID3v2ShortFrameNameLookup[4]['album_sort_order']                  = 'TSOA';
+			$ID3v2ShortFrameNameLookup[4]['performer_sort_order']              = 'TSOP';
+			$ID3v2ShortFrameNameLookup[4]['title_sort_order']                  = 'TSOT';
+			$ID3v2ShortFrameNameLookup[4]['set_subtitle']                      = 'TSST';
+			$ID3v2ShortFrameNameLookup[4]['year']                              = 'TDRC'; // subset of ISO 8601: valid timestamps are yyyy, yyyy-MM, yyyy-MM-dd, yyyy-MM-ddTHH, yyyy-MM-ddTHH:mm and yyyy-MM-ddTHH:mm:ss. All time stamps are UTC
 		}
 		return (isset($ID3v2ShortFrameNameLookup[$majorversion][strtolower($long_description)]) ? $ID3v2ShortFrameNameLookup[$majorversion][strtolower($long_description)] : '');
 

--- a/application/libraries/getid3/write.lyrics3.php
+++ b/application/libraries/getid3/write.lyrics3.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // write.lyrics3.php                                           //
@@ -16,31 +17,56 @@
 
 class getid3_write_lyrics3
 {
+	/**
+	 * @var string
+	 */
 	public $filename;
+
+	/**
+	 * @var array
+	 */
 	public $tag_data;
 	//public $lyrics3_version = 2;       // 1 or 2
-	public $warnings        = array(); // any non-critical errors will be stored here
-	public $errors          = array(); // any critical errors will be stored here
 
-	public function getid3_write_lyrics3() {
-		return true;
+	/**
+	 * Any non-critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $warnings        = array();
+
+	/**
+	 * Any critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $errors          = array();
+
+	public function __construct() {
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function WriteLyrics3() {
 		$this->errors[] = 'WriteLyrics3() not yet functional - cannot write Lyrics3';
 		return false;
 	}
+
+	/**
+	 * @return bool
+	 */
 	public function DeleteLyrics3() {
 		// Initialize getID3 engine
 		$getID3 = new getID3;
 		$ThisFileInfo = $getID3->analyze($this->filename);
 		if (isset($ThisFileInfo['lyrics3']['tag_offset_start']) && isset($ThisFileInfo['lyrics3']['tag_offset_end'])) {
-			if (is_readable($this->filename) && is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'a+b'))) {
+			if (is_readable($this->filename) && getID3::is_writable($this->filename) && is_file($this->filename) && ($fp = fopen($this->filename, 'a+b'))) {
 
 				flock($fp, LOCK_EX);
 				$oldignoreuserabort = ignore_user_abort(true);
 
-				fseek($fp, $ThisFileInfo['lyrics3']['tag_offset_end'], SEEK_SET);
+				fseek($fp, $ThisFileInfo['lyrics3']['tag_offset_end']);
 				$DataAfterLyrics3 = '';
 				if ($ThisFileInfo['filesize'] > $ThisFileInfo['lyrics3']['tag_offset_end']) {
 					$DataAfterLyrics3 = fread($fp, $ThisFileInfo['filesize'] - $ThisFileInfo['lyrics3']['tag_offset_end']);
@@ -49,7 +75,7 @@ class getid3_write_lyrics3
 				ftruncate($fp, $ThisFileInfo['lyrics3']['tag_offset_start']);
 
 				if (!empty($DataAfterLyrics3)) {
-					fseek($fp, $ThisFileInfo['lyrics3']['tag_offset_start'], SEEK_SET);
+					fseek($fp, $ThisFileInfo['lyrics3']['tag_offset_start']);
 					fwrite($fp, $DataAfterLyrics3, strlen($DataAfterLyrics3));
 				}
 

--- a/application/libraries/getid3/write.metaflac.php
+++ b/application/libraries/getid3/write.metaflac.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // write.metaflac.php                                          //
@@ -16,16 +17,38 @@
 
 class getid3_write_metaflac
 {
-
+	/**
+	 * @var string
+	 */
 	public $filename;
-	public $tag_data;
-	public $warnings = array(); // any non-critical errors will be stored here
-	public $errors   = array(); // any critical errors will be stored here
 
-	public function getid3_write_metaflac() {
-		return true;
+	/**
+	 * @var array
+	 */
+	public $tag_data;
+
+	/**
+	 * Any non-critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $warnings = array();
+
+	/**
+	 * Any critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $errors   = array();
+
+	private $pictures = array();
+
+	public function __construct() {
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function WriteMetaFLAC() {
 
 		if (preg_match('#(1|ON)#i', ini_get('safe_mode'))) {
@@ -33,9 +56,35 @@ class getid3_write_metaflac
 			return false;
 		}
 
+		$tempfilenames = array();
+
+
+		if (!empty($this->tag_data['ATTACHED_PICTURE'])) {
+			foreach ($this->tag_data['ATTACHED_PICTURE'] as $key => $picturedetails) {
+				$temppicturefilename = tempnam(GETID3_TEMP_DIR, 'getID3');
+				$tempfilenames[] = $temppicturefilename;
+				if (getID3::is_writable($temppicturefilename) && is_file($temppicturefilename) && ($fpcomments = fopen($temppicturefilename, 'wb'))) {
+					// https://xiph.org/flac/documentation_tools_flac.html#flac_options_picture
+					// [TYPE]|[MIME-TYPE]|[DESCRIPTION]|[WIDTHxHEIGHTxDEPTH[/COLORS]]|FILE
+					fwrite($fpcomments, $picturedetails['data']);
+					fclose($fpcomments);
+					$picture_typeid = (!empty($picturedetails['picturetypeid']) ? $this->ID3v2toFLACpictureTypes($picturedetails['picturetypeid']) : 3); // default to "3:Cover (front)"
+					$picture_mimetype = (!empty($picturedetails['mime']) ? $picturedetails['mime'] : ''); // should be auto-detected
+					$picture_width_height_depth = '';
+					$this->pictures[] = $picture_typeid.'|'.$picture_mimetype.'|'.preg_replace('#[^\x20-\x7B\x7D-\x7F]#', '', $picturedetails['description']).'|'.$picture_width_height_depth.'|'.$temppicturefilename;
+				} else {
+					$this->errors[] = 'failed to open temporary tags file, tags not written - fopen("'.$temppicturefilename.'", "wb")';
+					return false;
+				}
+			}
+			unset($this->tag_data['ATTACHED_PICTURE']);
+		}
+
+
 		// Create file with new comments
 		$tempcommentsfilename = tempnam(GETID3_TEMP_DIR, 'getID3');
-		if (is_writable($tempcommentsfilename) && is_file($tempcommentsfilename) && ($fpcomments = fopen($tempcommentsfilename, 'wb'))) {
+		$tempfilenames[] = $tempcommentsfilename;
+		if (getID3::is_writable($tempcommentsfilename) && is_file($tempcommentsfilename) && ($fpcomments = fopen($tempcommentsfilename, 'wb'))) {
 			foreach ($this->tag_data as $key => $value) {
 				foreach ($value as $commentdata) {
 					fwrite($fpcomments, $this->CleanmetaflacName($key).'='.$commentdata."\n");
@@ -64,7 +113,11 @@ class getid3_write_metaflac
 				clearstatcache();
 				$timestampbeforewriting = filemtime($this->filename);
 
-				$commandline = GETID3_HELPERAPPSDIR.'metaflac.exe --no-utf8-convert --remove-all-tags --import-tags-from='.escapeshellarg($tempcommentsfilename).' '.escapeshellarg($this->filename).' 2>&1';
+				$commandline  = GETID3_HELPERAPPSDIR.'metaflac.exe --no-utf8-convert --remove-all-tags --import-tags-from='.escapeshellarg($tempcommentsfilename);
+				foreach ($this->pictures as $picturecommand) {
+					$commandline .= ' --import-picture-from='.escapeshellarg($picturecommand);
+				}
+				$commandline .= ' '.escapeshellarg($this->filename).' 2>&1';
 				$metaflacError = `$commandline`;
 
 				if (empty($metaflacError)) {
@@ -80,13 +133,19 @@ class getid3_write_metaflac
 		} else {
 
 			// It's simpler on *nix
-			$commandline = 'metaflac --no-utf8-convert --remove-all-tags --import-tags-from='.escapeshellarg($tempcommentsfilename).' '.escapeshellarg($this->filename).' 2>&1';
+			$commandline  = 'metaflac --no-utf8-convert --remove-all-tags --import-tags-from='.escapeshellarg($tempcommentsfilename);
+			foreach ($this->pictures as $picturecommand) {
+				$commandline .= ' --import-picture-from='.escapeshellarg($picturecommand);
+			}
+			$commandline .= ' '.escapeshellarg($this->filename).' 2>&1';
 			$metaflacError = `$commandline`;
 
 		}
 
 		// Remove temporary comments file
-		unlink($tempcommentsfilename);
+		foreach ($tempfilenames as $tempfilename) {
+			unlink($tempfilename);
+		}
 		ignore_user_abort($oldignoreuserabort);
 
 		if (!empty($metaflacError)) {
@@ -99,7 +158,9 @@ class getid3_write_metaflac
 		return true;
 	}
 
-
+	/**
+	 * @return bool
+	 */
 	public function DeleteMetaFLAC() {
 
 		if (preg_match('#(1|ON)#i', ini_get('safe_mode'))) {
@@ -145,17 +206,33 @@ class getid3_write_metaflac
 		return true;
 	}
 
+	/**
+	 * @param int $id3v2_picture_typeid
+	 *
+	 * @return int
+	 */
+	public function ID3v2toFLACpictureTypes($id3v2_picture_typeid) {
+		// METAFLAC picture type list is identical to ID3v2 picture type list (as least up to 0x14 "Publisher/Studio logotype")
+		// http://id3.org/id3v2.4.0-frames (section 4.14)
+		// https://xiph.org/flac/documentation_tools_flac.html#flac_options_picture
+		//return (isset($ID3v2toFLACpictureTypes[$id3v2_picture_typeid]) ? $ID3v2toFLACpictureTypes[$id3v2_picture_typeid] : 3); // default: "3: Cover (front)"
+		return (($id3v2_picture_typeid <= 0x14) ? $id3v2_picture_typeid : 3); // default: "3: Cover (front)"
+	}
 
+	/**
+	 * @param string $originalcommentname
+	 *
+	 * @return string
+	 */
 	public function CleanmetaflacName($originalcommentname) {
 		// A case-insensitive field name that may consist of ASCII 0x20 through 0x7D, 0x3D ('=') excluded.
 		// ASCII 0x41 through 0x5A inclusive (A-Z) is to be considered equivalent to ASCII 0x61 through
 		// 0x7A inclusive (a-z).
 
 		// replace invalid chars with a space, return uppercase text
-		// Thanks Chris Bolt <chris-getid3Øbolt*cx> for improving this function
+		// Thanks Chris Bolt <chris-getid3Ã˜bolt*cx> for improving this function
 		// note: *reg_replace() replaces nulls with empty string (not space)
 		return strtoupper(preg_replace('#[^ -<>-}]#', ' ', str_replace("\x00", ' ', $originalcommentname)));
-
 	}
 
 }

--- a/application/libraries/getid3/write.php
+++ b/application/libraries/getid3/write.php
@@ -1,10 +1,11 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
-/////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 ///                                                            //
 // write.php                                                   //
@@ -26,48 +27,113 @@ if (!include_once(GETID3_INCLUDEPATH.'getid3.lib.php')) {
 	throw new Exception('write.php depends on getid3.lib.php, which is missing.');
 }
 
-
-// NOTES:
-//
-// You should pass data here with standard field names as follows:
-// * TITLE
-// * ARTIST
-// * ALBUM
-// * TRACKNUMBER
-// * COMMENT
-// * GENRE
-// * YEAR
-// * ATTACHED_PICTURE (ID3v2 only)
-//
-// http://www.personal.uni-jena.de/~pfk/mpp/sv8/apekey.html
-// The APEv2 Tag Items Keys definition says "TRACK" is correct but foobar2000 uses "TRACKNUMBER" instead
-// Pass data here as "TRACKNUMBER" for compatability with all formats
-
-
+/**
+ * NOTES:
+ *
+ * You should pass data here with standard field names as follows:
+ * * TITLE
+ * * ARTIST
+ * * ALBUM
+ * * TRACKNUMBER
+ * * COMMENT
+ * * GENRE
+ * * YEAR
+ * * ATTACHED_PICTURE (ID3v2 only)
+ * The APEv2 Tag Items Keys definition says "TRACK" is correct but foobar2000 uses "TRACKNUMBER" instead
+ * Pass data here as "TRACKNUMBER" for compatability with all formats
+ *
+ * @link http://www.personal.uni-jena.de/~pfk/mpp/sv8/apekey.html
+ */
 class getid3_writetags
 {
-	// public
-	public $filename;                            // absolute filename of file to write tags to
-	public $tagformats         = array();        // array of tag formats to write ('id3v1', 'id3v2.2', 'id2v2.3', 'id3v2.4', 'ape', 'vorbiscomment', 'metaflac', 'real')
-	public $tag_data           = array(array()); // 2-dimensional array of tag data (ex: $data['ARTIST'][0] = 'Elvis')
-	public $tag_encoding       = 'ISO-8859-1';   // text encoding used for tag data ('ISO-8859-1', 'UTF-8', 'UTF-16', 'UTF-16LE', 'UTF-16BE', )
-	public $overwrite_tags     = true;          // if true will erase existing tag data and write only passed data; if false will merge passed data with existing tag data
-	public $remove_other_tags  = false;          // if true will erase remove all existing tags and only write those passed in $tagformats; if false will ignore any tags not mentioned in $tagformats
+	/**
+	 * Absolute filename of file to write tags to.
+	 *
+	 * @var string
+	 */
+	public $filename;
 
-	public $id3v2_tag_language = 'eng';          // ISO-639-2 3-character language code needed for some ID3v2 frames (http://www.id3.org/iso639-2.html)
-	public $id3v2_paddedlength = 4096;           // minimum length of ID3v2 tags (will be padded to this length if tag data is shorter)
+	/**
+	 * Array of tag formats to write ('id3v1', 'id3v2.2', 'id2v2.3', 'id3v2.4', 'ape', 'vorbiscomment',
+	 * 'metaflac', 'real').
+	 *
+	 * @var array
+	 */
+	public $tagformats         = array();
 
-	public $warnings           = array();        // any non-critical errors will be stored here
-	public $errors             = array();        // any critical errors will be stored here
+	/**
+	 * 2-dimensional array of tag data (ex: $data['ARTIST'][0] = 'Elvis').
+	 *
+	 * @var array
+	 */
+	public $tag_data           = array(array());
 
-	// private
-	private $ThisFileInfo; // analysis of file before writing
+	/**
+	 * Text encoding used for tag data ('ISO-8859-1', 'UTF-8', 'UTF-16', 'UTF-16LE', 'UTF-16BE', ).
+	 *
+	 * @var string
+	 */
+	public $tag_encoding       = 'ISO-8859-1';
 
-	public function getid3_writetags() {
-		return true;
+	/**
+	 * If true will erase existing tag data and write only passed data; if false will merge passed data
+	 * with existing tag data.
+	 *
+	 * @var bool
+	 */
+	public $overwrite_tags     = true;
+
+	/**
+	 * If true will erase remove all existing tags and only write those passed in $tagformats;
+	 * If false will ignore any tags not mentioned in $tagformats.
+	 *
+	 * @var bool
+	 */
+	public $remove_other_tags  = false;
+
+	/**
+	 * ISO-639-2 3-character language code needed for some ID3v2 frames.
+	 *
+	 * @link http://www.id3.org/iso639-2.html
+	 *
+	 * @var string
+	 */
+	public $id3v2_tag_language = 'eng';
+
+	/**
+	 * Minimum length of ID3v2 tags (will be padded to this length if tag data is shorter).
+	 *
+	 * @var int
+	 */
+	public $id3v2_paddedlength = 4096;
+
+	/**
+	 * Any non-critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $warnings           = array();
+
+	/**
+	 * Any critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $errors             = array();
+
+	/**
+	 * Analysis of file before writing.
+	 *
+	 * @var array
+	 */
+	private $ThisFileInfo;
+
+	public function __construct() {
 	}
 
-
+	/**
+	 * @return bool
+	 */
 	public function WriteTags() {
 
 		if (empty($this->filename)) {
@@ -82,8 +148,23 @@ class getid3_writetags
 			$this->errors[] = 'tagformats must be an array in getid3_writetags';
 			return false;
 		}
+		// prevent duplicate tag formats
+		$this->tagformats = array_unique($this->tagformats);
+
+		// prevent trying to specify more than one version of ID3v2 tag to write simultaneously
+		$id3typecounter = 0;
+		foreach ($this->tagformats as $tagformat) {
+			if (substr(strtolower($tagformat), 0, 6) == 'id3v2.') {
+				$id3typecounter++;
+			}
+		}
+		if ($id3typecounter > 1) {
+			$this->errors[] = 'tagformats must not contain more than one version of ID3v2';
+			return false;
+		}
 
 		$TagFormatsToRemove = array();
+		$AllowedTagFormats = array();
 		if (filesize($this->filename) == 0) {
 
 			// empty file special case - allow any tag format, don't check existing format
@@ -124,14 +205,12 @@ class getid3_writetags
 							//$AllowedTagFormats = array('metaflac');
 							$this->errors[] = 'metaflac is not (yet) compatible with OggFLAC files';
 							return false;
-							break;
 						case 'vorbis':
 							$AllowedTagFormats = array('vorbiscomment');
 							break;
 						default:
 							$this->errors[] = 'metaflac is not (yet) compatible with Ogg files other than OggVorbis';
 							return false;
-							break;
 					}
 					break;
 
@@ -178,9 +257,7 @@ class getid3_writetags
 			switch ($tagformat) {
 				case 'ape':
 					$GETID3_ERRORARRAY = &$this->errors;
-					if (!getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'write.apetag.php', __FILE__, false)) {
-						return false;
-					}
+					getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'write.apetag.php', __FILE__, true);
 					break;
 
 				case 'id3v1':
@@ -189,9 +266,7 @@ class getid3_writetags
 				case 'metaflac':
 				case 'real':
 					$GETID3_ERRORARRAY = &$this->errors;
-					if (!getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'write.'.$tagformat.'.php', __FILE__, false)) {
-						return false;
-					}
+					getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'write.'.$tagformat.'.php', __FILE__, true);
 					break;
 
 				case 'id3v2.2':
@@ -199,15 +274,12 @@ class getid3_writetags
 				case 'id3v2.4':
 				case 'id3v2':
 					$GETID3_ERRORARRAY = &$this->errors;
-					if (!getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'write.id3v2.php', __FILE__, false)) {
-						return false;
-					}
+					getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'write.id3v2.php', __FILE__, true);
 					break;
 
 				default:
 					$this->errors[] = 'unknown tag format "'.$tagformat.'" in $tagformats in WriteTags()';
 					return false;
-					break;
 			}
 
 		}
@@ -236,9 +308,9 @@ class getid3_writetags
 			}
 		}
 
-		// Convert "TRACK" to "TRACKNUMBER" (if needed) for compatability with all formats
-		if (isset($this->tag_data['TRACK']) && !isset($this->tag_data['TRACKNUMBER'])) {
-			$this->tag_data['TRACKNUMBER'] = $this->tag_data['TRACK'];
+		// Convert "TRACK" to "TRACK_NUMBER" (if needed) for compatability with all formats
+		if (isset($this->tag_data['TRACK']) && !isset($this->tag_data['TRACK_NUMBER'])) {
+			$this->tag_data['TRACK_NUMBER'] = $this->tag_data['TRACK'];
 			unset($this->tag_data['TRACK']);
 		}
 
@@ -253,7 +325,7 @@ class getid3_writetags
 			switch ($tagformat) {
 				case 'ape':
 					$ape_writer = new getid3_write_apetag;
-					if (($ape_writer->tag_data = $this->FormatDataForAPE()) !== false) {
+					if ($ape_writer->tag_data = $this->FormatDataForAPE()) {
 						$ape_writer->filename = $this->filename;
 						if (($success = $ape_writer->WriteAPEtag()) === false) {
 							$this->errors[] = 'WriteAPEtag() failed with message(s):<pre><ul><li>'.str_replace("\n", '</li><li>', htmlentities(trim(implode("\n", $ape_writer->errors)))).'</li></ul></pre>';
@@ -265,7 +337,7 @@ class getid3_writetags
 
 				case 'id3v1':
 					$id3v1_writer = new getid3_write_id3v1;
-					if (($id3v1_writer->tag_data = $this->FormatDataForID3v1()) !== false) {
+					if ($id3v1_writer->tag_data = $this->FormatDataForID3v1()) {
 						$id3v1_writer->filename = $this->filename;
 						if (($success = $id3v1_writer->WriteID3v1()) === false) {
 							$this->errors[] = 'WriteID3v1() failed with message(s):<pre><ul><li>'.str_replace("\n", '</li><li>', htmlentities(trim(implode("\n", $id3v1_writer->errors)))).'</li></ul></pre>';
@@ -281,7 +353,10 @@ class getid3_writetags
 					$id3v2_writer = new getid3_write_id3v2;
 					$id3v2_writer->majorversion = intval(substr($tagformat, -1));
 					$id3v2_writer->paddedlength = $this->id3v2_paddedlength;
-					if (($id3v2_writer->tag_data = $this->FormatDataForID3v2($id3v2_writer->majorversion)) !== false) {
+					$id3v2_writer_tag_data = $this->FormatDataForID3v2($id3v2_writer->majorversion);
+					if ($id3v2_writer_tag_data !== false) {
+						$id3v2_writer->tag_data = $id3v2_writer_tag_data;
+						unset($id3v2_writer_tag_data);
 						$id3v2_writer->filename = $this->filename;
 						if (($success = $id3v2_writer->WriteID3v2()) === false) {
 							$this->errors[] = 'WriteID3v2() failed with message(s):<pre><ul><li>'.str_replace("\n", '</li><li>', htmlentities(trim(implode("\n", $id3v2_writer->errors)))).'</li></ul></pre>';
@@ -293,7 +368,7 @@ class getid3_writetags
 
 				case 'vorbiscomment':
 					$vorbiscomment_writer = new getid3_write_vorbiscomment;
-					if (($vorbiscomment_writer->tag_data = $this->FormatDataForVorbisComment()) !== false) {
+					if ($vorbiscomment_writer->tag_data = $this->FormatDataForVorbisComment()) {
 						$vorbiscomment_writer->filename = $this->filename;
 						if (($success = $vorbiscomment_writer->WriteVorbisComment()) === false) {
 							$this->errors[] = 'WriteVorbisComment() failed with message(s):<pre><ul><li>'.str_replace("\n", '</li><li>', htmlentities(trim(implode("\n", $vorbiscomment_writer->errors)))).'</li></ul></pre>';
@@ -305,7 +380,7 @@ class getid3_writetags
 
 				case 'metaflac':
 					$metaflac_writer = new getid3_write_metaflac;
-					if (($metaflac_writer->tag_data = $this->FormatDataForMetaFLAC()) !== false) {
+					if ($metaflac_writer->tag_data = $this->FormatDataForMetaFLAC()) {
 						$metaflac_writer->filename = $this->filename;
 						if (($success = $metaflac_writer->WriteMetaFLAC()) === false) {
 							$this->errors[] = 'WriteMetaFLAC() failed with message(s):<pre><ul><li>'.str_replace("\n", '</li><li>', htmlentities(trim(implode("\n", $metaflac_writer->errors)))).'</li></ul></pre>';
@@ -317,7 +392,7 @@ class getid3_writetags
 
 				case 'real':
 					$real_writer = new getid3_write_real;
-					if (($real_writer->tag_data = $this->FormatDataForReal()) !== false) {
+					if ($real_writer->tag_data = $this->FormatDataForReal()) {
 						$real_writer->filename = $this->filename;
 						if (($success = $real_writer->WriteReal()) === false) {
 							$this->errors[] = 'WriteReal() failed with message(s):<pre><ul><li>'.str_replace("\n", '</li><li>', htmlentities(trim(implode("\n", $real_writer->errors)))).'</li></ul></pre>';
@@ -330,7 +405,6 @@ class getid3_writetags
 				default:
 					$this->errors[] = 'Invalid tag format to write: "'.$tagformat.'"';
 					return false;
-					break;
 			}
 			if (!$success) {
 				return false;
@@ -340,7 +414,11 @@ class getid3_writetags
 
 	}
 
-
+	/**
+	 * @param string[] $TagFormatsToDelete
+	 *
+	 * @return bool
+	 */
 	public function DeleteTags($TagFormatsToDelete) {
 		foreach ($TagFormatsToDelete as $DeleteTagFormat) {
 			$success = false; // overridden if tag deletion is successful
@@ -402,9 +480,8 @@ class getid3_writetags
 					break;
 
 				default:
-					$this->errors[] = 'Invalid tag format to delete: "'.$tagformat.'"';
+					$this->errors[] = 'Invalid tag format to delete: "'.$DeleteTagFormat.'"';
 					return false;
-					break;
 			}
 			if (!$success) {
 				return false;
@@ -413,21 +490,30 @@ class getid3_writetags
 		return true;
 	}
 
-
+	/**
+	 * @param string $TagFormat
+	 * @param array  $tag_data
+	 *
+	 * @return bool
+	 * @throws Exception
+	 */
 	public function MergeExistingTagData($TagFormat, &$tag_data) {
 		// Merge supplied data with existing data, if requested
 		if ($this->overwrite_tags) {
 			// do nothing - ignore previous data
 		} else {
-throw new Exception('$this->overwrite_tags=false is known to be buggy in this version of getID3. Will be fixed in the near future, check www.getid3.org for a newer version.');
-			if (!isset($this->ThisFileInfo['tags'][$TagFormat])) {
-				return false;
-			}
-			$tag_data = array_merge_recursive($tag_data, $this->ThisFileInfo['tags'][$TagFormat]);
+			throw new Exception('$this->overwrite_tags=false is known to be buggy in this version of getID3. Check http://github.com/JamesHeinrich/getID3 for a newer version.');
+//			if (!isset($this->ThisFileInfo['tags'][$TagFormat])) {
+//				return false;
+//			}
+//			$tag_data = array_merge_recursive($tag_data, $this->ThisFileInfo['tags'][$TagFormat]);
 		}
 		return true;
 	}
 
+	/**
+	 * @return array
+	 */
 	public function FormatDataForAPE() {
 		$ape_tag_data = array();
 		foreach ($this->tag_data as $tag_key => $valuearray) {
@@ -454,8 +540,11 @@ throw new Exception('$this->overwrite_tags=false is known to be buggy in this ve
 		return $ape_tag_data;
 	}
 
-
+	/**
+	 * @return array
+	 */
 	public function FormatDataForID3v1() {
+		$tag_data_id3v1            = array();
 		$tag_data_id3v1['genreid'] = 255;
 		if (!empty($this->tag_data['GENRE'])) {
 			foreach ($this->tag_data['GENRE'] as $key => $value) {
@@ -465,20 +554,25 @@ throw new Exception('$this->overwrite_tags=false is known to be buggy in this ve
 				}
 			}
 		}
-		$tag_data_id3v1['title']   =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['TITLE']      ) ? $this->tag_data['TITLE']       : array())));
-		$tag_data_id3v1['artist']  =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['ARTIST']     ) ? $this->tag_data['ARTIST']      : array())));
-		$tag_data_id3v1['album']   =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['ALBUM']      ) ? $this->tag_data['ALBUM']       : array())));
-		$tag_data_id3v1['year']    =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['YEAR']       ) ? $this->tag_data['YEAR']        : array())));
-		$tag_data_id3v1['comment'] =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['COMMENT']    ) ? $this->tag_data['COMMENT']     : array())));
-		$tag_data_id3v1['track']   = intval(getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['TRACKNUMBER']) ? $this->tag_data['TRACKNUMBER'] : array()))));
-		if ($tag_data_id3v1['track'] <= 0) {
-			$tag_data_id3v1['track'] = '';
+		$tag_data_id3v1['title']        =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['TITLE']       ) ? $this->tag_data['TITLE']        : array())));
+		$tag_data_id3v1['artist']       =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['ARTIST']      ) ? $this->tag_data['ARTIST']       : array())));
+		$tag_data_id3v1['album']        =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['ALBUM']       ) ? $this->tag_data['ALBUM']        : array())));
+		$tag_data_id3v1['year']         =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['YEAR']        ) ? $this->tag_data['YEAR']         : array())));
+		$tag_data_id3v1['comment']      =        getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['COMMENT']     ) ? $this->tag_data['COMMENT']      : array())));
+		$tag_data_id3v1['track_number'] = intval(getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['TRACK_NUMBER']) ? $this->tag_data['TRACK_NUMBER'] : array()))));
+		if ($tag_data_id3v1['track_number'] <= 0) {
+			$tag_data_id3v1['track_number'] = '';
 		}
 
 		$this->MergeExistingTagData('id3v1', $tag_data_id3v1);
 		return $tag_data_id3v1;
 	}
 
+	/**
+	 * @param int $id3v2_majorversion
+	 *
+	 * @return array|false
+	 */
 	public function FormatDataForID3v2($id3v2_majorversion) {
 		$tag_data_id3v2 = array();
 
@@ -497,6 +591,51 @@ throw new Exception('$this->overwrite_tags=false is known to be buggy in this ve
 								$tag_data_id3v2['APIC'][] = $apic_data_array;
 						} else {
 							$this->errors[] = 'ID3v2 APIC data is not properly structured';
+							return false;
+						}
+					}
+					break;
+
+				case 'POPM':
+					if (isset($valuearray['email']) &&
+						isset($valuearray['rating']) &&
+						isset($valuearray['data'])) {
+							$tag_data_id3v2['POPM'][] = $valuearray;
+					} else {
+						$this->errors[] = 'ID3v2 POPM data is not properly structured';
+						return false;
+					}
+					break;
+
+				case 'GRID':
+					if (
+						isset($valuearray['groupsymbol']) &&
+						isset($valuearray['ownerid']) &&
+						isset($valuearray['data'])
+					) {
+							$tag_data_id3v2['GRID'][] = $valuearray;
+					} else {
+						$this->errors[] = 'ID3v2 GRID data is not properly structured';
+						return false;
+					}
+					break;
+
+				case 'UFID':
+					if (isset($valuearray['ownerid']) &&
+						isset($valuearray['data'])) {
+							$tag_data_id3v2['UFID'][] = $valuearray;
+					} else {
+						$this->errors[] = 'ID3v2 UFID data is not properly structured';
+						return false;
+					}
+					break;
+
+				case 'TXXX':
+					foreach ($valuearray as $key => $txxx_data_array) {
+						if (isset($txxx_data_array['description']) && isset($txxx_data_array['data'])) {
+							$tag_data_id3v2['TXXX'][] = $txxx_data_array;
+						} else {
+							$this->errors[] = 'ID3v2 TXXX data is not properly structured';
 							return false;
 						}
 					}
@@ -521,7 +660,7 @@ throw new Exception('$this->overwrite_tags=false is known to be buggy in this ve
 								// note: some software, notably Windows Media Player and iTunes are broken and treat files tagged with UTF-16BE (with BOM) as corrupt
 								// therefore we force data to UTF-16LE and manually prepend the BOM
 								$ID3v2_tag_data_converted = false;
-								if (!$ID3v2_tag_data_converted && ($this->tag_encoding == 'ISO-8859-1')) {
+								if (/*!$ID3v2_tag_data_converted && */($this->tag_encoding == 'ISO-8859-1')) {
 									// great, leave data as-is for minimum compatability problems
 									$tag_data_id3v2[$ID3v2_framename][$key]['encodingid'] = 0;
 									$tag_data_id3v2[$ID3v2_framename][$key]['data']       = $value;
@@ -531,7 +670,7 @@ throw new Exception('$this->overwrite_tags=false is known to be buggy in this ve
 									do {
 										// if UTF-8 string does not include any characters above chr(127) then it is identical to ISO-8859-1
 										for ($i = 0; $i < strlen($value); $i++) {
-											if (ord($value{$i}) > 127) {
+											if (ord($value[$i]) > 127) {
 												break 2;
 											}
 										}
@@ -565,6 +704,9 @@ throw new Exception('$this->overwrite_tags=false is known to be buggy in this ve
 		return $tag_data_id3v2;
 	}
 
+	/**
+	 * @return array
+	 */
 	public function FormatDataForVorbisComment() {
 		$tag_data_vorbiscomment = $this->tag_data;
 
@@ -572,21 +714,25 @@ throw new Exception('$this->overwrite_tags=false is known to be buggy in this ve
 		// and convert data to UTF-8 strings
 		foreach ($tag_data_vorbiscomment as $tag_key => $valuearray) {
 			foreach ($valuearray as $key => $value) {
-				str_replace("\r", "\n", $value);
-				if (strstr($value, "\n")) {
-					unset($tag_data_vorbiscomment[$tag_key][$key]);
-					$multilineexploded = explode("\n", $value);
-					foreach ($multilineexploded as $newcomment) {
-						if (strlen(trim($newcomment)) > 0) {
-							$tag_data_vorbiscomment[$tag_key][] = getid3_lib::iconv_fallback($this->tag_encoding, 'UTF-8', $newcomment);
-						}
-					}
-				} elseif (is_string($value) || is_numeric($value)) {
-					$tag_data_vorbiscomment[$tag_key][$key] = getid3_lib::iconv_fallback($this->tag_encoding, 'UTF-8', $value);
+				if (($tag_key == 'ATTACHED_PICTURE') && is_array($value)) {
+					continue; // handled separately in write.metaflac.php
 				} else {
-					$this->warnings[] = '$data['.$tag_key.']['.$key.'] is not a string value - all of $data['.$tag_key.'] NOT written to VorbisComment tag';
-					unset($tag_data_vorbiscomment[$tag_key]);
-					break;
+					str_replace("\r", "\n", $value);
+					if (strstr($value, "\n")) {
+						unset($tag_data_vorbiscomment[$tag_key][$key]);
+						$multilineexploded = explode("\n", $value);
+						foreach ($multilineexploded as $newcomment) {
+							if (strlen(trim($newcomment)) > 0) {
+								$tag_data_vorbiscomment[$tag_key][] = getid3_lib::iconv_fallback($this->tag_encoding, 'UTF-8', $newcomment);
+							}
+						}
+					} elseif (is_string($value) || is_numeric($value)) {
+						$tag_data_vorbiscomment[$tag_key][$key] = getid3_lib::iconv_fallback($this->tag_encoding, 'UTF-8', $value);
+					} else {
+						$this->warnings[] = '$data['.$tag_key.']['.$key.'] is not a string value - all of $data['.$tag_key.'] NOT written to VorbisComment tag';
+						unset($tag_data_vorbiscomment[$tag_key]);
+						break;
+					}
 				}
 			}
 		}
@@ -594,12 +740,18 @@ throw new Exception('$this->overwrite_tags=false is known to be buggy in this ve
 		return $tag_data_vorbiscomment;
 	}
 
+	/**
+	 * @return array
+	 */
 	public function FormatDataForMetaFLAC() {
 		// FLAC & OggFLAC use VorbisComments same as OggVorbis
 		// but require metaflac to do the writing rather than vorbiscomment
 		return $this->FormatDataForVorbisComment();
 	}
 
+	/**
+	 * @return array
+	 */
 	public function FormatDataForReal() {
 		$tag_data_real['title']     = getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['TITLE']    ) ? $this->tag_data['TITLE']     : array())));
 		$tag_data_real['artist']    = getid3_lib::iconv_fallback($this->tag_encoding, 'ISO-8859-1', implode(' ', (isset($this->tag_data['ARTIST']   ) ? $this->tag_data['ARTIST']    : array())));

--- a/application/libraries/getid3/write.vorbiscomment.php
+++ b/application/libraries/getid3/write.vorbiscomment.php
@@ -1,10 +1,12 @@
 <?php
+
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
-//  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
 /////////////////////////////////////////////////////////////////
-// See readme.txt for more details                             //
+//  see readme.txt for more details                            //
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // write.vorbiscomment.php                                     //
@@ -16,16 +18,36 @@
 
 class getid3_write_vorbiscomment
 {
-
+	/**
+	 * @var string
+	 */
 	public $filename;
-	public $tag_data;
-	public $warnings = array(); // any non-critical errors will be stored here
-	public $errors   = array(); // any critical errors will be stored here
 
-	public function getid3_write_vorbiscomment() {
-		return true;
+	/**
+	 * @var array
+	 */
+	public $tag_data;
+
+	/**
+	 * Any non-critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $warnings = array();
+
+	/**
+	 * Any critical errors will be stored here.
+	 *
+	 * @var array
+	 */
+	public $errors   = array();
+
+	public function __construct() {
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function WriteVorbisComment() {
 
 		if (preg_match('#(1|ON)#i', ini_get('safe_mode'))) {
@@ -35,7 +57,7 @@ class getid3_write_vorbiscomment
 
 		// Create file with new comments
 		$tempcommentsfilename = tempnam(GETID3_TEMP_DIR, 'getID3');
-		if (is_writable($tempcommentsfilename) && is_file($tempcommentsfilename) && ($fpcomments = fopen($tempcommentsfilename, 'wb'))) {
+		if (getID3::is_writable($tempcommentsfilename) && is_file($tempcommentsfilename) && ($fpcomments = fopen($tempcommentsfilename, 'wb'))) {
 
 			foreach ($this->tag_data as $key => $value) {
 				foreach ($value as $commentdata) {
@@ -99,18 +121,26 @@ class getid3_write_vorbiscomment
 		return true;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function DeleteVorbisComment() {
 		$this->tag_data = array(array());
 		return $this->WriteVorbisComment();
 	}
 
+	/**
+	 * @param string $originalcommentname
+	 *
+	 * @return string
+	 */
 	public function CleanVorbisCommentName($originalcommentname) {
 		// A case-insensitive field name that may consist of ASCII 0x20 through 0x7D, 0x3D ('=') excluded.
 		// ASCII 0x41 through 0x5A inclusive (A-Z) is to be considered equivalent to ASCII 0x61 through
 		// 0x7A inclusive (a-z).
 
 		// replace invalid chars with a space, return uppercase text
-		// Thanks Chris Bolt <chris-getid3Øbolt*cx> for improving this function
+		// Thanks Chris Bolt <chris-getid3Ã˜bolt*cx> for improving this function
 		// note: *reg_replace() replaces nulls with empty string (not space)
 		return strtoupper(preg_replace('#[^ -<>-}]#', ' ', str_replace("\x00", ' ', $originalcommentname)));
 


### PR DESCRIPTION
Among other things, this fixes issue #28.

Summary of changes:

Updated getID3 library to 1.9.20.

- The old getid3 library we were using has a bug which can incorrectly report files encoded by newer versions of LAME as VBR and the reported bitrate is slightly off which would cause the validator check to fail.
- The old getid3 library also does not work with PHP 7 (which would prevent upgrading the server to latest ubuntu 20.04 LTS).
- This is a bit of a scary change. @twinkietoes-on and I have done a fair bit of testing to try and ensure it doesn't break anything.

Other changes:
- If the file is detected as VBR the bitrate is now display as VBR. As before, when showing CBR bitrates it divides by 1000. Now it uses round instead of ceil and prepends a "~" if it was not an exact multiple of 1000.
- The validator now checks for CBR in addition to checking for 128000 bitrate.

For a few more details see the commit logs.