### PR TITLE
Shorter validator names

### DIFF
--- a/application/controllers/private/Validator.php
+++ b/application/controllers/private/Validator.php
@@ -56,7 +56,7 @@ class Validator extends Private_Controller
 		if (empty($this->data['project'])) redirect(base_url() . 'private/validator/select_project');
 
 		$this->data['project']->full_title = create_full_title($this->data['project']);
-		$this->data['project']->suggested_title = url_title(replace_accents($this->data['project']->full_title), '_', true);
+		$this->data['project']->suggested_title = substr(url_title(replace_accents($this->data['project']->full_title), '', true), 0, 22);
 		$this->data['project']->author_full_name = $this->_get_author_by_project($project_id);
 		$this->data['project']->author_last_name = $this->_get_author_by_project($project_id, 'last');
 

--- a/application/controllers/private/Validator.php
+++ b/application/controllers/private/Validator.php
@@ -56,7 +56,7 @@ class Validator extends Private_Controller
 		if (empty($this->data['project'])) redirect(base_url() . 'private/validator/select_project');
 
 		$this->data['project']->full_title = create_full_title($this->data['project']);
-		$this->data['project']->suggested_title = substr(url_title(replace_accents($this->data['project']->full_title), '', true), 0, 22);
+		$this->data['project']->suggested_title = substr(url_title(replace_accents($this->data['project']->full_title), '', true), 0, 21);
 		$this->data['project']->author_full_name = $this->_get_author_by_project($project_id);
 		$this->data['project']->author_last_name = $this->_get_author_by_project($project_id, 'last');
 

--- a/application/controllers/private/Validator.php
+++ b/application/controllers/private/Validator.php
@@ -56,7 +56,7 @@ class Validator extends Private_Controller
 		if (empty($this->data['project'])) redirect(base_url() . 'private/validator/select_project');
 
 		$this->data['project']->full_title = create_full_title($this->data['project']);
-		$this->data['project']->suggested_title = substr(url_title(replace_accents($this->data['project']->full_title), '', true), 0, 21);
+		$this->data['project']->suggested_title = substr(url_title(replace_accents($this->data['project']->full_title), '', true), 0, 39);
 		$this->data['project']->author_full_name = $this->_get_author_by_project($project_id);
 		$this->data['project']->author_last_name = $this->_get_author_by_project($project_id, 'last');
 


### PR DESCRIPTION
Fixes #44 
Seems like we can go up to 90 characters, but 40 (+ '_YYMM' + '.poem' = 50) ought to be enough.
See admin forum post: https://forum.librivox.org/viewtopic.php?p=2278465#p2278465