### PR TITLE
Adds language and section duration to project RSS

### DIFF
--- a/application/controllers/rss/Rss.php
+++ b/application/controllers/rss/Rss.php
@@ -69,6 +69,12 @@ class Rss extends Catalog_controller
 		{
 			$this->data['project']->title_bar .= ' by ' . $this->data['authors_string'];
 		}
+
+        $language_id = $this->data['project']->language_id;
+        if (!empty($language_id)) {
+            $this->load->model('language_model');
+            $this->data['language'] = $this->language_model->get($language_id);
+        }
 	}
 
 	function _build_sections()

--- a/application/views/rss/rss.php
+++ b/application/views/rss/rss.php
@@ -7,7 +7,13 @@
   <atom:link rel="self" href="https://librivox.org/rss/<?= $project->id ?>" />
   <description><![CDATA[<?= strip_tags($project->description) ?>]]></description>
   <!--<genre>project element=Genre</genre>-->
-  <!--<language>project element=lang.code</language>-->
+  <?php
+    if ($language->three_letter_code) { // Docs say two-letter, but three seems to validate
+      echo "<language>";
+      echo sprintf("<![CDATA[%s]]>", $language->three_letter_code);
+      echo "</language>";
+    }
+  ?>
   <itunes:type>serial</itunes:type>
   <itunes:author>LibriVox</itunes:author>
   <itunes:summary><![CDATA[<?= strip_tags($project->description) ?>]]></itunes:summary>
@@ -42,7 +48,9 @@
       <enclosure url="<?= $section->mp3_64_url?>" length="0" type="audio/mpeg" />
   <itunes:explicit>No</itunes:explicit>
   <itunes:block>No</itunes:block>
-  <itunes:duration><![CDATA[<?= $section->migrated_time?>]]></itunes:duration>
+  <itunes:duration>
+    <![CDATA[<?= $section->time ?>]]>
+  </itunes:duration>
   <!--<pubDate>file element=rss.pubDate</pubDate>-->
   <media:content url="<?= $section->mp3_64_url?>" type="audio/mpeg" />
  </item>

--- a/application/views/rss/rss.php
+++ b/application/views/rss/rss.php
@@ -8,10 +8,10 @@
   <description><![CDATA[<?= strip_tags($project->description) ?>]]></description>
   <!--<genre>project element=Genre</genre>-->
   <?php
-    if ($language->three_letter_code) { // Docs say two-letter, but three seems to validate
+    if (isset($language) && $language->three_letter_code) { // Docs say two-letter, but three seems to validate
       echo "<language>";
       echo sprintf("<![CDATA[%s]]>", $language->three_letter_code);
-      echo "</language>";
+      echo "</language>\n";
     }
   ?>
   <itunes:type>serial</itunes:type>


### PR DESCRIPTION
This adds two features to the project RSS feeds:

* Language support, using [ISO 639](http://www.loc.gov/standards/iso639-2/php/code_list.php) three-letter codes ([docs here suggest two-letter](https://help.apple.com/itc/podcasts_connect/#/itcb54353390), but the validator accepts three-letter, so I'm inclined to use that instead)
* Section duration - It turns out we already have the nicely-formatted duration there, we just needed to reference it. 


Something to look out for is that, when I looked at the scrubbed database, not all sections have a value for `playtime`, which is what is used to format the duration. In this case, the format function returns `00:00:00`, which isn't perfect but it's something. We could add an explicit check for that in the RSS code if we wanted to exclude the duration tags in that case, but I think it's probably fine as-is. Thoughts?