### PR TITLE
Remove Google Analytics

### DIFF
--- a/application/views/catalog/partials/footer.php
+++ b/application/views/catalog/partials/footer.php
@@ -462,18 +462,3 @@
 
 
 </script>
-
-<script type="text/javascript">
-
- var _gaq = _gaq || [];
- _gaq.push(['_setAccount', 'UA-1429228-8']);
- _gaq.push(['_setDomainName', 'librivox.org']);
- _gaq.push(['_trackPageview']);
-
- (function() {
-  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-
- </script>


### PR DESCRIPTION
We've had some users complain about the Ghostery extension flagging
these. As far as we know, they're unused, so remove them.
