### PR TITLE
Add Librivox project id to archive.org metadata as call_number

### DIFF
--- a/application/controllers/private/Iarchive_upload.php
+++ b/application/controllers/private/Iarchive_upload.php
@@ -33,6 +33,7 @@ class Iarchive_upload extends Private_Controller
 		//I think we need to load these files one by one; I will investigate doing a single upload,
 		//but am worried about several technical issues
 
+		$params['project_id'] = $project->id;
 		$params['project_slug'] = $fields['upload_name'];
 		$params['title'] = $fields['upload_title'];
 		$params['file_location'] = $dir;

--- a/application/libraries/Iarchive_uploader.php
+++ b/application/libraries/Iarchive_uploader.php
@@ -69,6 +69,8 @@ class Iarchive_uploader
 		$headers[] = 'x-archive-meta-date:'.$params['date'];
 		$headers[] = 'x-archive-meta-subject:'.$params['subject'];
 		$headers[] = 'x-archive-meta-licenseurl:'.$params['licenseurl'];
+		$headers[] = 'x-archive-meta-call--number:'.$params['project_id'];
+
 
 	    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 

--- a/application/libraries/Iarchive_uploader.php
+++ b/application/libraries/Iarchive_uploader.php
@@ -71,7 +71,6 @@ class Iarchive_uploader
 		$headers[] = 'x-archive-meta-licenseurl:'.$params['licenseurl'];
 		$headers[] = 'x-archive-meta-call--number:'.$params['project_id'];
 
-
 	    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
 	    curl_setopt($ch, CURLOPT_VERBOSE, 1);


### PR DESCRIPTION
Currently the archive.org metadata provides no direct way to get the original LibriVox project id.

There is usually a link to the LibriVox project slug (the name, e.g. https://librivox.org/sense-and-sensibility-by-jane-austen/ ) in the archive.org `description` field, but the format varies.

This PR adds the project_id to a standard archive.org field [`call_number`](https://archive.org/developers/metadata-schema/index.html#call-number) to enable automated references back to LibriVox, for checking or accessing the original metadata etc.

Example screenshot showing where the call_number appears on the archive.org details page (this one, 620,  was added manually to https://archive.org/details/0_sense_and_sensibility_librivox ):
**Screenshot:**

![image](https://user-images.githubusercontent.com/905545/234124350-3b686b8b-0005-4de5-867e-11bc9dbdd30a.png)


**Background:**
I'm currently working on generating MARC records for archive.org audiobooks, investigating what metadata is required and available. Being able to include a LibriVox URL (e.g. https://librivox.org/620 ) is helpful, and provides a way to locate any other metadata that happens to be missing from archive.org if it is ever required.

Perhaps I should create a MARC issue for this work. I notice MARC export is a documented 'feature', but it appears to be aspirational :)  My current code is standalone Python, but once I can get the algorithm working and the output verified, I could port it to PHP, or alternatively have the MARC records generated for archive.org as part of a separate process, and librivox-catalog can link to a standard location for each item. I'm still trying to confirm the MARC output is correct and sufficiently detailed to be useful to libraries, so it's a bit proof-of-concept at this stage.  