### PR TITLE
Reworks the pagination formatting

### DIFF
--- a/application/controllers/catalog/Author.php
+++ b/application/controllers/catalog/Author.php
@@ -44,7 +44,7 @@ class Author extends Catalog_controller
 
 		//pagination
 		$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
-		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);   // $first_page, $page_count
+		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);
 
 		$retval['status'] = 'SUCCESS';
 

--- a/application/controllers/catalog/Group.php
+++ b/application/controllers/catalog/Group.php
@@ -44,7 +44,7 @@ class Group extends Catalog_controller
 
 		//pagination
 		$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
-		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);   // $first_page, $page_count
+		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);
 
 		$retval['status'] = 'SUCCESS';
 

--- a/application/controllers/catalog/Reader.php
+++ b/application/controllers/catalog/Reader.php
@@ -51,7 +51,7 @@ class Reader extends Catalog_controller
 
 		//pagination
 		$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
-		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);   // $first_page, $page_count
+		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);
 
 		$retval['status'] = 'SUCCESS';
 

--- a/application/controllers/catalog/Search.php
+++ b/application/controllers/catalog/Search.php
@@ -197,7 +197,7 @@ class Search extends Catalog_controller
 			$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
 		}
 
-		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count, 'get_advanced_results');   // $first_page, $page_count
+		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count, 'get_advanced_results');
 
 		$retval['search_page'] = $input['search_page'];
 
@@ -297,7 +297,7 @@ class Search extends Catalog_controller
 
 			//pagination
 			$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
-			$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count, 'get_results');   // $first_page, $page_count
+			$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count, 'get_results');
 		}
 
 		$retval['status'] = 'SUCCESS';


### PR DESCRIPTION
See issue #32. This commit changes the pagination at the bottom of the page to better show how many pages are available. It doesn't include a "Go to X" field for jumping to a specific page.

I've also tweaked the requested format slightly - if there are fewer than ten pages, then we'll just show all of them.

Here's a demo video:

https://user-images.githubusercontent.com/5061320/232436456-ce596614-5b8a-43aa-8576-1f39bc4df3e2.mp4

