### PR TITLE
Show 'Assign reader sections' by default for 'open' projects

### DIFF
--- a/public_html/js/private/section_compiler/index.js
+++ b/public_html/js/private/section_compiler/index.js
@@ -356,6 +356,14 @@ $(document).ready(function() {
 		$('.add_btn').show(300);
 	});
 
+	// Show the 'Assign reader sections' button by default, if the project status is 'open'
+	var project_status = $('#status').val();
+	if (project_status == 'open')
+	{
+		$('#assign_reader_toggle').hide();
+		$('#assign_reader_div').show();
+	}
+
 
 });
 


### PR DESCRIPTION
Fixes #65 
Any project with status 'open' will have the 'assign reader section' controls open by default.  Projects with any other status - full, validation, proof-listing, etc., will still be able to open the controls by clicking as we do now.