### PR TITLE
Reveal keywords on project's catalogue page

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -2,5 +2,5 @@
 
 $config['migration_enabled'] = TRUE;
 $config['migration_type'] = 'sequential';
-$config['migration_version'] = 3;
+$config['migration_version'] = 4;
 $config['migration_path'] = APPPATH . 'migrations/';

--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -2,5 +2,5 @@
 
 $config['migration_enabled'] = TRUE;
 $config['migration_type'] = 'sequential';
-$config['migration_version'] = 2;
+$config['migration_version'] = 3;
 $config['migration_path'] = APPPATH . 'migrations/';

--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -121,6 +121,8 @@ $route['reader/get_results'] 	= "catalog/reader/get_results";
 $route['group/(:num)'] 			= "catalog/group/index/$1";
 $route['group/get_results'] 	= "catalog/group/get_results";
 
+$route['keywords/(:num)']                      = "catalog/keywords/index/$1";
+$route['keywords/get_results']         = "catalog/keywords/get_results";
 
 $route['sections/readers/(:num)']		= 'catalog/sections/readers/$1';
 

--- a/application/controllers/catalog/Keywords.php
+++ b/application/controllers/catalog/Keywords.php
@@ -1,0 +1,108 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Keywords extends Catalog_controller
+/**
+When passed a keywords_id, display a list of projects that have that keyword
+*/
+
+{
+
+	public function __construct()
+	{
+		parent::__construct();
+		$this->load->helper('general_functions_helper');
+	}
+
+	public function index($keywords_id)
+	{
+		if (empty($keywords_id)) {
+			show_404();
+		}
+		$this->load->model('keyword_model');
+		$this->data['keywords'] = $this->keyword_model->get($keywords_id);
+		$this->data['search_category'] = 'keywords';
+		$this->data['primary_key'] = $keywords_id;
+		$this->data['search_order'] = $this->input->get('search_order');
+		$params['keywords_id'] = $keywords_id;		
+		$params['offset'] = 0;
+		$params['limit'] = 1000000;
+		$params['search_order'] = $this->input->get('search_order');
+		$matches = $this->_get_projects_by_keywords_id($params);
+		$this->data['matches'] = count($matches);		
+		$this->_render('catalog/keywords');
+		return;
+	}
+	
+	function get_results()
+	{
+
+		// collect - search_category, sub_category, page_number, sort_order 
+		// and (sometimes) information about contents of project_type 
+		$input = $this->input->get(null, true);	
+			
+		$params['keywords_id'] = $input['primary_key'];
+		$params['search_order'] = $input['search_order'];
+
+		if (empty($params['keywords_id'])) {
+			show_error('A primary_key (keywords ID) must be supplied', 400);
+		}
+
+		//format offset
+		$params['offset'] = ($input['search_page'] - 1) * CATALOG_RESULT_COUNT;
+		
+		// format limit
+		$params['limit'] = CATALOG_RESULT_COUNT;
+		
+
+		
+		// format project_type_description. Note that values appearing here are not
+		// necessarily a match to values that appear in the projects.project_type column
+		// in the database - so we'll need to massage them later (in Project model->get_projects_by_keywords_id()).
+		if (array_key_exists('project_type', $input))
+		{
+			$params['project_type_description'] = $input['project_type'];
+		} else 
+		{
+			$params['project_type_description'] = 'either';
+		}
+
+		// go get results
+		$results = $this->_get_projects_by_keywords_id($params);
+		
+		// get full set by calling same function with different parameters
+		$params['offset'] = 0;
+		$params['limit'] = 1000000;
+
+		$full_set = $this->_get_projects_by_keywords_id($params);
+
+		// go format results
+		$retval['results'] = $this->_format_results($results, 'title');
+
+		//pagination
+		$page_count = (count($full_set) > CATALOG_RESULT_COUNT) ? ceil(count($full_set) / CATALOG_RESULT_COUNT) : 0;
+		$retval['pagination'] = (empty($page_count)) ? '' : $this->_format_pagination($input['search_page'], $page_count);
+
+		$retval['status'] = 'SUCCESS';
+
+		//return - results, pagination
+		if ($this->input->is_ajax_request())
+		{	
+			header('Content-Type: application/json;charset=utf-8');
+			echo json_encode($retval);
+			return;
+		}
+	}
+	
+	function _get_projects_by_keywords_id($params)
+	{
+		$this->load->model('project_model');
+		$projects = $this->project_model->get_projects_by_keywords_id($params);
+		
+		foreach ($projects as $key => $project)
+		{
+			$projects[$key]['author_list'] = $this->_author_list($project['id']);
+		}
+
+		return $projects;
+	}
+}

--- a/application/controllers/catalog/Page.php
+++ b/application/controllers/catalog/Page.php
@@ -61,6 +61,20 @@ class Page extends Catalog_controller
 		$this->data['volunteers']->bc = $this->user_model->get($this->data['project']->person_bc_id);
 		$this->data['volunteers']->mc = $this->user_model->get($this->data['project']->person_mc_id);
 		$this->data['volunteers']->pl = $this->user_model->get($this->data['project']->person_pl_id);
+	
+		
+		// **** KEYWORDS ****//
+		$MAX_KEYWORDS_TO_DISPLAY_INITIALLY = 10;
+		$this->data['keywords_array'] = $this->project_model->get_keywords_and_statistics_by_project($this->data['project']->id);
+		$this->data['project']->has_long_keywords_list = $this->_has_long_keywords_list($this->data['project']->id, $MAX_KEYWORDS_TO_DISPLAY_INITIALLY);
+		$this->data['project']->formatted_keywords_string_primary = $this->_formatted_keywords_string($this->data['project']->id, 
+													$this->data['project']->has_long_keywords_list, 
+													$MAX_KEYWORDS_TO_DISPLAY_INITIALLY, 
+													"primary_list");
+		$this->data['project']->formatted_keywords_string_secondary = $this->_formatted_keywords_string($this->data['project']->id, 
+													$this->data['project']->has_long_keywords_list, 
+													$MAX_KEYWORDS_TO_DISPLAY_INITIALLY, 
+													"secondary_list");
 
 		// **** MISC ****//
 		$this->data['project']->project_type = (trim($this->data['project']->project_type) == 'solo') ? 'solo' : 'group'; //keep on top - other values dependent on solo/group
@@ -170,7 +184,123 @@ class Page extends Catalog_controller
 
 		return implode(', ', $genres);
 	}
-
+	
+	function _formatted_keywords_string($project_id, $project_has_long_keywords_list, 
+						$max_keywords_to_display_initially, $list_variant)
+	{
+	/** 	The catalog page will contain one, or possibly two lists of keywords.
+		It will always contain a primary list.
+		If the project has more keywords than can conveniently be fitted in the primary list:
+		(a) We truncate this primary list
+		(b) We also output to the page a secondary list, iniitially hidden, that includes all the keywords for the project
+		(c) We add to the primary list a "Show full list" link which, if clicked, hides the primary list 
+		and shows the secondary list
+		*/
+		
+		$return_value = "";
+		
+		switch ($list_variant) {
+  			case "primary_list":
+  				if ($project_has_long_keywords_list)
+  				{
+  					$return_value =	$this->_formatted_truncated_keywords_string($project_id, $max_keywords_to_display_initially);
+  				} 
+  				else
+  				{
+  					$return_value =	$this->_formatted_full_keywords_string($project_id); 
+  				}
+    				break;
+  			case "secondary_list";
+    				if ($project_has_long_keywords_list)
+  				{
+  					$return_value =	$this->_formatted_full_keywords_string($project_id);
+  				} 
+    				break;
+  			default:
+    				$return_value = "";
+		}
+		return $return_value;
+	}
+	
+	
+	function _formatted_full_keywords_string($project_id) 
+	{
+		$return_value = '';
+		$keywords_array = $this->data['keywords_array'];
+		if (!empty($keywords_array))
+		{
+			foreach ($keywords_array as $key => $row)
+			{
+			// Add hyperlink only if at least two projects use this keyword
+				if ((int)$row['keyword_count'] > 1) 
+				{
+					$return_value .= '<a href="' . base_url() . 'keywords/' . $row['id'] . '">';
+				} 
+				$return_value .= $row['value'];
+				if ((int)$row['keyword_count'] > 1)
+				{
+					$return_value .= '</a>';
+				} 
+				$return_value .= ' (' . $row['keyword_count'] . '), ';
+			}
+		} 
+		else 
+		{
+			return $return_value;
+		}
+		// trim off final comma and trailing space 
+		$return_value = substr($return_value, 0, -2);
+		return $return_value;	
+	}
+	
+	function _formatted_truncated_keywords_string($project_id, $max_keywords_to_display_initially) 
+	{
+		$return_value = '';
+		$keywords_array = $this->data['keywords_array'];
+		if (!empty($keywords_array))
+		{
+			$i = 0;
+			foreach ($keywords_array as $key => $row)
+			{
+				
+			// Add hyperlink only if at least two projects use this keyword
+				if ((int)$row['keyword_count'] > 1) 
+				{
+					$return_value .= '<a href="' . base_url() . 'keywords/' . $row['id'] . '">';
+				} 
+				$return_value .= $row['value'];
+				if ((int)$row['keyword_count'] > 1)
+				{
+					$return_value .= '</a>';
+				} 
+				$return_value .= ' (' . $row['keyword_count'] . '), ';
+				$i++;
+				if ($i == $max_keywords_to_display_initially)
+				{
+					break;
+				}
+			}
+		} 
+		else 
+		{
+			return $return_value;
+		}
+		// trim off final comma and trailing space 
+		$return_value = substr($return_value, 0, -2);
+		
+		// Add "Show full list" link
+		$return_value .= " ... <a href='#' class='truncated-keywords js-truncated-keywords'>[Show full list]</a>";
+		
+		return $return_value;	
+	}
+	
+	function _has_long_keywords_list($project_id, $max_keywords_to_display_initially)
+	{
+		$keywords_number = $this->project_model->get_keywords_count_by_project($project_id)->keywords_number;
+		return $keywords_number > $max_keywords_to_display_initially;
+	}
+	
+		
 	function _language($language_id)
 	{
 		$this->load->model('language_model');

--- a/application/controllers/cron/Keywords_stats.php
+++ b/application/controllers/cron/Keywords_stats.php
@@ -1,0 +1,32 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Keywords_stats extends CI_Controller
+{
+	public function update_keywords_stats()
+	{
+		// Some keywords are not in use at all.
+		// Initialise count field to zero before tallying counts.
+		
+		$sql = '
+			UPDATE keywords
+			SET count = 0';
+		$this->db->query($sql);
+		
+		$sql = '
+			UPDATE keywords
+			JOIN
+			(SELECT pk.keyword_id as keyword_id, COUNT(pk.project_id) AS count
+        		FROM project_keywords pk
+        		GROUP BY 1
+			) as sub
+			ON keywords.id = sub.keyword_id
+			SET keywords.count = sub.count ';
+		$this->db->query($sql);
+
+	}
+}
+
+
+/* End of file Keyword_stats.php */
+/* Location: ./application/controllers/cron/Keyword_stats.php */
+

--- a/application/libraries/Catalog_item.php
+++ b/application/libraries/Catalog_item.php
@@ -211,6 +211,9 @@ class Catalog_item {
                 $this->ci->project_keyword_model->insert(array('project_id'=>$project_id));
             }
 		}
+		// For keywords used in this project, update 'instances' field of 'keywords' table now,
+                // so correct keyword instances stats can be shown on catalog page even before keywords cron stats job runs. 
+                $this->ci->project_keyword_model->set_keywords_statistics_by_project($project_id);
 
 	}
 

--- a/application/migrations/003_add_keywords_count_field.php
+++ b/application/migrations/003_add_keywords_count_field.php
@@ -1,0 +1,22 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Add_keywords_count_field extends CI_Migration {
+
+        public function up()
+        {
+		$fields = array(
+        		'count' => array('type' => 'INT',
+			'default' => '0',
+			'after' => 'value')
+		);
+		$this->dbforge->add_column('keywords', $fields);
+        }
+
+        public function down()
+        {
+                $this->dbforge->drop_column('keywords', 'count');
+        }
+}
+

--- a/application/migrations/004_drop_redundant_keywords_from_projects.php
+++ b/application/migrations/004_drop_redundant_keywords_from_projects.php
@@ -1,0 +1,52 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Drop_redundant_keywords_from_projects extends CI_Migration {
+
+        public function up()
+        {
+    		$sql = '
+		DELETE pk2.*
+		FROM project_keywords pk2
+		WHERE keyword_id IN
+		(
+			SELECT id 
+			FROM keywords k 
+			WHERE k.value in (
+			"librivox", 
+			"ibrivox",
+			"llibrivox",
+			"librixox",
+			"librivox;",
+			"libriox",
+			"libirivox",
+			"librivos",
+			"audio",
+			"audiobook",
+			"audiobooks",
+			"audio books",
+			"audio book",
+			"audioboek",
+			"audiobuch",
+			"audiobooklibrivox",
+			"audibook",
+			"audioook",
+			"autiobook",
+			"audiobook:",
+			"audioboo",
+			"audiolibro",
+			"audio libro",
+			"audiolibros",
+			"audiolivre",
+			"audiolivro"
+			)
+		)';
+    		$this->db->query($sql);
+        }
+
+        public function down()
+        {
+                ;
+        }
+}

--- a/application/models/Project_keyword_model.php
+++ b/application/models/Project_keyword_model.php
@@ -2,7 +2,27 @@
 
 class Project_keyword_model extends MY_Model {
 
-    
+   public function set_keywords_statistics_by_project($project_id)
+    {        
+        $sql = '
+ 	UPDATE keywords k
+	JOIN
+		(SELECT pk.keyword_id as keyword_id, COUNT(pk.project_id) AS count
+        	FROM project_keywords pk
+		GROUP BY 1
+		) as sub
+	ON k.id = sub.keyword_id
+	SET k.count = sub.count 
+	WHERE k.id IN
+		(SELECT keyword_id 
+        	FROM project_keywords
+        	WHERE project_id = ?)';
+
+
+        $query = $this->db->query($sql, array($project_id));
+    }
+
+
 }
 
 /* End of file project_keyword.php */

--- a/application/models/Project_keyword_model.php
+++ b/application/models/Project_keyword_model.php
@@ -3,7 +3,6 @@
 class Project_keyword_model extends MY_Model {
 
     
-
 }
 
 /* End of file project_keyword.php */

--- a/application/views/catalog/keywords.php
+++ b/application/views/catalog/keywords.php
@@ -1,0 +1,39 @@
+<?= $header;  ?>
+
+<div class="main-content advanced-search-form">
+		
+	<div id="sidebar_wrapper" >
+		<?= $sidebar;  ?>
+	</div>
+	
+	
+	<div class="browse browse-title">
+		<div class="browse-header-wrap">
+			<h4 class="browse-header"></h4>
+			<h3>Audiobooks tagged with keywords "<?= $keywords->value ?>"</h3>
+
+			<div class="sort-menu" id="sort_menu" style="display:none;">
+				<p>Order by</p>
+				<select class="js-sort-menu">
+					<option value="alpha" <?= $search_order === 'alpha' ? 'selected' : '' ?>>Alphabetically</option>
+					<option value="catalog_date" <?= $search_order === 'catalog_date' ? 'selected' : '' ?>>Release date</option>
+				</select> 
+			</div><!-- end .sort-menu -->
+			
+		</div>
+
+		<ul class="browse-list"></ul>
+	
+		<div class="page-number-nav"></div>
+	
+	</div>
+
+
+</div><!-- end .main-content -->
+
+<?= $footer;  ?>
+
+
+
+</body>
+</html>

--- a/application/views/catalog/page.php
+++ b/application/views/catalog/page.php
@@ -32,11 +32,18 @@
 				<p class="book-page-genre"><span>Genre(s):</span> <?= $project->genre_list; ?></p>
 
 				<p class="book-page-genre"><span>Language:</span> <?= $project->language; ?></p>
+				
+				<?php if(!empty($project->formatted_keywords_string_primary)): ?>
+				<p class="book-page-genre primary_keywords_string"><span>Keyword(s):</span> <?= $project->formatted_keywords_string_primary; ?></p>
+				<?php endif;?>
+				<?php if(!empty($project->formatted_keywords_string_secondary)): ?>
+				<p class="book-page-genre secondary_keywords_string" style="display:none;"><span>Keyword(s):</span> <?= $project->formatted_keywords_string_secondary; ?></p>
+				<?php endif;?>
 
 				<?php if(!empty($project->group)):?>
 				<p class="book-page-genre"><span>Group:</span> <a href="<?= base_url().'group/'. $project->group->group_id?>"><?= $project->group->group_name; ?></a></p>
 				<?php endif;?>
-
+				</p>
 				
 			</div> 	<!-- end .content-wrap --> 
 		

--- a/application/views/catalog/partials/footer.php
+++ b/application/views/catalog/partials/footer.php
@@ -87,7 +87,7 @@
 			var item = $('.js-menu_item[data-menu_item="'+search_category+'"]');
 			load_search_data(item, search_category);
 		}
-		else if (jQuery.inArray(current_page, ['author', 'reader', 'group']) > -1)
+		else if (jQuery.inArray(current_page, ['author', 'reader', 'group', 'keywords']) > -1)
 		{
 			get_results(current_page, search_page, sub_category, primary_key);
 		}
@@ -333,6 +333,15 @@
 	}	
 
 
+	$('.js-truncated-keywords').on('click', function(e){
+
+		e.preventDefault();
+		$('.secondary_keywords_string').show();
+		$('.primary_keywords_string').hide();
+		return false;	
+
+	});
+
 	$('.js-advanced-search').on('click', function(e){
 
 		// TODO: make toggle
@@ -348,6 +357,7 @@
 		return false;	
 
 	});
+	
 
 	function advanced_search_actions()
 	{


### PR DESCRIPTION
The effect of the changes proposed here would be:

- to display a list of keywords associated with a project on that project's catalog page, together with statistics indicating to the viewer how many other projects share each keyword, and 
- to allow the user, by clicking a hyperlinked keyword, immediately to list other projects associated with that keyword. 

In compiling this proposal, I have looked for opportunities to develop any relevant unit tests, but have not seen any.