### PR TITLE
Expand author autocomplete

### DIFF
--- a/application/controllers/public/Public_ajax.php
+++ b/application/controllers/public/Public_ajax.php
@@ -12,8 +12,10 @@ class Public_ajax extends Public_Controller
 	{
 		$term = $this->input->post('term');
 		$search_field = $this->input->post('search_field');
+		$filter_term = $this->input->post('filter_term');
+		$filter_field = $this->input->post('filter_field');
 		$this->load->model('author_model');
-		echo json_encode($this->author_model->autocomplete($term, $search_field));
+		echo json_encode($this->author_model->autocomplete($term, $search_field, $filter_term, $filter_field));
 	}
 
 	function autocomplete_user()

--- a/application/models/Author_model.php
+++ b/application/models/Author_model.php
@@ -2,7 +2,7 @@
 
 class Author_model extends MY_Model
 {
-	public function autocomplete($term, $search_field)
+	public function autocomplete($term, $search_field, $filter_term, $filter_field)
 	{
 
 		if (!preg_match("/[\w]/", $term))
@@ -82,6 +82,25 @@ class Author_model extends MY_Model
 				}
 				break;
 		}
+
+
+		// An additional option, which we have on the Template Generator but not Section Compiler, is filtering the results of one box by what's in the other.
+		switch ($filter_field)
+		{
+			case 'first_name':
+				$name_clause .= '
+					AND (match_table.first_name LIKE ?
+						OR (match_table.first_name = "" AND match_table.last_name LIKE ?) )';
+				$bindings =  array_merge($bindings, array('%'. $filter_term .'%', '%'. $filter_term .'%'));
+				break;
+
+			case 'last_name':
+				$name_clause .= '
+						AND match_table.last_name LIKE ?';
+				$bindings =  array_merge($bindings, array('%'. $filter_term .'%'));
+				break;
+		}
+
 
 		$sql = 'SELECT id, first_name, last_name, dob, dod, author_url
 			FROM authors match_table

--- a/application/models/Author_model.php
+++ b/application/models/Author_model.php
@@ -101,9 +101,17 @@ class Author_model extends MY_Model
 				break;
 		}
 
+		// Since we use the name-matching clause once for authors and once for pseudonyms, we need the bindings for it twice.
+		$bindings = array_merge($bindings, $bindings);
 
-		$sql = 'SELECT id, first_name, last_name, dob, dod, author_url
+		$sql = 'SELECT id, first_name, last_name, dob, dod, author_url, NULL AS pseudo_first, NULL AS pseudo_last
 			FROM authors match_table
+			WHERE linked_to = 0
+			'. $name_clause .'
+			UNION
+			SELECT a.id, a.first_name, a.last_name, dob, dod, author_url, match_table.first_name AS pseudo_first, match_table.last_name AS pseudo_last
+			FROM author_pseudonyms match_table
+			JOIN authors a ON (a.id = match_table.author_id)
 			WHERE linked_to = 0
 			'. $name_clause .'
 			ORDER BY '. $sort_order .'

--- a/application/tests/controllers/public/Public_ajax_test.php
+++ b/application/tests/controllers/public/Public_ajax_test.php
@@ -1,0 +1,165 @@
+<?php
+
+class Public_ajax_test extends TestCase
+{
+	public function setUp(): void
+	{
+		$this->resetInstance();
+	}
+
+	/**
+	* @dataProvider provider
+	*/
+	public function test_author_autocomplete($search_terms, $expected, $not_expected) {
+        foreach($search_terms as $term_set) {
+            $response = $this->request(
+                'POST',
+                'public/public_ajax/autocomplete_author',
+                $term_set,
+            );
+            foreach ($expected as $str) {
+                $this->assertStringContainsString($str, $response);
+            }
+            foreach ($not_expected as $str) {
+                $this->assertStringNotContainsString($str, $response);
+            }
+        }
+	}
+
+	public static function provider() {
+		return array(
+
+            // Don't search for empty terms
+			array(
+                'search_terms' => array(
+                    array('search_field' => 'first_name', 'term' => ''),
+                    array('search_field' => 'last_name', 'term' => ''),
+                    array('search_field' => 'full_name', 'term' => '')
+                ),
+                'expected' => array("[]"),
+                'not_expected' => array("{")
+            ),
+
+            // Searches solely by first name (Walter)
+			array(
+                'search_terms' => array(
+                    array('search_field' => 'first_name', 'term' => 'walter')
+                ),
+                'expected' => array(
+                    "http:\/\/en.wikipedia.org\/wiki\/Walter_Flex", // Simple "begin at the beginning" match
+                    "http:\/\/en.wikipedia.org\/wiki\/Sam_Walter_Foss", // A "first name" that includes, but does not start with our search term
+
+                    '"id":"12799"', // E. Walter Walters, a first-and-last name match, should not be excluded.
+
+                    "http:\/\/en.wikipedia.org\/wiki\/Walter_Conrad_Arensberg", // A couple more to round things out.
+                    "https:\/\/en.wikipedia.org\/wiki\/Walter_R._Brooks"
+                ),
+                'not_expected' => array(
+                    "http:\/\/en.wikipedia.org\/wiki\/Wolfgang_Sartorius_von_Waltershausen", // A "last name"-only match should be excluded
+                )
+            ),
+
+
+            // Searches solely by last name (Was[...])
+            array(
+                'search_terms' => array(
+                    array('search_field' => 'last_name', 'term' => 'was')
+                ),
+                'expected' => array(
+                    "https:\/\/en.wikipedia.org\/wiki\/Lemuel_K._Washburn",
+                    "https:\/\/en.wikipedia.org\/wiki\/George_Washington",
+                    "http:\/\/en.wikipedia.org\/wiki\/Booker_T._Washington",
+                    "http:\/\/en.wikipedia.org\/wiki\/Jakob_Wassermann"
+                ),
+                'not_expected' => array(
+                    "https:\/\/en.wikipedia.org\/wiki\/George_Washington_Carver", // A few authors with a 'was' included in the "first" name
+                    "https:\/\/prabook.com\/web\/george.smalley\/3768926",
+                    "https:\/\/de.wikipedia.org\/wiki\/Stepan_Rudanskyj"
+                )
+            ),
+
+
+            // Searches by first name, continuing through to the last name (George Washington[...])
+            array(
+                'search_terms' => array(
+                    array('search_field' => 'first_name', 'term' => 'george washington'),
+                    array('search_field' => 'full_name', 'term' => 'george washington')
+                ),
+                'expected' => array(
+                    "https:\/\/en.wikipedia.org\/wiki\/George_Washington", // The man himself
+
+                    "https:\/\/en.wikipedia.org\/wiki\/George_Washington_Bethune", // Various folks with "George Washington" as part of their "first" name
+                    "https:\/\/en.wikipedia.org\/wiki\/George_Washington_Cable",
+                    "https:\/\/en.wikipedia.org\/wiki\/George_Washington_Carver",
+                ),
+                'not_expected' => array(
+                    "https:\/\/en.wikipedia.org\/wiki\/George_Frederick_Abbott", // A pair of other Georges
+                    "http:\/\/en.wikipedia.org\/wiki\/George_William_Bagby",
+
+                    "https:\/\/en.wikipedia.org\/wiki\/Washington_Allston", // Assorted non-George "Washington"-s
+                    "http:\/\/en.wikipedia.org\/wiki\/Adolphus_Greely",
+                    "Catharine Marguerite Beauchamp"
+                )
+            ),
+
+
+            // Searches by both names, either "filtered" or comma-separated ('Jo' + wild + 'ith')
+            array(
+                'search_terms' => array(
+                    array('search_field' => 'first_name', 'term' => 'jo', 'filter_field' => 'last_name', 'filter_term' => 'ith'),
+                    array('search_field' => 'last_name', 'term' => 'ith', 'filter_field' => 'first_name', 'filter_term' => 'jo'),
+                    array('search_field' => 'last_name', 'term' => 'ith, jo'),
+                    array('search_field' => 'full_name', 'term' => 'ith, jo')
+                ),
+                'expected' => array(
+                    "https:\/\/en.wikipedia.org\/wiki\/John_Arrowsmith_(scholar)",
+                    "http:\/\/en.wikipedia.org\/wiki\/John_Smith_(explorer)",
+                    "https:\/\/de.wikipedia.org\/wiki\/Johann_Philipp_Lorenz_Withof"
+                ),
+                'not_expected' => array(
+                    "https:\/\/en.wikipedia.org\/wiki\/John_Stevens_Cabot_Abbott", // First-name-only match
+                    "https:\/\/en.wikipedia.org\/wiki\/H._H._Asquith", // Last-name-only match
+                    "Reverend Frederick Robert", // Mixed-match between a pseudonym and a real name: "John Ackworth", AKA "Reverend Frederick Robert Smith"
+                )
+            ),
+
+
+            // Searches for authors that have ONLY a last name in the database (Supreme Court)
+            array(
+                'search_terms' => array(
+                    array('search_field' => 'first_name', 'term' => 'supreme court'),
+                    array('search_field' => 'last_name', 'term' => 'supreme court'),
+                    array('search_field' => 'full_name', 'term' => 'supreme court'),
+                    array('search_field' => 'full_name', 'term' => 'court, supreme'),
+                    array('search_field' => 'first_name', 'term' => 'supreme', 'filter_field' => 'last_name', 'filter_term' => 'court'),
+                    array('search_field' => 'last_name', 'term' => 'court', 'filter_field' => 'first_name', 'filter_term' => 'supreme')
+                ),
+                'expected' => array(
+                    "http:\/\/en.wikipedia.org\/wiki\/Supreme_Court_of_the_United_States"
+                ),
+                'not_expected' => array(
+                    "[]"
+                )
+            ),
+
+
+            // Searches by pseudonym (Samuel L. Clemens)
+            array(
+                'search_terms' => array(
+                    array('search_field' => 'first_name', 'term' => 'l. clemens'),
+                    array('search_field' => 'full_name', 'term' => 'l. clemens'),
+                    array('search_field' => 'last_name', 'term' => 'clemens, sam'),
+                    array('search_field' => 'full_name', 'term' => 'clemens, sam'),
+                    array('search_field' => 'first_name', 'term' => 'sam', 'filter_field' => 'last_name', 'filter_term' => 'clemens'),
+                    array('search_field' => 'last_name', 'term' => 'clemens', 'filter_field' => 'first_name', 'filter_term' => 'sam')
+                ),
+                'expected' => array(
+                    "https:\/\/en.wikipedia.org\/wiki\/Mark_Twain"
+                ),
+                'not_expected' => array()
+            ),
+		);
+	}
+}
+
+?>

--- a/application/views/private/section_compiler/index.php
+++ b/application/views/private/section_compiler/index.php
@@ -58,12 +58,12 @@
 
 	<table>
 		<thead>
-			<tr><th>Section</th><th>Author <span style="font-size:10px;">(last name search)</span></th><th>Source</th><th>Language</th><th>Duration</th><th></th></tr>
+			<tr><th>Section</th><th>Author <span style="font-size:10px;">(full name search)</span></th><th>Source</th><th>Language</th><th>Duration</th><th></th></tr>
 		</thead>
 		<tbody>
 			<tr>
 				<td><input style="width:40px;" type="text" id="add_to_section_number" ><input type="hidden" id="add_to_section_id" value="0"></td>
-				<td><input style="width:200px;" type="text" id="add_author" class="autocomplete" data-add_author_id="0" data-search_field="last_name" data-search_area="author" data-search_func="autocomplete_author" data-array_index="1"></td>
+				<td><input style="width:200px;" type="text" id="add_author" class="autocomplete" data-add_author_id="0" data-search_field="full_name" data-search_area="author" data-search_func="autocomplete_author" data-array_index="1"></td>
 				<td><input style="width:160px;" type="text" id="add_source" ></td>
 				<td><?= $recorded_languages; ?></td>
 				<td><input style="width:80px;" type="text" id="add_playtime" placeholder="00:00:00"></td>

--- a/application/views/public/project_launch/author_block.php
+++ b/application/views/public/project_launch/author_block.php
@@ -5,10 +5,10 @@
      <div class="controls center">
         <input type="hidden" name="auth_id[<?= $counter ?>]" id="auth_id[<?= $counter ?>]" value="<?= set_value('auth_id[]', 0)?>"  data-array_index="<?= $counter ?>"/>
         <?= form_label(lang('proj_launch_auth_last_name'),  'auth_last_name', array('class'=>'span2')); ?>
-        <?= form_input(array('name'=> 'auth_last_name[' . $counter . ']', 'value' => '' ,'id' => 'auth_last_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'last_name', 'data-search_area'=>'author', 'data-array_index'=>$counter )); ?>
+        <?= form_input(array('name'=> 'auth_last_name[' . $counter . ']', 'value' => '' ,'id' => 'auth_last_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'last_name', 'data-filter_element'=>'auth_first_name[' . $counter . ']', 'data-search_area'=>'author', 'data-array_index'=>$counter )); ?>
 
         <?= form_label(lang('proj_launch_auth_first_name'),  'auth_first_name', array('style'=>'margin-left:30px;width:140px')); ?>
-        <?= form_input(array('name'=> 'auth_first_name[' . $counter . ']', 'value' => '' ,'id' => 'auth_first_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'first_name' , 'data-search_area'=>'author' , 'data-array_index'=>$counter)); ?>
+        <?= form_input(array('name'=> 'auth_first_name[' . $counter . ']', 'value' => '' ,'id' => 'auth_first_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'first_name', 'data-filter_element'=>'auth_last_name[' . $counter . ']', 'data-search_area'=>'author' , 'data-array_index'=>$counter)); ?>
      </div>
 </div>   
 

--- a/application/views/public/project_launch/author_block.php
+++ b/application/views/public/project_launch/author_block.php
@@ -8,7 +8,7 @@
         <?= form_input(array('name'=> 'auth_last_name[' . $counter . ']', 'value' => '' ,'id' => 'auth_last_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'last_name', 'data-search_area'=>'author', 'data-array_index'=>$counter )); ?>
 
         <?= form_label(lang('proj_launch_auth_first_name'),  'auth_first_name', array('style'=>'margin-left:30px;width:140px')); ?>
-        <?= form_input(array('name'=> 'auth_first_name[' . $counter . ']', 'value' => '' ,'id' => 'auth_first_name[' . $counter . ']',  'class'=>'', 'data-search_field'=>'first_name' , 'data-search_area'=>'author' , 'data-array_index'=>$counter)); ?>
+        <?= form_input(array('name'=> 'auth_first_name[' . $counter . ']', 'value' => '' ,'id' => 'auth_first_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'first_name' , 'data-search_area'=>'author' , 'data-array_index'=>$counter)); ?>
      </div>
 </div>   
 

--- a/application/views/public/project_launch/translator_block.php
+++ b/application/views/public/project_launch/translator_block.php
@@ -8,7 +8,7 @@
         <?= form_input(array('name'=> 'trans_last_name[' . $counter . ']', 'value' => '' ,'id' => 'trans_last_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'last_name', 'data-search_area'=>'translator', 'data-array_index'=>$counter )); ?>
 
         <?= form_label(lang('proj_launch_auth_first_name'),  'trans_first_name', array('style'=>'margin-left:30px;width:140px')); ?>
-        <?= form_input(array('name'=> 'trans_first_name[' . $counter . ']', 'value' => '' ,'id' => 'trans_first_name[' . $counter . ']',  'class'=>'', 'data-search_field'=>'first_name' , 'data-search_area'=>'translator' , 'data-array_index'=>$counter)); ?>
+        <?= form_input(array('name'=> 'trans_first_name[' . $counter . ']', 'value' => '' ,'id' => 'trans_first_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'first_name' , 'data-search_area'=>'translator' , 'data-array_index'=>$counter)); ?>
      </div>
 </div>
 

--- a/application/views/public/project_launch/translator_block.php
+++ b/application/views/public/project_launch/translator_block.php
@@ -5,10 +5,10 @@
      <div class="controls center">
         <input type="hidden" name="trans_id[<?= $counter ?>]" id="trans_id[<?= $counter ?>]" value="<?= set_value('trans_id[]', 0)?>"  data-array_index="<?= $counter ?>"/>
         <?= form_label(lang('proj_launch_trans_last_name'),  'trans_last_name', array('class'=>'span2')); ?>
-        <?= form_input(array('name'=> 'trans_last_name[' . $counter . ']', 'value' => '' ,'id' => 'trans_last_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'last_name', 'data-search_area'=>'translator', 'data-array_index'=>$counter )); ?>
+        <?= form_input(array('name'=> 'trans_last_name[' . $counter . ']', 'value' => '' ,'id' => 'trans_last_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'last_name', 'data-filter_element'=>'trans_first_name[' . $counter . ']', 'data-search_area'=>'translator', 'data-array_index'=>$counter )); ?>
 
         <?= form_label(lang('proj_launch_auth_first_name'),  'trans_first_name', array('style'=>'margin-left:30px;width:140px')); ?>
-        <?= form_input(array('name'=> 'trans_first_name[' . $counter . ']', 'value' => '' ,'id' => 'trans_first_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'first_name' , 'data-search_area'=>'translator' , 'data-array_index'=>$counter)); ?>
+        <?= form_input(array('name'=> 'trans_first_name[' . $counter . ']', 'value' => '' ,'id' => 'trans_first_name[' . $counter . ']',  'class'=>'autocomplete', 'data-search_func'=>'autocomplete_author', 'data-search_field'=>'first_name' , 'data-filter_element'=>'trans_last_name[' . $counter . ']', 'data-search_area'=>'translator' , 'data-array_index'=>$counter)); ?>
      </div>
 </div>
 

--- a/public_html/js/common/application.js
+++ b/public_html/js/common/application.js
@@ -341,12 +341,18 @@ function _create_list_html(title ,array, page)
 }
 
 function author_string(item) {
-	var label = item.first_name ? item.first_name + ' ' + item.last_name : item.last_name;
-	var dob = (!item.dob || item.dob == 0) ? '' : item.dob;
-	var dod = (!item.dod || item.dod == 0) ? '' : item.dod;
-	if (dob || dod) {
-		label += ' (' + dob + ' - ' + dod + ')';
-	}
+    if (item.pseudo_last) {
+        var label = item.pseudo_first ? item.pseudo_first + ' ' + item.pseudo_last : item.pseudo_last;
+        label += ' (' + (item.first_name ? item.first_name + ' ' + item.last_name : item.last_name) + ')';
+    }
+    else {
+        var label = item.first_name ? item.first_name + ' ' + item.last_name : item.last_name;
+        var dob = (!item.dob || item.dob == 0) ? '' : item.dob;
+        var dod = (!item.dod || item.dod == 0) ? '' : item.dod;
+        if (dob || dod) {
+            label += ' (' + dob + ' - ' + dod + ')';
+        }
+    }
 
 	return label;
 }

--- a/public_html/js/common/autocomplete.js
+++ b/public_html/js/common/autocomplete.js
@@ -13,8 +13,16 @@ function set_autocomplete() {
             array_index = element.attr('data-array_index');
 			search_area = element.attr('data-search_area');
 
+            var filter_element_id = element.attr('data-filter_element');
+            if (filter_element_id) {
+                var filter_element_obj = $('input[id^="' + filter_element_id + '"]')[0];
+                var filter_field = filter_element_obj.attributes['data-search_field'].value;
+                var filter_term = filter_element_obj.value;
+            }
+
             $.ajax({ url: CI_ROOT + 'public/public_ajax/' + search_func,
-                data: { 'term': element.val(), 'search_field': search_field},
+                data: { 'term': element.val(), 'search_field': search_field,
+                    'filter_field': filter_field, 'filter_term':  filter_term},
                 dataType: "json",
                 type: "POST",
 				global: false, // prevent modal loader dialog


### PR DESCRIPTION
Status updated in a later comment.


----
**Status of this PR:**
* Code: is in need of some further tests before going live.
* "Do we want it?": Precisely the reason for the early PR.  I'd like folks to try it out on staging, when you have the time to put it there.

Until now, autocomplete for filling in author names has been confined to only searching by `last_name` of the "real" author entry in the database.  Pseudonyms are not included in the search list (#42), and for common names like "smith", we have too many results for folks to find the right one (#197)... resulting in duplicates as authors are re-added.  This PR addresses both.

I know this may be one of those 'too clever for your own good' situations, so please do let me know what you think, when you get the time.  I've rewritten this series of commits, which should hopefully make each one easier to follow than the larger chunk all at once.