### PR TITLE
WIP: Ignore mp3 files that mp3gain cannot process

### DIFF
--- a/application/libraries/Librivox_id3tag.php
+++ b/application/libraries/Librivox_id3tag.php
@@ -161,6 +161,7 @@ class Librivox_id3tag{
 
                 //analyze volume
                 $mp3gain_result = $this->librivox_mp3gain->analyze_file($dir, $file);
+                if (! $mp3gain_result) continue;
 
 				$file_array = $this-> _create_file_array($freeze); //prototype
 

--- a/application/libraries/Librivox_mp3gain.php
+++ b/application/libraries/Librivox_mp3gain.php
@@ -68,9 +68,13 @@ class Librivox_mp3gain
 		$command = $this->mp3gain .  ' ' . $this->flag . $dir. $file_name;
 		exec($command, $output);
 
-		$parts = explode("\t", $output[1]);
+        if (count($output) > 1) {
+            $parts = explode("\t", $output[1]);
+            return $parts;
+        } else {
+            return false;
+        }
 
-		return $parts;
 
 	}
 


### PR DESCRIPTION
In the validator, sometimes audio files either have a typo in their
path, or aren't actually audio files (when this patch was being
tested, the offending files were HTML files from a 301 redirect
response). In those cases, mp3gain does not return any useful output.
Specifically, instead of printing the header line plus the actually
useful line, it just prints the header line, with an error message
going to stderr (which we ignore because we only look at stdout).

This patch just makes the validator skip any such files.

Resolves #119