### PR TITLE
Low-Code Fixes

### DIFF
--- a/application/controllers/private/Validator.php
+++ b/application/controllers/private/Validator.php
@@ -56,7 +56,7 @@ class Validator extends Private_Controller
 		if (empty($this->data['project'])) redirect(base_url() . 'private/validator/select_project');
 
 		$this->data['project']->full_title = create_full_title($this->data['project']);
-		$this->data['project']->suggested_title = url_title(replace_accents($this->data['project']->full_title), '_', true);
+		$this->data['project']->suggested_title = substr(url_title(replace_accents($this->data['project']->full_title), '', true), 0, 21);
 		$this->data['project']->author_full_name = $this->_get_author_by_project($project_id);
 		$this->data['project']->author_last_name = $this->_get_author_by_project($project_id, 'last');
 

--- a/application/libraries/Keywords.php
+++ b/application/libraries/Keywords.php
@@ -106,20 +106,7 @@ class Keywords {
 	 */
 	public function add($keyword)
 	{
-		return $this->ci->keyword_m->insert(array('value' => self::prep($keyword)));
-	}
-
-	/**
-	 * Prepare Keyword
-	 *
-	 * Gets a keyword ready to be saved
-	 *
-	 * @param	string	$keyword
-	 * @return	bool
-	 */
-	public function prep($keyword)
-	{
-		return strtolower(trim($keyword));
+		return $this->ci->keyword_m->insert(array('value' => trim($keyword)));
 	}
 
 	/**
@@ -143,7 +130,7 @@ class Keywords {
 		$keywords = explode(',', $keywords);
 		foreach ($keywords as &$keyword)
 		{
-			$keyword = self::prep($keyword);
+			$keyword = trim($keyword);
 			// Keyword already exists
 			if (($row = $this->ci->db->where('value', $keyword)->get('keywords')->row()))
 			{

--- a/application/views/public/project_launch/index.php
+++ b/application/views/public/project_launch/index.php
@@ -18,8 +18,6 @@
                <a href="<?= base_url()?>workflow" class="menu_link">LibriVox Dashboard</a>
                <a href="https://forum.librivox.org" class="menu_link">LibriVox Forum</a>
                <a href="<?= base_url()?>pages/workflow-help" class="menu_link">Help</a>
-               <br />
-               <?= form_dropdown('lang_select', $languages, $current_lang , 'id="lang_select" style="float:right;margin-top:20px;"'); ?>
           </div>
      </div>
 
@@ -30,6 +28,15 @@
 
                <?= validation_errors('<div class="alert alert-error">', '</div>'); ?>
                <div id="showErrors"></div>
+
+               <fieldset class="fieldset-margin">
+                    <legend><?= lang('proj_launch_choose_lang'); ?></legend>
+                    <div class="control-group">
+                         <div class="controls center">
+                              <?= form_dropdown('lang_select', $languages, $current_lang , 'id="lang_select"'); ?>
+                         </div>
+                    </div>
+               </fieldset>
 
                <fieldset class="fieldset-margin">  
                     <legend><?= lang('proj_launch_project'); ?></legend> 
@@ -303,4 +310,4 @@
      </div>
 </div>
 
-</form>    
+</form>


### PR DESCRIPTION
Well, there goes my attempt to keep the commit history clean.  I'm still getting the hang of git, let alone GitHub.  :neutral_face: 

Here's a collection of fixes with a relatively low code complexity.   I don't know if it's easier to accept these changes all from the same branch in one PR, or to keep them entirely separate.  For anything more than a very few lines of code, I'll definitely go for a separate PR.

Fixes #44 - no underscores, and the title portion of the suggested validator name is capped at 22 characters.  This makes for a max of 32 characters by the time the '_YYMM' and sometimes '.poem' are added.

Fixes #74 - we already had the translation string for "Select a language for your template", so I've added it as a heading and moved the language selection box down from the corner.

Fixes #43 - the 'prep' function would lowercase the tag names and trim them.  I've replaced calls to 'prep' with calls to 'trim', and removed the now-redundant function.
