### PR TITLE
Fix API giving uploader URLs instead of Archive

### DIFF
--- a/application/libraries/Format.php
+++ b/application/libraries/Format.php
@@ -139,7 +139,13 @@ class Format {
 			else
 			{
 				// add single node.
-				$value = htmlspecialchars(html_entity_decode($value, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, "UTF-8");
+				if ($value != null) {
+					$value = htmlspecialchars(html_entity_decode($value, ENT_QUOTES, 'UTF-8'), ENT_QUOTES, "UTF-8");
+				}
+				else
+				{
+					$value = '';
+				}
 
 				$structure->addChild($key, $value);
 			}

--- a/application/libraries/Librivox_API.php
+++ b/application/libraries/Librivox_API.php
@@ -240,7 +240,7 @@ class Librivox_API{
 
 	function _get_sections($project_id)
 	{
-		$result =  $this->db->select('s.id, s.section_number, s.title, s.listen_url, COALESCE(l.language, "English") AS language, COALESCE(s.playtime, 0) AS playtime, s.file_name', false)
+		$result =  $this->db->select('s.id, s.section_number, s.title, s.mp3_64_url as listen_url, COALESCE(l.language, "English") AS language, COALESCE(s.playtime, 0) AS playtime, s.file_name', false)
 		->join('languages l', 'l.id=s.language_id', 'left outer')
 		->where('s.project_id', $project_id)
 		->get('sections s')
@@ -251,7 +251,7 @@ class Librivox_API{
 
 	function _get_section($id)
 	{
-		$result =  $this->db->select('s.id, s.section_number, s.title, s.listen_url, COALESCE(l.language, "English") AS language, COALESCE(s.playtime, 0) AS playtime, s.file_name', false)
+		$result =  $this->db->select('s.id, s.section_number, s.title, s.mp3_64_url as listen_url, COALESCE(l.language, "English") AS language, COALESCE(s.playtime, 0) AS playtime, s.file_name', false)
 		->join('languages l', 'l.id=s.language_id', 'left outer')
 		->where('s.id', $id)
 		->get('sections s')


### PR DESCRIPTION
Take two.  I'd actually thought the first one was merged, and I'm in the habit of keeping as few branches on GH as necessary.

Fixes #211. Calling `/api/feed/audiobooks` with `extended=1` will now give the Archive.org URLs for sections in completed projects, and empty strings for projects in progress.

From the database, we're substituting mp3_64_url for the previously used listen_url. I opted to leave the API name the same, in case someone actually has been using it successfully.