### PR TITLE
Validate author field length on template generator

### DIFF
--- a/application/controllers/public/Project_launch.php
+++ b/application/controllers/public/Project_launch.php
@@ -207,11 +207,11 @@ class Project_launch extends Public_Controller
 		$this->form_validation->set_rules('lang_select', 'Language Selector', 'trim|required|xss_clean');
 
 		$this->form_validation->set_rules('auth_id[]', 'Author id', 'trim|xss_clean');
-		$this->form_validation->set_rules('auth_first_name[]', 'lang:proj_launch_auth_first_name', 'trim|xss_clean');
-		$this->form_validation->set_rules('auth_last_name[]', 'lang:proj_launch_auth_last_name', 'trim|xss_clean');
-		$this->form_validation->set_rules('auth_yob[]', 'lang:proj_launch_auth_dob', 'trim|xss_clean');
-		$this->form_validation->set_rules('auth_yod[]', 'lang:proj_launch_auth_dod', 'trim|xss_clean');
-		$this->form_validation->set_rules('link_to_auth[]', 'lang:proj_launch_link_to_auth', 'trim|xss_clean|prep_url');
+		$this->form_validation->set_rules('auth_first_name[]', 'lang:proj_launch_auth_first_name', 'trim|xss_clean|max_length[255]');
+		$this->form_validation->set_rules('auth_last_name[]', 'lang:proj_launch_auth_last_name', 'trim|xss_clean|max_length[255]');
+		$this->form_validation->set_rules('auth_yob[]', 'lang:proj_launch_auth_dob', 'trim|xss_clean|max_length[255]');
+		$this->form_validation->set_rules('auth_yod[]', 'lang:proj_launch_auth_dod', 'trim|xss_clean|max_length[255]');
+		$this->form_validation->set_rules('link_to_auth[]', 'lang:proj_launch_link_to_auth', 'trim|xss_clean|prep_url|max_length[255]');
 
 		$this->form_validation->set_rules('trans_id[]', 'Translator id', 'trim|xss_clean|numeric');
 		$this->form_validation->set_rules('trans_first_name[]', 'lang:proj_launch_auth_first_name', 'trim|xss_clean');

--- a/application/tests/controllers/public/Project_launch_test.php
+++ b/application/tests/controllers/public/Project_launch_test.php
@@ -1,0 +1,98 @@
+<?php
+
+class Project_launch_test extends TestCase
+{
+	public function test_long_author_names_show_validation_errors() {
+		$response = $this->request(
+			'POST',
+			'add_project',
+			[
+				'lang_select' => 'english',
+				'title' => 'aoeu',
+				'is_compilation' => '0',
+				'link_to_text' => 'aoeu',
+				'project_type' => 'solo',
+				'expected_completion_year' => '0',
+				'expected_completion_month' => '0',
+				'expected_completion_day' => '0',
+				'recorded_language' => '1',
+				'recorded_language_other' => '',
+				'auth_id' => '0',
+				'auth_last_name' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+				'auth_first_name' => '',
+				'auth_yob' => '',
+				'auth_yod' => '',
+				'link_to_auth' => '',
+				'trans_id' => '0',
+				'trans_last_name' => '',
+				'trans_first_name' => '',
+				'trans_yob' => '',
+				'trans_yod' => '',
+				'link_to_trans' => '',
+				'edition_year' => '',
+				'brief_summary' => '',
+				'brief_summary_by' => '',
+				'link_to_book' => '',
+				'pub_year' => '',
+				'genres' => '',
+				'list_keywords' => '',
+				'proof_level' => 'standard',
+				'has_preface' => '0',
+				'num_sections' => '1',
+				'forum_name' => '',
+				'soloist_name' => '',
+				'soloist_link' => '',
+			],
+		);
+		$this->assertResponseCode(200);
+		$this->assertStringContainsString('Last name field can not exceed 255 characters in length', $response);
+	}
+
+	public function test_long_author_links_show_validation_errors() {
+		$response = $this->request(
+			'POST',
+			'add_project',
+			[
+				'lang_select' => 'english',
+				'title' => 'aoeu',
+				'is_compilation' => '0',
+				'link_to_text' => 'aoeu',
+				'project_type' => 'solo',
+				'expected_completion_year' => '0',
+				'expected_completion_month' => '0',
+				'expected_completion_day' => '0',
+				'recorded_language' => '1',
+				'recorded_language_other' => '',
+				'auth_id' => '0',
+				'auth_last_name' => 'aaaaa',
+				'auth_first_name' => '',
+				'auth_yob' => '',
+				'auth_yod' => '',
+				'link_to_auth' => 'https://en.wikipedia.org/wiki/Jos%C3%A9_Joaqu%C3%ADn_Fern%C3%A1ndez_de_Lizardiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+				'trans_id' => '0',
+				'trans_last_name' => '',
+				'trans_first_name' => '',
+				'trans_yob' => '',
+				'trans_yod' => '',
+				'link_to_trans' => '',
+				'edition_year' => '',
+				'brief_summary' => '',
+				'brief_summary_by' => '',
+				'link_to_book' => '',
+				'pub_year' => '',
+				'genres' => '',
+				'list_keywords' => '',
+				'proof_level' => 'standard',
+				'has_preface' => '0',
+				'num_sections' => '1',
+				'forum_name' => '',
+				'soloist_name' => '',
+				'soloist_link' => '',
+			],
+		);
+		$this->assertResponseCode(200);
+		$this->assertStringContainsString('Link to author on Wikipedia field can not exceed 255 characters in length', $response);
+	}
+}
+
+?>


### PR DESCRIPTION
I think a lot of the blank screen/500 ERROR messages that people in the forums have encountered with the template generator might be related to missing field length validations on the author fields -- When users enter a name that's too long, the database insert fails, which gives an ugly 500 error.

This PR doesn't solve the underlying problem, which is that the database fields are quite short, but it does at least highlight the issue for users so that they have a better idea of what's wrong. Ideally, it'd be good to bump the limits in the database at the same time so that people don't hit them so often. (Especially the author link length limit, 55 chars is nothing in terms of URL length.)

Unfortunately, this seems to reset most of the form state, so they have to enter it again, but that's no worse than what happens with the error message anyway as far as I understand it.

(For your reviewing convenience, here's a `SHOW COLUMNS` for the two author tables.)

```
MariaDB [librivox_catalog]> SHOW COLUMNS FROM form_generators_authors;
+-----------------+-------------+------+-----+---------+----------------+
| Field           | Type        | Null | Key | Default | Extra          |
+-----------------+-------------+------+-----+---------+----------------+
| auth_id         | int(11)     | NO   | PRI | NULL    | auto_increment |
| auth_first_name | varchar(55) | YES  |     | NULL    |                |
| auth_last_name  | varchar(55) | YES  |     | NULL    |                |
| auth_yob        | varchar(10) | YES  |     | NULL    |                |
| auth_yod        | varchar(10) | YES  |     | NULL    |                |
| link_to_auth    | varchar(55) | YES  |     | NULL    |                |
+-----------------+-------------+------+-----+---------+----------------+

MariaDB [librivox_catalog]> SHOW COLUMNS FROM authors;
+-------------------+-------------+------+-----+---------+----------------+
| Field             | Type        | Null | Key | Default | Extra          |
+-------------------+-------------+------+-----+---------+----------------+
| id                | int(11)     | NO   | PRI | NULL    | auto_increment |
| first_name        | varchar(55) | YES  |     | NULL    |                |
| last_name         | varchar(55) | NO   |     | NULL    |                |
| psuedo_first_name | varchar(55) | YES  |     | NULL    |                |
| psuedo_last_name  | varchar(55) | YES  |     | NULL    |                |
| author_url        | text        | YES  |     | NULL    |                |
| other_url         | text        | YES  |     | NULL    |                |
| image_url         | text        | YES  |     | NULL    |                |
| dob               | varchar(10) | YES  |     | NULL    |                |
| dod               | varchar(10) | YES  |     | NULL    |                |
| name_hash         | varchar(32) | YES  |     | NULL    |                |
| confirmed         | int(1)      | NO   |     | 0       |                |
| linked_to         | int(11)     | NO   |     | 0       |                |
| blurb             | text        | YES  |     | NULL    |                |
| meta_complete     | int(4)      | NO   |     | 0       |                |
| meta_in_progress  | int(4)      | NO   |     | 0       |                |
+-------------------+-------------+------+-----+---------+----------------+
```