### PR TITLE
Add edit link to Project page for administrators

### DIFF
--- a/application/controllers/catalog/Page.php
+++ b/application/controllers/catalog/Page.php
@@ -7,6 +7,7 @@ class Page extends Catalog_controller
 	{
 		parent::__construct();
 		$this->load->helper('general_functions_helper');
+		$this->load->library('Librivox_auth');
 	}
 
 	public function index($slug)
@@ -32,6 +33,9 @@ class Page extends Catalog_controller
 			$this->_render('catalog/not_found');
 			return;
 		}
+		
+		//create link to project editing page for logged in user with appropriate permissions
+		$this->data['project']->edit_link = $this->_get_edit_link($this->data['project']->id);
 
 		// **** AUTHORS ****//
 		$this->data['authors_string'] = '';
@@ -112,6 +116,33 @@ class Page extends Catalog_controller
 
 		$this->_render('catalog/page');
 		return;
+	}
+	
+	
+	function _get_edit_link($project_id)
+	{
+		$link = '';
+		$auth_checker = new Librivox_auth();
+		
+		if (empty($project_id))
+		{
+			return $link;
+		}
+		
+		$user_id = $auth_checker->get_user_id();
+		if ($user_id < 1) {
+			return $link;
+		}
+		
+		//check permissions
+		$allowed_groups = array(PERMISSIONS_ADMIN, PERMISSIONS_MCS);		
+		if ($auth_checker->has_permission($allowed_groups, $user_id))
+		{
+			$link = base_url() . 'add_catalog_item/' . $project_id ;
+			return $link;
+		}
+		
+		return $link;
 	}
 
 	function _project_group($project_id = 0)

--- a/application/views/catalog/partials/book_sidebar.php
+++ b/application/views/catalog/partials/book_sidebar.php
@@ -88,6 +88,10 @@
 		<?php if (!empty($project->project_urls)): foreach ($project->project_urls as $project_url): ?>
 			<p><a href="<?= $project_url->url ?>"><?= $project_url->label?></a></p>
 		<?php endforeach; endif; ?>
+		
+		<?php if (!empty($project->edit_link)): ?>
+			<p><a href="<?= $project->edit_link ?>">Edit this page</a></p>
+		<?php endif; ?>
 
 	</div>
 				


### PR DESCRIPTION
The effect of this change is to add an "Edit this page" link at the bottom of the "Links" section of a project's Catalog page, in the left sidebar. The link is visible only to a user logged in with the same administrative privileges as are required to edit a project page. Other users see nothing. 

This screenshot below shows what such a link looks like in our development environment. In this example, the link is to URL https://librivox.org/add_catalog_item/14934, which is the Project Details page for this project.

<img width="287" alt="Screenshot 2024-06-27 at 6 29 16 PM" src="https://github.com/LibriVox/librivox-catalog/assets/65576684/794ea84d-de63-4f68-a04f-cfdc70446b4e">
