### PR TITLE
Fix advanced search for compilations - by language or reader

### DIFF
--- a/application/libraries/Librivox_search.php
+++ b/application/libraries/Librivox_search.php
@@ -154,11 +154,16 @@ class Librivox_search{
 		}
 
 		$reader_clause = '';
+		$section_reader_clause = '';
 		if (!empty($params['reader']))
 		{
 			$exact_match = (isset($params['exact_match'])) ? true: false;
+
 			$project_ids = $this->_get_projects_by_reader($params['reader'], $exact_match);
 			$reader_clause = ' AND p.id IN (' . implode(',', $project_ids) . ') ';
+
+			$reader_ids = $this->_get_reader_ids($params['reader'], $exact_match);
+			$section_reader_clause = ' AND st.section_reader_id in (' . implode(',', $reader_ids) . ')';
 		}
 
 		// ======================================================================================================================================
@@ -253,7 +258,7 @@ class Librivox_search{
 				' . $project_type . '
 				' . $title . '
 				' . $section_author_clause . '
-				' . $reader_clause . '
+				' . $section_reader_clause . '
 				' . $section_language_clause . ' ';
 
 

--- a/application/libraries/Librivox_search.php
+++ b/application/libraries/Librivox_search.php
@@ -77,16 +77,31 @@ class Librivox_search{
 		$recorded_language = (int)$params['recorded_language'];
 		if ($recorded_language !== 0)
 		{
-			//$language = ' AND p.language_id = ' . $params['recorded_language'] ;
+			if (empty($params['title']) and empty($params['author']) and empty($params['reader']))
+			{
+				// If we're just browsing, we can remove some redundant entries to make the results more compact.
 
-			// Projects having at least one section in that language.
-			$section_project_ids = $this->_get_projects_by_section_language($recorded_language);
-			//$language_clause = ' AND p.id IN (' . implode(',', $section_project_ids) . ') ';
+				// Projects: only listed if they are primarily in this language.
+				$language_clause = ' AND p.language_id = ' . $recorded_language;
 
-			$language_clause = ' AND ( p.language_id = ' . $recorded_language . ' OR p.id IN (' . implode(',', $section_project_ids) . ') ) ';
-			$section_language_clause = '
-				AND ( p.language_id = ' . $recorded_language . '
-					OR st.section_language_id = ' . $recorded_language . ') ';
+				// Sections: only (individually) listed if they are in this language, but from a project we wouldn't list above.
+				$section_language_clause = '
+					AND p.language_id <> ' . $recorded_language . '
+					AND st.section_language_id = ' . $recorded_language;
+			}
+			else
+			{
+				// If we're searching by specifics, we should cast a wide net for potential matches.
+
+				// Projects: search among all that have any sections in this language.
+				$section_project_ids = $this->_get_projects_by_section_language($recorded_language);
+				$language_clause = ' AND ( p.language_id = ' . $recorded_language . ' OR p.id IN (' . implode(',', $section_project_ids) . ') ) ';
+
+				// Sections: search among all in this language, whether from multi-lingual or mono-lingual compilation projects.
+				$section_language_clause = '
+					AND ( st.section_language_id = ' . $recorded_language . '
+						OR ( st.section_language_id IS NULL AND p.language_id = ' . $recorded_language . ') ) ';
+			}
 		}
 
 


### PR DESCRIPTION
Status has changed, see the latest comment in chain.  😄 

---
**Status of this PR:**
* In terms of code, if somebody has time to check for issues which I might have overlooked out of ignorance, that would be welcome.
Otherwise, this at least makes for a good update on what I've been learning so far...
* In terms of "do we want this", I've got enough question marks, that I should touch base with other admins before going much further.

Continuing discussion from #12.

The earlier proposed change would indeed hide Sections from the search results, where they were part of a mono-lingual compilation Project.  The Project itself would ideally be a single result, rather than a scattering of individual Sections.

This makes perfect sense, _unless_ we're searching by a detail that is specific to each Section.  For example, even if our search is an exact match for a Section's title, that Section will still be hidden.  And since the _Project_ title will not match that search, we'll get no results at all.

**One approach:**
I know there is a special Project <-> Group relation, where searching for the title of a Project (e.g. "The Tower Treasure") will make the relevant Group ("The Hardy Boys") show up in the results.  You can see the mechanism for this in `application/controllers/cron/Search_table_update.php`.
That would _work_, as far as I can see, but it comes with both technical and usability trade-offs - more entries in the search table, and less visibility into "what is this thing, and why is it in my results for this particular search?"

**Instead:**
Here, I've set up @rillig's change to apply only when we are _not_ searching by title.  We could extend this exception for searches by author and by reader, as are also Section-specific.  That would come with some edge-case false positives... which we also have in master, so why not?  I digress.

I'm now wondering if we wouldn't rather leave the Advanced Search as it is, and instead apply a change like this to the Browse by Language and/or Simple Search features.  _If_ other admins have the same thought, then I'll likely approach that with fresh eyes in a week or three.  I'm tapped out on this for the moment. 😪 

Happy to hear any opinions!  I'll get back to them when ready.