### PR TITLE
Fix slow spinner using the main nav from the author page

### DIFF
--- a/application/controllers/catalog/Author.php
+++ b/application/controllers/catalog/Author.php
@@ -11,6 +11,10 @@ class Author extends Catalog_controller
 
 	public function index($author_id)
 	{
+		if (empty($author_id)) {
+			show_404();
+		}
+
 		$this->load->model('author_model');
 		$this->data['author'] = $this->author_model->get($author_id);
 
@@ -29,14 +33,19 @@ class Author extends Catalog_controller
 	{
 		//collect - search_category, sub_category, page_number, sort_order
 		$input = $this->input->get(null, true);
+		$author_id = $input['primary_key'];
+
+		if (empty($author_id)) {
+			show_error('A primary_key (author ID) must be supplied', 400);
+		}
 
 		//format offset
 		$offset = ($input['search_page'] - 1) * CATALOG_RESULT_COUNT;
 
 		// go get results
-		$results = $this->_get_all_author($input['primary_key'], $offset, CATALOG_RESULT_COUNT, $input['search_order'], $input['project_type']);
+		$results = $this->_get_all_author($author_id, $offset, CATALOG_RESULT_COUNT, $input['search_order'], $input['project_type']);
 
-		$full_set = $this->_get_all_author($input['primary_key'], 0, 1000000, 'alpha', $input['project_type']);
+		$full_set = $this->_get_all_author($author_id, 0, 1000000, 'alpha', $input['project_type']);
 		//$retval['sql'] = $this->db->last_query();
 
 		// go format results

--- a/application/controllers/catalog/Group.php
+++ b/application/controllers/catalog/Group.php
@@ -11,6 +11,10 @@ class Group extends Catalog_controller
 
 	public function index($group_id)
 	{
+		if (empty($group_id)) {
+			show_404();
+		}
+
 		$this->load->model('group_model');
 		$this->data['group'] = $this->group_model->get($group_id);
 
@@ -29,14 +33,19 @@ class Group extends Catalog_controller
 	{
 		//collect - search_category, sub_category, page_number, sort_order
 		$input = $this->input->get(null, true);
+		$group_id = $input['primary_key'];
+
+		if (empty($group_id)) {
+			show_error('A primary_key (group ID) must be supplied', 400);
+		}
 
 		//format offset
 		$offset = ($input['search_page'] - 1) * CATALOG_RESULT_COUNT;
 
 		// go get results
-		$results = $this->_get_all_group_projects($input['primary_key'], $offset, CATALOG_RESULT_COUNT);
+		$results = $this->_get_all_group_projects($group_id, $offset, CATALOG_RESULT_COUNT);
 
-		$full_set = $this->_get_all_group_projects($input['primary_key'], 0, 1000000);
+		$full_set = $this->_get_all_group_projects($group_id, 0, 1000000);
 		//$retval['sql'] = $this->db->last_query();
 
 		// go format results

--- a/application/controllers/catalog/Reader.php
+++ b/application/controllers/catalog/Reader.php
@@ -11,6 +11,10 @@ class Reader extends Catalog_controller
 
 	public function index($reader_id)
 	{
+		if (empty($reader_id)) {
+			show_404();
+		}
+
 		$this->load->model('user_model');
 		$this->data['reader'] = $this->user_model->as_array()->get($reader_id);
 
@@ -36,14 +40,19 @@ class Reader extends Catalog_controller
 	{
 		//collect - search_category, sub_category, page_number, sort_order
 		$input = $this->input->get(null, true);
+		$reader_id = $input['primary_key'];
+
+		if (empty($reader_id)) {
+			show_error('A primary_key (reader ID) must be supplied', 400);
+		}
 
 		//format offset
 		$offset = ($input['search_page'] - 1) * CATALOG_RESULT_COUNT;
 
 		// go get results
-		$results = $this->_get_all_reader($input['primary_key'], $offset, CATALOG_RESULT_COUNT, $input['search_order'], $input['project_type']);
+		$results = $this->_get_all_reader($reader_id, $offset, CATALOG_RESULT_COUNT, $input['search_order'], $input['project_type']);
 
-		$full_set = $this->_get_all_reader($input['primary_key'], 0, 1000000, 'alpha', $input['project_type']);
+		$full_set = $this->_get_all_reader($reader_id, 0, 1000000, 'alpha', $input['project_type']);
 		//$retval['sql'] = $this->db->last_query();
 
 		// go format results

--- a/application/views/catalog/partials/footer.php
+++ b/application/views/catalog/partials/footer.php
@@ -120,6 +120,7 @@
 		if (current_page !== 'search')
 		{
 			window.location.href = CI_ROOT + 'search/' + search_category;
+			return;
 		}	
 
 		e.preventDefault();


### PR DESCRIPTION
(Note: This was a problem for me on Firefox 121, I haven't tried other browsers.)

When I'm on an author page, and I click on one of the main nav items, I get a _really_ long spinner. There are two problems that seem to play in together to give this result.

In the Javascript that handles menu item clicks in `footer.php`, we try to do a redirect to `/search/<category>`, but we don't actually stop execution there - the script keeps going. It sets up a spinner and tries to fetch new results etc.

This is the first problem - the results it tries to load are always from `/author/get_results` rather than from `/search/get_results`. The page seems to wait until that call has resolved before doing the redirect to `/search/<category>` and loading the _actual_ search results. I've changed this handler to return immediately instead.

What exacerbated the problem for the author search is that the search would fetch `/author/get_results` with `primary_key=0`, so the backend would try to load every author and then every title for each of them, which was a lot. On my machine, it would eventually run out of memory and fail the request. You can get similar behavior by browsing to `https://librivox.org/author/0` (but maybe do it locally).

The reader and group pages had the same problems, but their `/get_results` endpoints failed quickly if you passed in `primary_key=0`, so it wasn't as noticeable.

I've changed the controllers to explicitly check for empty/zero IDs before they try to run anything.