### PR TITLE
Minor - Remove PHP short tags

### DIFF
--- a/application/views/private/administer_projects/add_catalog_item.php
+++ b/application/views/private/administer_projects/add_catalog_item.php
@@ -173,16 +173,16 @@
                                                                  <?php $class = (empty($grandchild['children']))? '': 'dropdown-submenu' ; ?>
 
                                                                  <li class="<?= $class ?>  level-3"><a class="genre_item" data-id="<?= $grandchild['id'];?>" data-level="3"  data-name="<?= $grandchild['name'];?>"><?= $grandchild['name'];?></a></li>
-                                                            <? endforeach; ?>             
+                                                            <?php endforeach; ?>
                                                        </ul>
                                                   <?php endif ?>
                                                   </li>
 
-                                             <? endforeach; ?>             
+                                             <?php endforeach; ?>
                                         </ul>
                                    <?php endif ?>
                               </li>
-                         <? endforeach; ?>
+                         <?php endforeach; ?>
                          </ul>
                     </div>                 
                </div>

--- a/application/views/public/project_launch/index.php
+++ b/application/views/public/project_launch/index.php
@@ -192,16 +192,16 @@
                                                                            <?php $class = (empty($grandchild['children']))? '': 'dropdown-submenu' ; ?>
 
                                                                            <li class="<?= $class ?>  level-3"><a class="genre_item" data-id="<?= $grandchild['id'];?>" data-level="3"  data-name="<?= $grandchild['name'];?>"><?= $grandchild['name'];?></a></li>
-                                                                      <? endforeach; ?>             
+                                                                      <?php endforeach; ?>
                                                                  </ul>
                                                             <?php endif ?>
                                                             </li>
 
-                                                       <? endforeach; ?>             
+                                                       <?php endforeach; ?>
                                                   </ul>
                                              <?php endif ?>
                                         </li>
-                                   <? endforeach; ?>
+                                   <?php endforeach; ?>
                                    </ul>
                               </div>                 
                          </div>
@@ -303,4 +303,4 @@
      </div>
 </div>
 
-</form>    
+</form>

--- a/application/views/test/test_genres.php
+++ b/application/views/test/test_genres.php
@@ -119,10 +119,10 @@ Genres:
 						<?php $class = (empty($child['children']))? '': 'dropdown-submenu' ; ?>
 
 						<li class="<?= $class ?>  level-2"><a class="genre_item" data-id="<?= $child['id'];?>" data-level="2"  data-name="<?= $child['name'];?>"><?= $child['name'];?></a></li>
-					<? endforeach; ?>			
+					<?php endforeach; ?>
 				</ul>
 			<?php endif ?>
 		</li>
-	<? endforeach; ?>
+	<?php endforeach; ?>
 	</ul>
 </div>


### PR DESCRIPTION
This commit removes the short tags (`<? ?>`) in favour of the long ones (`<?php ?>`).

I was messing around with `ci-phpunit-test` to see if I could figure out how to write unit tests for some of the PHP code, and I ran across some warnings where the coverage tooling didn't understand short tags properly.

As a bonus, this makes us more compliant with PSR-1.