### PR TITLE
More accurate pagination URLs

### DIFF
--- a/application/controllers/catalog/Author.php
+++ b/application/controllers/catalog/Author.php
@@ -25,6 +25,8 @@ class Author extends Catalog_controller
 		$matches = $this->_get_all_author($author_id);
 		$this->data['matches'] = count($matches);
 
+		$this->data['search_order'] = $this->input->get('search_order');
+
 		$this->_render('catalog/author');
 		return;
 	}
@@ -34,6 +36,7 @@ class Author extends Catalog_controller
 		//collect - search_category, sub_category, page_number, sort_order
 		$input = $this->input->get(null, true);
 		$author_id = $input['primary_key'];
+		$search_order = $input['search_order'];
 
 		if (empty($author_id)) {
 			show_error('A primary_key (author ID) must be supplied', 400);
@@ -43,7 +46,7 @@ class Author extends Catalog_controller
 		$offset = ($input['search_page'] - 1) * CATALOG_RESULT_COUNT;
 
 		// go get results
-		$results = $this->_get_all_author($author_id, $offset, CATALOG_RESULT_COUNT, $input['search_order'], $input['project_type']);
+		$results = $this->_get_all_author($author_id, $offset, CATALOG_RESULT_COUNT, $search_order, $input['project_type']);
 
 		$full_set = $this->_get_all_author($author_id, 0, 1000000, 'alpha', $input['project_type']);
 		//$retval['sql'] = $this->db->last_query();
@@ -53,7 +56,20 @@ class Author extends Catalog_controller
 
 		//pagination
 		$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
-		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);
+		$retval['pagination'] = (empty($page_count))
+							  ? ''
+							  : $this->_format_pagination(
+								  $input['search_page'],
+								  $page_count,
+								  'get_results',
+								  function ($page) use ($author_id, $search_order) {
+									  $query_string = http_build_query(array(
+										  'search_page' => $page,
+										  'search_order' => $search_order,
+									  ));
+									  return '/author/' . $author_id . '/?' . $query_string;
+								  },
+							  );
 
 		$retval['status'] = 'SUCCESS';
 

--- a/application/controllers/catalog/Group.php
+++ b/application/controllers/catalog/Group.php
@@ -25,6 +25,8 @@ class Group extends Catalog_controller
 		$matches = $this->_get_all_group_projects($group_id, 0, 1000000);
 		$this->data['matches'] = count($matches);
 
+		$this->data['search_order'] = $this->input->get('search_order');
+
 		$this->_render('catalog/group');
 		return;
 	}
@@ -53,7 +55,19 @@ class Group extends Catalog_controller
 
 		//pagination
 		$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
-		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);
+		$retval['pagination'] = (empty($page_count))
+							  ? ''
+							  : $this->_format_pagination(
+								  $input['search_page'],
+								  $page_count,
+								  'get_results',
+								  function ($page) use ($group_id) {
+									  $query_string = http_build_query(array(
+										  'search_page' => $page,
+									  ));
+									  return '/group/' . $group_id . '/?' . $query_string;
+								  },
+							  );
 
 		$retval['status'] = 'SUCCESS';
 

--- a/application/controllers/catalog/Reader.php
+++ b/application/controllers/catalog/Reader.php
@@ -32,6 +32,8 @@ class Reader extends Catalog_controller
 		$matches = $this->_get_all_reader($reader_id);
 		$this->data['matches'] = count($matches);
 
+		$this->data['search_order'] = $this->input->get('search_order');
+
 		$this->_render('catalog/reader');
 		return;
 	}
@@ -41,6 +43,7 @@ class Reader extends Catalog_controller
 		//collect - search_category, sub_category, page_number, sort_order
 		$input = $this->input->get(null, true);
 		$reader_id = $input['primary_key'];
+		$search_order = $input['search_order'];
 
 		if (empty($reader_id)) {
 			show_error('A primary_key (reader ID) must be supplied', 400);
@@ -50,7 +53,7 @@ class Reader extends Catalog_controller
 		$offset = ($input['search_page'] - 1) * CATALOG_RESULT_COUNT;
 
 		// go get results
-		$results = $this->_get_all_reader($reader_id, $offset, CATALOG_RESULT_COUNT, $input['search_order'], $input['project_type']);
+		$results = $this->_get_all_reader($reader_id, $offset, CATALOG_RESULT_COUNT, $search_order, $input['project_type']);
 
 		$full_set = $this->_get_all_reader($reader_id, 0, 1000000, 'alpha', $input['project_type']);
 		//$retval['sql'] = $this->db->last_query();
@@ -60,7 +63,20 @@ class Reader extends Catalog_controller
 
 		//pagination
 		$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
-		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);
+		$retval['pagination'] = (empty($page_count))
+							  ? ''
+							  : $this->_format_pagination(
+								  $input['search_page'],
+								  $page_count,
+								  'get_results',
+								  function ($page) use ($reader_id, $search_order) {
+									  $query_string = http_build_query(array(
+										  'search_page' => $page,
+										  'search_order' => $search_order,
+									  ));
+									  return '/reader/' . $reader_id . '/?' . $query_string;
+								  },
+							  );
 
 		$retval['status'] = 'SUCCESS';
 

--- a/application/core/Catalog_controller.php
+++ b/application/core/Catalog_controller.php
@@ -24,7 +24,27 @@ class Catalog_controller extends CI_Controller
 		$this->load->view($file, $this->data);
 	}
 
-	function _format_pagination($current_page, $page_count, $call_function = 'get_results')
+	/**
+	 * Format pagination links as HTML to display in the browser.
+	 *
+	 * The links use '#' as the URL by default, but you can customize this by
+	 * passing in a $link_url_builder. E.g.:
+	 *
+	 *   $this->_format_pagination(
+	 *     1,
+	 *     10,
+	 *     'example_search_function',
+	 *     function ($page) {
+	 *       return '/path/to/thing/' . $page;
+	 *     },
+	 *   )
+	 *
+	 * @param int $current_page	The page the user is currently on, starts at 1
+	 * @param float $page_count The total number of pages
+	 * @param string $call_function The name of the function that's calling this, gets attached to the links for some reason?
+	 * @param callable $link_url_builder A function to render the pagination URL given a page number, just uses '#' by default
+	 */
+	function _format_pagination($current_page, $page_count, $call_function = 'get_results', $link_url_builder = null)
 	{
         $page_count = intval($page_count); // It's a float, but we want ints. (Causes problems when generating ranges.)
 
@@ -35,12 +55,12 @@ class Catalog_controller extends CI_Controller
         $html = '';
 
         // Print the link to the first page
-        $html .= $this->_format_pagination_link(1, $current_page, $call_function);
+        $html .= $this->_format_pagination_link(1, $current_page, $call_function, $link_url_builder);
         $distance_to_first_page = $pages[0] - 1;
         if ($distance_to_first_page === 2)
         {
             // If we're only one hop away, just print the link rather than the '...'
-            $html .= $this->_format_pagination_link(2, $current_page, $call_function);
+            $html .= $this->_format_pagination_link(2, $current_page, $call_function, $link_url_builder);
         }
         else if ($distance_to_first_page > 2)
         {
@@ -56,7 +76,7 @@ class Catalog_controller extends CI_Controller
             }
             else
             {
-                $html .= $this->_format_pagination_link($page, $current_page, $call_function);
+                $html .= $this->_format_pagination_link($page, $current_page, $call_function, $link_url_builder);
             }
 		}
 
@@ -66,12 +86,12 @@ class Catalog_controller extends CI_Controller
         if ($distance_to_last_page === 2)
         {
             // If we're only one hop away, just print the link rather than the '...'
-            $html .= $this->_format_pagination_link($page_count - 1, $current_page, $call_function);
+            $html .= $this->_format_pagination_link($page_count - 1, $current_page, $call_function, $link_url_builder);
         }
         else if ($distance_to_last_page > 2) {
             $html .= ' ... ';
         }
-        $html .= $this->_format_pagination_link($page_count, $current_page, $call_function);
+        $html .= $this->_format_pagination_link($page_count, $current_page, $call_function, $link_url_builder);
 
 		return $html;
 	}
@@ -84,13 +104,16 @@ class Catalog_controller extends CI_Controller
 		return range($start, $end);
 	}
 
-    function _format_pagination_link($page, $current_page, $call_function)
+    function _format_pagination_link($page, $current_page, $call_function, $link_url_builder)
     {
         $active = ($page == $current_page) ? 'active' : '';
+		$href = !empty($link_url_builder)
+			  ? $link_url_builder($page)
+			  : '#';
         return '<a
                   class="page-number ' . $active . '"
                   data-page_number="' . $page . '"
-                  href="#"
+                  href="' . $href . '"
                   data-call_function="' . $call_function . '"
                   >' . $page . '</a>';
     }

--- a/application/views/catalog/author.php
+++ b/application/views/catalog/author.php
@@ -35,8 +35,8 @@
 			<div class="sort-menu" id="sort_menu" style="display:none;">
 				<p>Order by</p>
 				<select class="js-sort-menu">
-					  <option value="alpha">Alphabetically</option>
-					  <option value="catalog_date">Release date</option>
+					<option value="alpha" <?= $search_order === 'alpha' ? 'selected' : '' ?>>Alphabetically</option>
+					<option value="catalog_date" <?= $search_order === 'catalog_date' ? 'selected' : '' ?>>Release date</option>
 				 </select> 
 			</div><!-- end .sort-menu -->
 		</div><!-- end . page-header -->

--- a/application/views/catalog/group.php
+++ b/application/views/catalog/group.php
@@ -25,8 +25,8 @@
 			<div class="sort-menu" id="sort_menu" style="display:none;">
 				<p>Order by</p>
 				<select class="js-sort-menu">
-					  <option value="alpha">Alphabetically</option>
-					  <option value="catalog_date">Release date</option>
+					<option value="alpha" <?= $search_order === 'alpha' ? 'selected' : '' ?>>Alphabetically</option>
+					<option value="catalog_date" <?= $search_order === 'catalog_date' ? 'selected' : '' ?>>Release date</option>
 				 </select> 
 			</div><!-- end .sort-menu -->
 		</div><!-- end . page-header -->

--- a/application/views/catalog/partials/footer.php
+++ b/application/views/catalog/partials/footer.php
@@ -45,7 +45,7 @@
 	var search_page = get_search_page_from_url();
 	set_advanced_form_page(search_page);
 
-	var search_order = 'alpha';
+	var search_order = $('.js-sort-menu').val() || 'alpha';
 
 	var project_type = 'either';
 
@@ -240,7 +240,7 @@
 				if (history.pushState) {
 					history.pushState(null, location.textContent, location.href);
 
-					history.replaceState(null, null, "?primary_key=" + primary_key + '&search_category=' + search_category + '&search_page=' + search_page + '&search_form=get_results');	
+					history.replaceState(null, null, "?primary_key=" + primary_key + '&search_category=' + search_category + '&search_page=' + search_page + '&search_form=get_results&search_order=' + search_order);
 					
 				}
 

--- a/application/views/catalog/reader.php
+++ b/application/views/catalog/reader.php
@@ -29,8 +29,8 @@
 			<div class="sort-menu" id="sort_menu" style="display:none;">
 				<p>Order by</p>
 				<select class="js-sort-menu">
-					  <option value="alpha">Alphabetically</option>
-					  <option value="catalog_date">Release date</option>
+					<option value="alpha" <?= $search_order === 'alpha' ? 'selected' : '' ?>>Alphabetically</option>
+					<option value="catalog_date" <?= $search_order === 'catalog_date' ? 'selected' : '' ?>>Release date</option>
 				 </select> 
 			</div><!-- end .sort-menu -->
 		</div><!-- end . page-header -->


### PR DESCRIPTION
Before this change, the pagination URLs just pointed to `#`, which meant
that you couldn't do things like 'Open in new tab' or bookmark a
specific page if you were sorting by Release Date.

This commit helps solve those problems on the Reader, Group, and Author
pages by:

 * Specifying a better URL for the pagination links (solves for 'Open in
   new tab')
 * Pushing the `search_order` parameter into the page URL when new pages
   are fetched from the server (solves for accurate bookmarking)

(I haven't fixed it on the Search pages.)
