### PR TITLE
Render newlines in Project page description

### DIFF
--- a/application/controllers/catalog/Page.php
+++ b/application/controllers/catalog/Page.php
@@ -81,6 +81,9 @@ class Page extends Catalog_controller
 		//$this->data['sections'] = $this->section_model->as_array()->get_many_by(array('project_id'=>$this->data['project']->id));
 		$this->data['sections'] = $this->section_model->get_full_sections_info($this->data['project']->id);
 
+		$this->load->helper('description_html_render');
+		$this->data['project']->description = _normalize_and_deduplicate_newlines_in_html($this->data['project']->description);
+
 		//var_dump($this->data['sections']);
 		if (!empty($this->data['sections']))
 		{

--- a/application/helpers/description_html_render_helper.php
+++ b/application/helpers/description_html_render_helper.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * For a while, newlines weren't being rendered properly in the catalog HTML,
+ * so people put manual <br /> tags into project descriptions. Now, we want to
+ * render the newlines properly, so we need to try and dedupe a bit so that we
+ * don't have crazy amounts of whitespace.
+ *
+ * Inspired by this post: https://www.darklaunch.com/php-normalize-newlines-line-endings-crlf-cr-lf-unix-windows-mac.html
+ *
+ * $description string The description to render as HTML
+ */
+function _normalize_and_deduplicate_newlines_in_html($description) {
+	// Normalise everything to '\n' characters
+	$description = str_replace(
+		array("<br>", "<br />", "\r\n"),
+		"\n",
+		$description
+	);
+
+	// Replace suspiciously-long strings of newlines
+	$description = preg_replace(
+		"/\n{3,}/",
+		"\n\n",
+		$description,
+	);
+
+	// Turn the newlines into '<br />' tags
+	// return nl2br($description);
+	return str_replace(
+		"\n",
+		"<br />",
+		$description,
+	);
+}


### PR DESCRIPTION
This PR is an attempt to address issue #188.

For a while, newlines in Project descriptions weren't being rendered properly in the catalog HTML, so people put manual `<br />` tags into them.

Now, we want to render the newlines as they are in the admin screens, but that could cause extra unintended whitespace for projects that already have manual `<br />` tags in them, so we normalize all of the different kinds of "newline" and strip some out if there are too many in a row.

(If this works as intended, then we can apply the same thing to the author pages as well.)