### PR TITLE
Fix PHP error on Project not found page.

### DIFF
--- a/application/controllers/catalog/Page.php
+++ b/application/controllers/catalog/Page.php
@@ -14,6 +14,9 @@ class Page extends Catalog_controller
 		$this->load->model('project_model');
 		$this->load->model('user_model');
 
+		$this->data['search_category'] = 'page';
+		$this->data['primary_key'] = 0;
+
 		if (empty($slug))
 		{
 			$this->data['message'] = 'You must include either the Project Id or the Project Slug (i.e., "tom_sawyer_by_mark_twain" , without any other link info)';
@@ -103,9 +106,6 @@ class Page extends Catalog_controller
 				}
 			}
 		}
-
-		$this->data['search_category'] = 'page';
-		$this->data['primary_key'] = 0;
 
 		$this->_render('catalog/page');
 		return;


### PR DESCRIPTION
This commit moves setting of search_category and primary_key closer to the
beginning of the index() member function of the Page class. These should be
set before the call to _render. Previously when certain errors happened
such as the project not being found these were left unset triggering a PHP
error in header.php.

Resolves #111.