### PR TITLE
Insert missing period character in IA audiobook description

### DIFF
--- a/application/views/private/validator/archive_description.php
+++ b/application/views/private/validator/archive_description.php
@@ -1,5 +1,5 @@
 <a href="https://librivox.org/">LibriVox</a> recording of <?= $title ?> by <?= $authors ?>. <?= $translators ?><br />
-Read in <?= $language ?> by <?= $reader_name ?><br /><br />
+Read in <?= $language ?> by <?= $reader_name ?>.<br /><br />
 <?= $description ?><br /><br />
 For further information, including links to online text, reader information, RSS feeds, CD cover or other formats (if available), please go to the <a href="<?= $catalog_url ?>">LibriVox catalog page</a> for this recording.<br /><br />
 For more free audio books or to become a volunteer reader, visit <a href="https://librivox.org/">librivox.org</a>.<br /><br />


### PR DESCRIPTION
A forum member has noticed (https://forum.librivox.org/viewtopic.php?t=103606) that there is a period character missing immediately after the reader identifier in the book description that appears at archive.org.

This fix addresses that issue.