### PR TITLE
Fix Archive 'Read by' list not matching catalog

### DIFF
--- a/application/controllers/catalog/Page.php
+++ b/application/controllers/catalog/Page.php
@@ -131,9 +131,9 @@ class Page extends Catalog_controller
 	{
 		if (strtolower($project->project_type) == 'group') return 'LibriVox Volunteers';
 
-		$readers = $this->project_model->get_project_readers($project->id);
+		$readerstub = $this->project_model->get_solo_reader($project->id);
 
-		if ($readers) return '<a href="' . base_url() . 'reader/' . $readers[0]['reader_id'] . '">' . $readers[0]['display_name'] . '</a>';
+		if (isset($readerstub)) return '<a href="' . base_url() . 'reader/' . $readerstub['reader_id'] . '">' . $readerstub['display_name'] . '</a>';
 
 		return 'Solo';
 	}

--- a/application/controllers/private/Iarchive_upload.php
+++ b/application/controllers/private/Iarchive_upload.php
@@ -113,8 +113,16 @@ class Iarchive_upload extends Private_Controller
 		$this->data['language'] = empty($language) ? 'English' : $language->language;
 		$this->data['language_code'] = empty($language) ? 'eng' : $language->three_letter_code;
 
-		$this->load->model('project_model');
-		$this->data['readers'] = $this->project_model->create_project_reader_list($project->id);
+		if ($project->project_type == 'solo')
+		{
+			$this->load->model('project_model');
+			$readerstub = $this->project_model->get_solo_reader($project->id);
+			$this->data['reader_name'] = isset($readerstub) ? $readerstub['display_name'] : "Solo";
+		}
+		else
+		{
+			$this->data['reader_name'] = 'LibriVox Volunteers';
+		}
 
 		$this->data['description'] = $project->description;
 		$this->data['catalog_url'] = $project->url_librivox;

--- a/application/models/Project_model.php
+++ b/application/models/Project_model.php
@@ -111,41 +111,22 @@ class Project_model extends MY_Model
 
     }
 
-    function get_project_readers($project_id)
+
+    // For catalog and Archive pages of solo projects.
+    //   Not every solo project has exactly one reader, and the solo reader is not always the BC.  We don't have a `person_soloreader_id` column.
+    //   Given that, MCs are comfortable with this 'pick first result' heuristic, which is how the catalog pages have functioned up to now.
+    function get_solo_reader($project_id)
     {
         $sql = 'SELECT u.id AS reader_id, u.display_name
-                FROM users u
-                JOIN section_readers sr ON (sr.reader_id = u.id)
-                JOIN sections s ON (s.id = sr.section_id)
-                WHERE s.project_id = ? ';
-
-        $query = $this->db->query($sql, array($project_id));
-
-        return $query->result_array();
-    }
-
-
-    function create_project_reader_list($project_id)
-    {
-        $sql = 'SELECT u.display_name
         FROM users u
         JOIN section_readers sr ON (sr.reader_id = u.id)
         JOIN sections s ON (s.id = sr.section_id)
-        WHERE s.project_id = ? ';
+        WHERE s.project_id = ?
+        LIMIT 1';
 
         $query = $this->db->query($sql, array($project_id));
 
-        $reader_list = array();
-
-        if ($query->num_rows())
-        {
-            foreach ($query->result() as $reader)
-            {
-                $reader_list[] = $reader->display_name;
-            }
-        }
-
-        return implode('; ', $reader_list);
+        return $query->row_array();
 
     }
 

--- a/application/views/private/validator/archive_description.php
+++ b/application/views/private/validator/archive_description.php
@@ -1,5 +1,5 @@
 <a href="https://librivox.org/">LibriVox</a> recording of <?= $title ?> by <?= $authors ?>. <?= $translators ?><br />
-Read in <?= $language ?> by <?= $readers ?><br /><br />
+Read in <?= $language ?> by <?= $reader_name ?><br /><br />
 <?= $description ?><br /><br />
 For further information, including links to online text, reader information, RSS feeds, CD cover or other formats (if available), please go to the <a href="<?= $catalog_url ?>">LibriVox catalog page</a> for this recording.<br /><br />
 For more free audio books or to become a volunteer reader, visit <a href="https://librivox.org/">librivox.org</a>.<br /><br />


### PR DESCRIPTION
Fixes #201.  Per MC discussion, we want Archive pages to match the existing 'Read by' label on our catalog pages:
* All types of group projects show 'LibriVox Volunteers', regardless of reader count.
* Solo projects show the first reader result returned from the database, or 'Solo' if there are none.

Along with this change, I've refactored `get_project_readers` and `create_project_reader_list` into `get_solo_reader`:
* `get_project_readers` was called only from catalog pages, but only for solo projects, and only to get the first reader result.
* `create_project_reader_list` is no longer needed.  It was called only from Iarchive_upload, which should also only need to call it for solo projects.

If you think it would be better to have the group vs solo check be in the model rather than the controllers, we could do that at the cost of a second (but quick) database query.  Open to that, or other suggestions!