### PR TITLE
More consistent ordering of autocomplete results

### DIFF
--- a/application/models/Author_model.php
+++ b/application/models/Author_model.php
@@ -10,7 +10,7 @@ class Author_model extends MY_Model
 
 		$name_clause = '';
 		$bindings = array();
-		$sort_order = 'last_name';
+		$sort_order = 'TRIM(COALESCE(pseudo_first, first_name)), TRIM(COALESCE(pseudo_last, last_name))';
 
 		switch ($search_field)
 		{
@@ -33,9 +33,9 @@ class Author_model extends MY_Model
 						AND CONCAT(match_table.first_name, " ", match_table.last_name) LIKE ?';
 					$bindings =  array_merge($bindings, array('%'. $term .'%'));
 				}
-				else
+				elseif (empty($filter_term))
 				{
-					$search_order = 'first_name';
+					$sort_order = 'TRIM(COALESCE(pseudo_last, last_name)), TRIM(COALESCE(pseudo_first, first_name))';
 				}
 				break;
 
@@ -54,8 +54,6 @@ class Author_model extends MY_Model
 						AND (match_table.first_name LIKE ?
 							OR (match_table.first_name = "" AND match_table.last_name LIKE ?) )';
 					$bindings =  array_merge($bindings, array('%'. $name_parts[1] .'%', '%'. $name_parts[1] .'%'));
-
-					$sort_order = 'first_name';
 				}
 				break;
 
@@ -77,8 +75,6 @@ class Author_model extends MY_Model
 						AND (match_table.first_name LIKE ?
 							OR (match_table.first_name = "" AND match_table.last_name LIKE ?) )';
 					$bindings =  array_merge($bindings, array('%'. $name_parts[0] .'%', '%'. $name_parts[1] .'%', '%'. $name_parts[1] .'%'));
-
-					$sort_order = 'first_name';
 				}
 				break;
 		}


### PR DESCRIPTION
As discussed with admins (and with thanks to Peter/TheBanjo for suggesting it), this adjusts the order of autocomplete suggestions.  This seems small enough to go live.  :+1: 

- Pseudonyms are now properly sorted (an edge case remains when both the "real" name and pseudonym are suggested at once)
- We ignore leading spaces, for the purpose of sorting
- We sort by firstname, lastname in most cases.  We reverse that order when searching by first name _only_.



In case someone's leery of `COALESCE()`, I can confirm that it does NOT mix separate data rows here.  It returns the first not-null argument that is fed to it, as it is run on each _individual_ row.
For example, if I were to call `COALESCE( A, B )` on a table like this:
**A**|**B**
-|-
null|1
2|null
3|4

...then the result would be this:

|**Result**|
|-|
|1|
|2|
|3|

No fear of mixing the rows!