### PR TITLE
[WIP] Keep capitalization on keywords/tags

### DIFF
--- a/application/libraries/Keywords.php
+++ b/application/libraries/Keywords.php
@@ -106,20 +106,7 @@ class Keywords {
 	 */
 	public function add($keyword)
 	{
-		return $this->ci->keyword_m->insert(array('value' => self::prep($keyword)));
-	}
-
-	/**
-	 * Prepare Keyword
-	 *
-	 * Gets a keyword ready to be saved
-	 *
-	 * @param	string	$keyword
-	 * @return	bool
-	 */
-	public function prep($keyword)
-	{
-		return strtolower(trim($keyword));
+		return $this->ci->keyword_m->insert(array('value' => trim($keyword)));
 	}
 
 	/**
@@ -143,7 +130,7 @@ class Keywords {
 		$keywords = explode(',', $keywords);
 		foreach ($keywords as &$keyword)
 		{
-			$keyword = self::prep($keyword);
+			$keyword = trim($keyword);
 			// Keyword already exists
 			if (($row = $this->ci->db->where('value', $keyword)->get('keywords')->row()))
 			{


### PR DESCRIPTION
Fixes #43
The 'prep' function would call 'trim' and 'strtolower' on any given keyword.  I've replaced both calls to 'prep' with just 'trim'.  No more lowercase, and we can remove that function.