### PR TITLE
Add cover art to RSS feeds

### DIFF
--- a/application/views/rss/rss.php
+++ b/application/views/rss/rss.php
@@ -18,6 +18,11 @@
   <itunes:category text="Arts">
     <itunes:category text="Literature" />
   </itunes:category>
+  <?php
+  if ($project->coverart_jpg) {
+    echo sprintf('<itunes:image href="%s" />', $project->coverart_jpg);
+  }
+  ?>
   <!-- file loop -->
   <?php foreach($sections as $section): ?>
   <item>


### PR DESCRIPTION
Hi! I saw pull request #10 and I would like this feature too, so I thought I'd have a go reviving that since the PR seems a bit dead.

@kgroeneveld had some comments about it at the time:

> The coverart_jpg field is empty for some items in the catalog. Most other spots where the cover art is displayed will substitute a generic image in this case. I wonder if the RSS feed should do the same or if the RSS feed should just omit the image tag in this case? The pull request as is will result in an empty href in this case which doesn’t seem good.

I've changed the code to only render the `<itunes:image />` when the image is actually there. In the case where there is no cover art, I've just left it as-is and hopefully podcast apps do something sensible. (The app I'm using, Podcast Addict, just uses the book title with a random background colour if there's no art present, which is a nice default.)

> The Apple specs for the <itunes:image> tag (https://help.apple.com/itc/podcasts_connect/#/itcb54353390) specify the size must be minimum 1400x1400. I think most of the LibriVox images are a lot smaller than this. I am not sure how much that would matter.

The images I've seen are indeed smaller. I don't have an Apple device to test on, but it all works fine on Podcast Addict on Android, which is what I'm using. If I had to guess, I'd look at https://podcasters.apple.com/support/902-troubleshooting-artwork-issues, which seems to imply that the art just won't show if it doesn't meet the requirements? Hard to say

> I wonder if it would be better to use a standard RSS <image> instead of the itunes one? Or maybe include both? I don’t really have much experience with RSS...

I have no idea, sorry.