### PR TITLE
adding catalog webpage into url_source for id3 tags

### DIFF
--- a/application/libraries/Librivox_id3tag.php
+++ b/application/libraries/Librivox_id3tag.php
@@ -127,6 +127,7 @@ class Librivox_id3tag{
 		    'genre'   => array('speech'),
 		    'playtime_string' => array('0:00'),
 		    'track'   => array($track),
+		    'url_source'  => array($project->url_librivox),
 		    //language??
 		);
 


### PR DESCRIPTION
Added code to include catalog webpage in the ID3 tags.

Ok, i think I finally got it. A clean pull request with its one single commit.

(referencing https://github.com/LibriVox/librivox-catalog/pull/227 and https://github.com/LibriVox/librivox-catalog/pull/229)