### PR TITLE
Expand tests for description HTML formatting

### DIFF
--- a/application/tests/helpers/Description_html_render_helper_test.php
+++ b/application/tests/helpers/Description_html_render_helper_test.php
@@ -9,8 +9,8 @@ class Description_html_render_helper_test extends TestCase
 	}
 
 	/**
-     * @dataProvider provider
-     */
+	* @dataProvider provider
+	*/
 	public function test_newline_smushing_works($input, $expected) {
 		$actual = _normalize_and_deduplicate_newlines_in_html($input);
 		$this->assertEquals($expected, $actual);
@@ -21,7 +21,26 @@ class Description_html_render_helper_test extends TestCase
 			// Simple case
 			array("a b", "a b"),
 
-			/** A bunch of cases omitted for brevity **/
+			// Multiple newlines
+			array("a\nb",     "a<br />b"),
+			array("a\n\nb",   "a<br /><br />b"),
+			array("a\n\n\nb", "a<br /><br />b"),
+
+			// Multiple carriage returns + newlines
+			array("a\r\nb",         "a<br />b"),
+			array("a\r\n\r\nb",     "a<br /><br />b"),
+			array("a\r\n\r\n\r\nb", "a<br /><br />b"),
+
+			// Multiple <br /> tags
+			array("a<br />b",             "a<br />b"),
+			array("a<br /><br />b",       "a<br /><br />b"),
+			array("a<br /><br /><br />b", "a<br /><br />b"),
+
+			// Multiple <br> tags
+			array("a<br>b",             "a<br />b"),
+			array("a<br><br>b",         "a<br /><br />b"),
+			array("a<br><br><br>b",     "a<br /><br />b"),
+			array("a<br><br><br><br>b", "a<br /><br />b"),
 
 			// Mixed "newline" things
 			array("a<br>\n<br />b",       "a<br /><br />b"),


### PR DESCRIPTION
I posted this test as an example when I suggetsed adding ci-phpunit-test, but I had left out a bunch of the actual test cases to keep the description short :slightly_smiling_face: 