### PR TITLE
Relax username validation for user profile updates.

### DIFF
--- a/application/controllers/private/User.php
+++ b/application/controllers/private/User.php
@@ -75,7 +75,12 @@ class User extends Private_Controller
 		if ($is_admin)
 		{
 			$allowed_fields[] = 'username';
-			$this->form_validation->set_rules('username', 'User Name', 'trim|required|xss_clean|alpha_dash');
+
+			// Note: When adding a new user the validation includes alpha_dash. However there
+			// are already existing user names that violate this requirement so we do no include
+			// alpha_dash here otherwise editing a user (even just changing other fields) could
+			// fail.
+			$this->form_validation->set_rules('username', 'User Name', 'trim|required|xss_clean');
 		}
 
 		// fields which the user can only update for themselves


### PR DESCRIPTION
Note that I have not actually tested this change.

Commit d406d197a7aa added more validation for the username field, including the alpha_dash rule. However there are already existing user names that violate this requirement in which case updating that profile would fail.

Note this only impacted full admin accounts as no one else (even MCs) can attempt to edit a username. When you are not allowed to edit the username no validation was taking place on the name field.