### PR TITLE
Start using CodeIgniter DB migrations

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -1,41 +1,6 @@
 <?php defined('BASEPATH') OR exit('No direct script access allowed');
-/*
-|--------------------------------------------------------------------------
-| Enable/Disable Migrations
-|--------------------------------------------------------------------------
-|
-| Migrations are disabled by default but should be enabled 
-| whenever you intend to do a schema migration.
-|
-*/
-$config['migration_enabled'] = FALSE;
 
-
-/*
-|--------------------------------------------------------------------------
-| Migrations version
-|--------------------------------------------------------------------------
-|
-| This is used to set migration version that the file system should be on.
-| If you run $this->migration->latest() this is the version that schema will
-| be upgraded / downgraded to.
-|
-*/
+$config['migration_enabled'] = TRUE;
+$config['migration_type'] = 'sequential';
 $config['migration_version'] = 0;
-
-
-/*
-|--------------------------------------------------------------------------
-| Migrations Path
-|--------------------------------------------------------------------------
-|
-| Path to your migrations folder.
-| Typically, it will be within your application path.
-| Also, writing permission is required within the migrations path.
-|
-*/
 $config['migration_path'] = APPPATH . 'migrations/';
-
-
-/* End of file migration.php */
-/* Location: ./application/config/migration.php */

--- a/application/controllers/Migrate.php
+++ b/application/controllers/Migrate.php
@@ -1,0 +1,17 @@
+<?php
+
+class Migrate extends CI_Controller
+{
+
+    public function migrate()
+    {
+        $this->load->library('migration');
+        $target_version = $this->migration->current();
+        if ($target_version)
+        {
+            $this->migration->version($target_version);
+        } else {
+            show_error($this->migration->error_string());
+        } 
+    }
+}


### PR DESCRIPTION
We've already done a few schema changes "out of band", but with
https://github.com/LibriVox/librivox-catalog/pull/212 we now have a
situation where a schema change is needed in a PR for the code to
work, and since we have no way to supply that, our CI (continuout
integration, not Code Ingiter), basic such as it is, fails because the
schema that the code relies on is not deployed in the CI VM.

In addition, tracking schema changes inline with migrations is just
good standard practice.

This patch starts making use of Code Igniter's DB migrations framework
(https://codeigniter.com/userguide3/libraries/migration.html) to allow
PRs to include schema changes. There will be a librivox-ansible
follow-up patch to run the DB migrate script on every deployment.
