### PR TITLE
Add catalog URL to ID3 tags

### DIFF
--- a/application/libraries/Librivox_id3tag.php
+++ b/application/libraries/Librivox_id3tag.php
@@ -127,7 +127,7 @@ class Librivox_id3tag{
 		    'genre'   => array('speech'),
 		    'playtime_string' => array('0:00'),
 		    'track'   => array($track),
-		    'url_source'	=> array($project->url_librivox),
+		    'url_source'  => array($project->url_librivox),
 		    //language??
 		);
 

--- a/application/libraries/Librivox_id3tag.php
+++ b/application/libraries/Librivox_id3tag.php
@@ -127,7 +127,7 @@ class Librivox_id3tag{
 		    'genre'   => array('speech'),
 		    'playtime_string' => array('0:00'),
 		    'track'   => array($track),
-        'url_source'	=> array($project->url_librivox),
+		    'url_source'	=> array($project->url_librivox),
 		    //language??
 		);
 

--- a/application/libraries/Librivox_id3tag.php
+++ b/application/libraries/Librivox_id3tag.php
@@ -127,6 +127,7 @@ class Librivox_id3tag{
 		    'genre'   => array('speech'),
 		    'playtime_string' => array('0:00'),
 		    'track'   => array($track),
+        'url_source'	=> array($project->url_librivox),
 		    //language??
 		);
 


### PR DESCRIPTION
This is a proposal to add the catalog URL to the ID3 tags of the mp3 files.

Discussion continued from https://github.com/LibriVox/librivox-catalog/pull/227


(I didn't realize I could just re-branch the upstream master, so I took the circuitous route of resetting my copy of the repo to prior to my commits and then forcing a push... Well, at least now I know how to do _that_.)