### PR TITLE
Keep track of page numbers between refreshes

### DIFF
--- a/application/views/catalog/partials/footer.php
+++ b/application/views/catalog/partials/footer.php
@@ -15,6 +15,25 @@
 
 <script type="text/javascript">
 
+	function get_search_page_from_url() {
+		var query_string = window.location.href.slice(
+			window.location.href.indexOf('?')
+		);
+
+		if (typeof URLSearchParams !== 'function') {
+			// Manual parsing is annoying and most browsers support URLSearchParams
+			return 1;
+		}
+
+		var query_params = new URLSearchParams(query_string);
+		var search_page_param = parseInt(query_params.get('search_page'));
+		if (typeof search_page_param === 'number' && search_page_param > 0) {
+			return search_page_param;
+		} else {
+			return 1;
+		}
+	}
+
 	var search_category = <?= json_encode($search_category, JSON_HEX_TAG | JSON_HEX_QUOT); ?>;
 
 	var sub_category;
@@ -23,7 +42,7 @@
 
 	var primary_key = <?= (int)$primary_key ?>;
 
-	var search_page = <?= (int)(isset($search_page) ? $search_page : 1) ?>;
+	var search_page = get_search_page_from_url();
 	set_advanced_form_page(search_page);
 
 	var search_order = 'alpha';
@@ -360,6 +379,7 @@
 			return;
 		}
 
+		set_advanced_form_page(1); // This is a new search, so reset
 		librivox_search();
 
 		$('#sidebar_wrapper').show();
@@ -370,8 +390,6 @@
 
 	function librivox_search()
 	{
-		set_advanced_form_page(1); //this is a new search, so reset
-
 		search_order = 'alpha';
 
 		$('#advanced_search_form #sort_order').val('alpha'); // the code eventually serializes the form, so we need to set it to alpha here


### PR DESCRIPTION
This PR should help with some of issue #158, at least for the Author, Group, and Reader pages. 

On a page of search results, we're tracking the current page number in memory in the browser to know where we are. We also push that value into the history under the query param `search_page`.

However, when a user browses away and comes back, we don't make use of it. (The parameter isn't propagated by the PHP controller and it's not checked by the Javascript.)

Originally, I pushed this PR with a change to make sure the PHP controllers are passing through the `search_page`, but I decided that it would be better to have the frontend read the value instead. (I've left both commits in the PR, but I can squash them if you want the history kept tidy.)

Notably, I'm using [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams), which [isn't supported by every browser](https://caniuse.com/urlsearchparams), but is supported by most.