### PR TITLE
add support to API for params: "sort_field", "sort_order"

### DIFF
--- a/application/controllers/api/Feed.php
+++ b/application/controllers/api/Feed.php
@@ -16,6 +16,8 @@ class Feed extends REST_Controller
 	{
 		$params['offset'] = $this->get('offset');
 		$params['limit'] = $this->get('limit');
+		$params['sort_field'] = $this->get('sort_field');
+		$params['sort_order'] = $this->get('sort_order');
 		$params['id'] = $this->get('id');
 
 		$params['since'] = $this->get('since');

--- a/application/libraries/Librivox_API.php
+++ b/application/libraries/Librivox_API.php
@@ -76,6 +76,15 @@ class Librivox_API{
 		$limit = (!empty($params['limit'])) ? $params['limit'] : 50;
 		$offset = (!empty($params['offset'])) ? $params['offset'] : 0;
 
+		$sort_fields = array('id', 'title', 'copyright_year', 'date_catalog');
+		$sort_field  = (!empty($params['sort_field']) && in_array($params['sort_field'], $sort_fields, true))
+			? $params['sort_field']
+			: $sort_fields[0];
+
+		$sort_order = (!empty($params['sort_order']) && ($params['sort_order'] === 'desc'))
+			? $params['sort_order']
+			: 'asc';
+
 		/*
 
 			*** Searching ***
@@ -118,6 +127,7 @@ class Librivox_API{
 
 		$result =  $this->db->select('p.*, l.language', false)
 			->join('languages l', 'p.language_id=l.id')
+			->order_by(('p.' . $sort_field), $sort_order)
 			->limit($limit, $offset)
 			->get('projects p')
 			->result_array();


### PR DESCRIPTION
very minor patch that adds some much-needed functionality to the API.

please test this before merging..
my PHP is very rusty..
nearly 20 years rusty..
but it seems like a very straight-forward update.