### PR TITLE
Revert "Show 'Assign reader sections' by default for 'open' projects"

### DIFF
--- a/public_html/js/private/section_compiler/index.js
+++ b/public_html/js/private/section_compiler/index.js
@@ -356,14 +356,6 @@ $(document).ready(function() {
 		$('.add_btn').show(300);
 	});
 
-	// Show the 'Assign reader sections' button by default, if the project status is 'open'
-	var project_status = $('#status').val();
-	if (project_status == 'open')
-	{
-		$('#assign_reader_toggle').hide();
-		$('#assign_reader_div').show();
-	}
-
 
 });
 


### PR DESCRIPTION
Reverting, by admin request.  Consensus: :+1: 

The feature was useful for some, but a (slight, but frequent) annoyance for others, as it would cause a hitch in the page load that I never noticed.