### PR TITLE
Check for null author passed into format_author().

### DIFF
--- a/application/helpers/previewer_helper.php
+++ b/application/helpers/previewer_helper.php
@@ -228,7 +228,10 @@ function format_authors($authors, $flags = 0, $max = 0)
 
 function format_author($author, $flags = 0)
 {
-	return format_authors(array($author), $flags);
+	if (isset($author))
+		return format_authors(array($author), $flags);
+	else
+		return '';
 }
 
 function format_playtime($seconds)


### PR DESCRIPTION
One such case where null gets passed to this function is when viewing
a compilation where a section has no author set. This would result in
errors such as:

A PHP Error was encountered
Severity: Notice
Message: Trying to get property of non-object
Filename: helpers/previewer_helper.php
Line Number: 149

And:
A PHP Error was encountered
Severity: Notice
Message: Trying to get property of non-object
Filename: helpers/previewer_helper.php
Line Number: 211

This addresses #109.