### PR TITLE
Remove unused variables from advanced search

### DIFF
--- a/application/libraries/Librivox_search.php
+++ b/application/libraries/Librivox_search.php
@@ -141,20 +141,9 @@ class Librivox_search{
 		$reader_clause = '';
 		if (!empty($params['reader']))
 		{
-
 			$exact_match = (isset($params['exact_match'])) ? true: false;
-			//var_dump($exact_match);
-
 			$project_ids = $this->_get_projects_by_reader($params['reader'], $exact_match);
-			$section_project_ids = $this->_get_projects_by_section_author($params['author']);
-
 			$reader_clause = ' AND p.id IN (' . implode(',', $project_ids) . ') ';
-
-			$reader_ids = $this->_get_reader_ids($params['reader'], $exact_match);
-			$section_reader_clause = ' AND ( st.source_id IN (' . implode(',', $project_ids) . ') AND st.section_reader_id IN  (' . implode(',', $reader_ids) . ') )  ';
-
-
-
 		}
 
 		// ======================================================================================================================================


### PR DESCRIPTION
Fixes #155.

Calling `$this->_get_projects_by_section_author($params['author']);` without an author ID is really expensive, and we just throw the result away anyway. I also removed a few other unused variables while I was there, though the performance impact of those was negligible.

This should make searching by reader without an author much faster.