### PR TITLE
Alert Advanced Search users there are flexible search for our collection at Internet Archive

### DIFF
--- a/application/views/catalog/partials/advanced_search.php
+++ b/application/views/catalog/partials/advanced_search.php
@@ -100,10 +100,9 @@
 	              </button>
 	         </div>
 	       </div>
-
-               <h5>Still can't find what you're looking for? Try searching <a href="https://archive.org/details/librivoxaudio">Internet Archive's LibriVox Audiobook Collection</a>
-                 by title, author, reader, key terms, or terms appearing in book descriptions.
-               </h5>
+		
+		<h4>Couldn't find what you're looking for?</h4>
+		<h5>You can also try searching for Librivox audiobooks by title, author, reader, key terms, or terms appearing in book descriptions at <A href="https://archive.org/details/librivoxaudio?tab=collection" target="_blank">Internet Archive Librivox Free Audiobook Collection.</A> </h5>
 
 	       <input type="hidden" name="search_page" id="search_page" value="1">
 	       <input type="hidden" name="search_form" id="search_form" value="advanced">


### PR DESCRIPTION
This view change adds some text beneath the Advanced Search Submit button.
The general idea was first discussed here: https://forum.librivox.org/viewtopic.php?t=101695&start=90 (see for example my post in this thread dated 3 March,2024, 9:32 am). 
On 6 March redrun appeared to indicate that some change of this sort should move forward.
I have slightly altered the text from what I originally suggested.