### PR TITLE
Form Generator - Require author and translator dates are numeric

### DIFF
--- a/application/controllers/public/Project_launch.php
+++ b/application/controllers/public/Project_launch.php
@@ -209,15 +209,15 @@ class Project_launch extends Public_Controller
 		$this->form_validation->set_rules('auth_id[]', 'Author id', 'trim|xss_clean');
 		$this->form_validation->set_rules('auth_first_name[]', 'lang:proj_launch_auth_first_name', 'trim|xss_clean');
 		$this->form_validation->set_rules('auth_last_name[]', 'lang:proj_launch_auth_last_name', 'trim|xss_clean');
-		$this->form_validation->set_rules('auth_yob[]', 'lang:proj_launch_auth_dob', 'trim|xss_clean');
-		$this->form_validation->set_rules('auth_yod[]', 'lang:proj_launch_auth_dod', 'trim|xss_clean');
+		$this->form_validation->set_rules('auth_yob[]', 'lang:proj_launch_auth_dob', 'trim|xss_clean|numeric');
+		$this->form_validation->set_rules('auth_yod[]', 'lang:proj_launch_auth_dod', 'trim|xss_clean|numeric');
 		$this->form_validation->set_rules('link_to_auth[]', 'lang:proj_launch_link_to_auth', 'trim|xss_clean|prep_url');
 
 		$this->form_validation->set_rules('trans_id[]', 'Translator id', 'trim|xss_clean|numeric');
 		$this->form_validation->set_rules('trans_first_name[]', 'lang:proj_launch_auth_first_name', 'trim|xss_clean');
 		$this->form_validation->set_rules('trans_last_name[]', 'lang:proj_launch_auth_last_name', 'trim|xss_clean');
-		$this->form_validation->set_rules('trans_yob[]', 'lang:proj_launch_trans_dob', 'trim|xss_clean');
-		$this->form_validation->set_rules('trans_yod[]', 'lang:proj_launch_trans_dod', 'trim|xss_clean');
+		$this->form_validation->set_rules('trans_yob[]', 'lang:proj_launch_trans_dob', 'trim|xss_clean|numeric');
+		$this->form_validation->set_rules('trans_yod[]', 'lang:proj_launch_trans_dod', 'trim|xss_clean|numeric');
 		$this->form_validation->set_rules('link_to_trans[]', 'lang:proj_launch_link_to_trans', 'trim|xss_clean');
 
 		$this->form_validation->set_rules('project_type', 'lang:proj_launch_type_of_project', 'trim|xss_clean|alpha_dash');

--- a/application/controllers/public/Project_launch.php
+++ b/application/controllers/public/Project_launch.php
@@ -223,19 +223,20 @@ class Project_launch extends Public_Controller
 		$this->form_validation->set_rules('project_type', 'lang:proj_launch_type_of_project', 'trim|xss_clean|alpha_dash');
 		$this->form_validation->set_rules('recorded_language', 'lang:proj_launch_recorded_language', 'trim|xss_clean|numeric');
 		$this->form_validation->set_rules('title', 'lang:proj_launch_title', 'trim|xss_clean|required');
+		$this->form_validation->set_rules('edition_year', 'lang:proj_launch_edition_year', 'trim|xss_clean|numeric');
 		$this->form_validation->set_rules('brief_summary', 'Brief Summary', 'trim|xss_clean');
 		$this->form_validation->set_rules('brief_summary_by', 'Brief Summary By', 'trim|xss_clean');
 		$this->form_validation->set_rules('link_to_text', 'lang:proj_launch_link_to_text_1', 'trim|xss_clean|prep_url');
 
 		$this->form_validation->set_rules('link_to_book', 'lang:proj_launch_link_to_book', 'trim|xss_clean|prep_url');
-		$this->form_validation->set_rules('pub_year', 'lang:proj_launch_pub_year', 'trim|xss_clean');
+		$this->form_validation->set_rules('pub_year', 'lang:proj_launch_pub_year', 'trim|xss_clean|numeric');
 
-		$this->form_validation->set_rules('expected_completion_year', 'lang:proj_launch_expected_completion', 'trim|xss_clean');
-		$this->form_validation->set_rules('expected_completion_month', 'lang:proj_launch_expected_completion', 'trim|xss_clean');
-		$this->form_validation->set_rules('expected_completion_day', 'lang:proj_launch_expected_completion', 'trim|xss_clean');
+		$this->form_validation->set_rules('expected_completion_year', 'lang:proj_launch_expected_completion', 'trim|xss_clean|numeric');
+		$this->form_validation->set_rules('expected_completion_month', 'lang:proj_launch_expected_completion', 'trim|xss_clean|numeric');
+		$this->form_validation->set_rules('expected_completion_day', 'lang:proj_launch_expected_completion', 'trim|xss_clean|numeric');
 
 		$this->form_validation->set_rules('proof_level', 'lang:proj_launch_proof_level', 'trim|xss_clean|alpha_dash');
-		$this->form_validation->set_rules('num_sections', 'lang:proj_launch_num_sections', 'trim|xss_clean');
+		$this->form_validation->set_rules('num_sections', 'lang:proj_launch_num_sections', 'trim|xss_clean|numeric');
 
 		$this->form_validation->set_rules('has_preface', 'lang:proj_launch_has_preface', 'trim|xss_clean|exact_length[1]');
 


### PR DESCRIPTION
This goes some way to addressing issue #154 -- users won't be able to enter non-numeric dates, which is unfortunate, but it does mean that they'll get a proper error message in the form instead of the random server error that they get right now.

For the more technical explanation -- When we save the form generation, that all goes into the `form_generators` table. Any new authors that are created as part of the generator are saved into `form_generators_authors`, which has the `auth_yob` and `auth_yod` columns as four-digit integers. This doesn't align well with the actual `authors` table, which allows pretty much anything (`varchar(10)`), and I have no idea how people specify AD vs. BCE using the generator (negative, maybe?).

I don't know enough about how the table is used to know whether we should consider migrating it to `varchar(10)` to match `authors`, but having the two consistent with each other would be good probably.

I also tried specifying the input fields as numeric in the HTML, but that didn't quite have the desired effect -- it would just submit the field as empty if it wasn't right, which meant we'd silently drop the data rather than get a validation error.

EDIT: I've added the `|numeric` to a few other fields that were missing it as well.