### PR TITLE
Add language to ia metadata

### DIFF
--- a/application/controllers/private/Iarchive_upload.php
+++ b/application/controllers/private/Iarchive_upload.php
@@ -48,7 +48,7 @@ class Iarchive_upload extends Private_Controller
 
 		$description = $this->_get_full_description($params, $project);
 		$params['description'] = trim(preg_replace('/\s+/', ' ', $description));  //trims all newlines before placing in header
-		$params['language'] = $this->data['language'];
+		$params['language'] = $this->data['language_code'];
 
 		// Close db connection before uploading to avoid hogging connections
 		$this->db->close();
@@ -109,6 +109,7 @@ class Iarchive_upload extends Private_Controller
 		$language = $this->language_model->get($project->language_id);
 
 		$this->data['language'] = empty($language) ? 'English' : $language->language;
+		$this->data['language_code'] = empty($language) ? 'eng' : $language->three_letter_code;
 
 		$this->load->model('project_model');
 		$this->data['readers'] = $this->project_model->create_project_reader_list($project->id);

--- a/application/controllers/private/Iarchive_upload.php
+++ b/application/controllers/private/Iarchive_upload.php
@@ -48,6 +48,7 @@ class Iarchive_upload extends Private_Controller
 
 		$description = $this->_get_full_description($params, $project);
 		$params['description'] = trim(preg_replace('/\s+/', ' ', $description));  //trims all newlines before placing in header
+		$params['language'] = $this->data['language'];
 
 		// Close db connection before uploading to avoid hogging connections
 		$this->db->close();

--- a/application/libraries/Iarchive_uploader.php
+++ b/application/libraries/Iarchive_uploader.php
@@ -63,13 +63,14 @@ class Iarchive_uploader
 		$headers[] = 'x-archive-meta-title:' . $title;
 
 		//additional info
-		$headers[] = 'x-archive-meta-creator:'.$params['creator'] ;
+		$headers[] = 'x-archive-meta-creator:'.$params['creator'];
 		$headers[] = 'x-archive-meta-description:'.$params['description'];
-		$headers[] = 'x-archive-meta-date:'.$params['date'] ;
-		$headers[] = 'x-archive-meta-subject:'.$params['subject'] ;
+		$headers[] = 'x-archive-meta-language:'.$params['language'];
+		$headers[] = 'x-archive-meta-date:'.$params['date'];
+		$headers[] = 'x-archive-meta-subject:'.$params['subject'];
 		$headers[] = 'x-archive-meta-licenseurl:'.$params['licenseurl'];
 
-	    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);  
+	    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
 	    curl_setopt($ch, CURLOPT_VERBOSE, 1);
 	    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
closes #8
and partially #132 

I'd like it if there was a 3 letter language code rather than a full name. (Hopefully done now with 42f73de8d8dfd3ce25bc29834c6cfe84647747ac)

Some of the existing code suggests there is a `3_letter_code`  (https://github.com/LibriVox/librivox-catalog/search?q=three_letter_code) , but I'm not completely sure whether this is guaranteed to exist, or where it comes from.


The archive.org fields to target are:
* https://archive.org/developers/metadata-schema/index.html#language
* https://archive.org/developers/metadata-schema/index.html#runtime


If I can determine a good source -> destination mapping, I can very likely make retrospective updates to the existing archive.org items happen.

I have not tested this code yet (not sure the best way to do so).
