### PR TITLE
Use spacing helper in Archive uploads, and fix display of older items in the catalog

### DIFF
--- a/application/controllers/private/Iarchive_upload.php
+++ b/application/controllers/private/Iarchive_upload.php
@@ -41,6 +41,7 @@ class Iarchive_upload extends Private_Controller
 		//additional params
 		$this->load->model('author_model');
 		$this->load->model('keyword_model');
+		$this->load->helper('description_html_render');
 
 		$params['creator'] = $this->author_model->create_author_list($project->id, 'author');
 		$params['date'] = date('Y-m-d');
@@ -48,7 +49,7 @@ class Iarchive_upload extends Private_Controller
 		$params['licenseurl'] = LICENSE_LINK;
 
 		$description = $this->_get_full_description($params, $project);
-		$params['description'] = trim(preg_replace('/\s+/', ' ', $description));  //trims all newlines before placing in header
+		$params['description'] = _normalize_and_deduplicate_newlines_in_html($description);  //Standardizes whitespace, replacing newlines with <br /> tags
 		$params['language'] = $this->data['language_code'];
 
 		// Close db connection before uploading to avoid hogging connections

--- a/application/helpers/description_html_render_helper.php
+++ b/application/helpers/description_html_render_helper.php
@@ -12,8 +12,8 @@
  */
 function _normalize_and_deduplicate_newlines_in_html($description) {
 	// Normalise everything to '\n' characters
-	$description = str_replace(
-		array("<br>", "<br />", "\r\n"),
+	$description = preg_replace(
+		array("/<br ?\/?>\r?\n?/i", "/\r\n?/"),
 		"\n",
 		$description
 	);

--- a/application/tests/helpers/Description_html_render_helper_test.php
+++ b/application/tests/helpers/Description_html_render_helper_test.php
@@ -48,6 +48,10 @@ class Description_html_render_helper_test extends TestCase
 			array("a<br>\n\r\n<br />b",   "a<br /><br />b"),
 			array("a\n<br />\r\n<br />b", "a<br /><br />b"),
 			array("a\n\r\n<br />b",       "a<br /><br />b"),
+
+			// Case sensitivity, and deduplicating newlines following tags
+			array("a<BR>\r\n<BR />\r\nb", "a<br /><br />b"),
+			array("a<bR>\n<Br/>\rb",      "a<br /><br />b"),
 		);
 	}
 }

--- a/application/views/private/validator/archive_description.php
+++ b/application/views/private/validator/archive_description.php
@@ -1,5 +1,5 @@
 <a href="https://librivox.org/">LibriVox</a> recording of <?= $title ?> by <?= $authors ?>. <?= $translators ?><br />
-Read in <?= $language ?> by <?= $readers ?><br />
-<?= $description ?><br />
+Read in <?= $language ?> by <?= $readers ?><br /><br />
+<?= $description ?><br /><br />
 For further information, including links to online text, reader information, RSS feeds, CD cover or other formats (if available), please go to the <a href="<?= $catalog_url ?>">LibriVox catalog page</a> for this recording.<br /><br />
 For more free audio books or to become a volunteer reader, visit <a href="https://librivox.org/">librivox.org</a>.<br /><br />


### PR DESCRIPTION
Got admin consensus for this one:  :+1: 

The regex version will collapse any br that is immediately followed by a \n, a \r, or both, into just a single newline.  That fixes display of old cast lists and such on our catalog pages.  Added a few more test cases to address this, and possible capitalization differences.

Then we use the helper on Archive uploads, so both are consistent.  Also add an extra space before and after the item description, as these are manually added by MCs right now.