### PR TITLE
Simplify DB migration controller

### DIFF
--- a/application/controllers/Migrate.php
+++ b/application/controllers/Migrate.php
@@ -6,12 +6,10 @@ class Migrate extends CI_Controller
     public function migrate()
     {
         $this->load->library('migration');
-        $target_version = $this->migration->current();
-        if ($target_version)
+
+        if ($this->migration->current() === FALSE)
         {
-            $this->migration->version($target_version);
-        } else {
             show_error($this->migration->error_string());
-        } 
+        }
     }
 }


### PR DESCRIPTION
current() actually updates the DB, there's no need to call current()
to get the version, and then to call version(). Just call current()
directly.
