### PR TITLE
Normalize RSS spacing

### DIFF
--- a/application/controllers/rss/Rss.php
+++ b/application/controllers/rss/Rss.php
@@ -42,6 +42,9 @@ class Rss extends Catalog_controller
 
 		$this->_build_sections();
 
+		$this->load->helper('description_html_render_helper');
+		$this->data['project']->description = _normalize_and_deduplicate_newlines_in_html($this->data['project']->description);
+
 		$this->load->view('rss/rss', $this->data, FALSE);
 	}
 
@@ -118,6 +121,9 @@ class Rss extends Catalog_controller
 					$this->data['projects'][$key]->title_bar .= ' by ' . $this->data['projects'][$key]->authors_string;
 				}
 				//$this->data['projects'][$key]->authors = $this->project_model->get_project_authors($project->id);
+
+				$this->load->helper('description_html_render_helper');
+				$this->data['projects'][$key]->description = _normalize_and_deduplicate_newlines_in_html($this->data['projects'][$key]->description);
 			}
 		}
 

--- a/application/views/rss/rss.php
+++ b/application/views/rss/rss.php
@@ -5,7 +5,7 @@
   <title><![CDATA[<?= $project->title_bar ?>]]></title>
   <link><![CDATA[<?= $project->url_librivox ?>]]></link>
   <atom:link rel="self" href="https://librivox.org/rss/<?= $project->id ?>" />
-  <description><![CDATA[<?= strip_tags($project->description) ?>]]></description>
+  <description><![CDATA[<?= $project->description ?>]]></description>
   <!--<genre>project element=Genre</genre>-->
   <?php
     if (isset($language) && $language->three_letter_code) { // Docs say two-letter, but three seems to validate
@@ -16,7 +16,7 @@
   ?>
   <itunes:type>serial</itunes:type>
   <itunes:author>LibriVox</itunes:author>
-  <itunes:summary><![CDATA[<?= strip_tags($project->description) ?>]]></itunes:summary>
+  <itunes:summary><![CDATA[<?= $project->description ?>]]></itunes:summary>
   <itunes:owner>
     <itunes:name>LibriVox</itunes:name>
     <itunes:email>info@librivox.org</itunes:email>


### PR DESCRIPTION
The per-title RSS feed (views/rss/rss.php) has been stripping all HTML tags, including spacing.  The latest releases feed has not.  If we're going to strip tags, it should be on the input side instead.

This PR makes use of Gareth's helper, and (I think) fixes #188 for good.

I'd like to re-factor RSS sometime, add in GUIDs to the per-title feed, along with a pubDate... but not today. :neutral_face: 