### PR TITLE
[Sanity Check] Run query once per search

### DIFF
--- a/application/controllers/catalog/Search.php
+++ b/application/controllers/catalog/Search.php
@@ -177,24 +177,12 @@ class Search extends Catalog_controller
 
 		if (count($this->data['results']) > 0)
 		{
-			// TODO: rewrite this to only return count, not full dataset
-
 			$retval['results'] = $this->_manage_result_set($this->data['results']);
 
 			//pagination
-			$input['offset'] = 0;
-			$input['limit'] = 1000000;
+			$full_count = $this->data['results'][0]['full_count'];
 
-			if (!empty($input['q']))
-			{
-				$full_set = $this->librivox_simple_search->simple_search($input);
-			}
-			else
-			{
-				$full_set = $this->librivox_search->advanced_title_search($input);
-			}
-
-			$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
+			$page_count = ($full_count > CATALOG_RESULT_COUNT) ? ceil($full_count / CATALOG_RESULT_COUNT) : 0;
 		}
 
 		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count, 'get_advanced_results');

--- a/application/libraries/Librivox_search.php
+++ b/application/libraries/Librivox_search.php
@@ -153,6 +153,8 @@ class Librivox_search{
 
 				$cols = array();
 
+				$sql .= 'WITH results AS (';
+
 				$cols[] = 'st.source_table';
 				$cols[] = 'st.search_field';
 				$cols[] = 'p.title';
@@ -287,6 +289,8 @@ class Librivox_search{
 
 
 				//***** finalize query parts *****//
+
+				$sql .= ") SELECT *, COUNT(*) OVER() as full_count FROM results";
 
 				$sql .= ($params['sort_order'] == 'catalog_date') ? ' ORDER BY 5 DESC ' : ' ORDER BY 4 ASC ';
 


### PR DESCRIPTION
Not urgent, but if I'm on the right track, we can improve search performance by a fair bit.

---

It looks like controllers/catalog/Search.php is running each search query twice: once for the items on the current page, and then again to count the total number of matches for the search.  There doesn't seem to be a clean way to count the total results, but here's _one_ way.

We can't use a regular `COUNT(*)`, because that will stop at our `LIMIT` of 25.  So: the `OVER()` call ([1], [2]) lets us `COUNT` before we discard the other results.
But: doing this on each of our `UNION` sets will give different results, which we'd need to add together selectively.  Collecting them all in a sub-query (`WITH results AS (`) gives us a combined set to count.

I don't know how much of a hack this is, and how much overhead it adds, but it at least seems much faster than running the entire search query twice.

[1]: https://stackoverflow.com/a/8242764
[2]: https://stackoverflow.com/a/28888696