### PR TITLE
Advanced Search by language: All Except English

### DIFF
--- a/application/config/constants.php
+++ b/application/config/constants.php
@@ -92,6 +92,8 @@ define('CATALOG_RESULT_COUNT',				25);
 
 define ('AUTOCOMPLETE_LIMIT', 100);
 
+define ('ALL_EXCEPT_ENGLISH', -1);
+
 
 /* End of file constants.php */
 /* Location: ./application/config/constants.php */

--- a/application/controllers/catalog/Search.php
+++ b/application/controllers/catalog/Search.php
@@ -123,7 +123,7 @@ class Search extends Catalog_controller
 		$this->data['languages'] = $this->config->item('languages');
 
 		$this->load->model('language_model');
-		$this->data['recorded_languages'] = full_languages_dropdown('recorded_language', $this->data['advanced_search_form']['recorded_language']);
+		$this->data['recorded_languages'] = full_languages_dropdown('recorded_language', $this->data['advanced_search_form']['recorded_language'], true);
 
 		$this->load->model('genre_model', 'model');
 		$genres = $this->model->order_by('lineage', 'asc')->as_array()->get_all();

--- a/application/helpers/general_functions_helper.php
+++ b/application/helpers/general_functions_helper.php
@@ -116,7 +116,7 @@ function alphabet()
 }
 
 
-function full_languages_dropdown($id='', $selected_id=''  )
+function full_languages_dropdown($id='', $selected_id='', $show_all_except_english=false)
 {
     $ci = &get_instance();
 
@@ -135,6 +135,13 @@ function full_languages_dropdown($id='', $selected_id=''  )
         //separator
         $selected = ($selected_id == '')? ' selected ': '';
         $html .= '<option value="" '. $selected .' > ------ </option>';
+    }
+
+    if ($show_all_except_english)
+    {
+        $selected = ($selected_id == ALL_EXCEPT_ENGLISH) ? ' selected ': '';
+        $html .= '<option value="'. ALL_EXCEPT_ENGLISH .'" '. $selected .' >All Except English</option>';
+        $html .= '<option value=""> ------ </option>';
     }
 
     if (!empty($languages))

--- a/application/libraries/Librivox_search.php
+++ b/application/libraries/Librivox_search.php
@@ -75,7 +75,7 @@ class Librivox_search{
 		$language_clause = ' ';
 		$section_language_clause = ' ';
 		$recorded_language = (int)$params['recorded_language'];
-		if ($recorded_language !== 0)
+		if ($recorded_language > 0)
 		{
 			if (empty($params['title']) and empty($params['author']) and empty($params['reader']))
 			{
@@ -101,6 +101,24 @@ class Librivox_search{
 				$section_language_clause = '
 					AND ( st.section_language_id = ' . $recorded_language . '
 						OR ( st.section_language_id IS NULL AND p.language_id = ' . $recorded_language . ') ) ';
+			}
+		}
+		elseif ($recorded_language === ALL_EXCEPT_ENGLISH)
+		{
+			// "All Except English" query
+
+			$language_clause = ' AND p.language_id <> 1';
+
+			// Again, only show individual sections if we're searching, rather than browsing
+			if (empty($params['title']) and empty($params['author']) and empty($params['reader']))
+			{
+				$section_language_clause = ' AND FALSE ';
+			}
+			else
+			{
+				$section_language_clause = '
+					AND st.section_language_id <> 1
+					AND p.language_id <> 1';
 			}
 		}
 


### PR DESCRIPTION
Consensus: :+1: 

This adds an 'All Except English' option to the Advanced Search drop-down, and one more stanza to the Search controller to implement it.  The option is not visible anywhere except Advanced Search.