### PR TITLE
Fix recent glitch in display of birth/death years.

### DIFF
--- a/application/helpers/previewer_helper.php
+++ b/application/helpers/previewer_helper.php
@@ -151,7 +151,7 @@ function format_author_years($author)
 	$dob = empty($author->dob) ? '' : $author->dob;
 	$dod = empty($author->dod) ? '' : $author->dod;
 
-	if (!empty($dod) || !empty($dod))
+	if (!empty($dob) || !empty($dod))
 		return '(' . $dob . ' - ' . $dod . ')';
 	else
 		return '';


### PR DESCRIPTION
It was only a matter of time before I broke something... fortunately this is fairly minor.

And now that the WordPress theme uses this same code directly I only need to fix it in one spot. The JavaScript version of this function was okay.