### PR TITLE
Manual sorting for genres

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -2,5 +2,5 @@
 
 $config['migration_enabled'] = TRUE;
 $config['migration_type'] = 'sequential';
-$config['migration_version'] = 0;
+$config['migration_version'] = 1;
 $config['migration_path'] = APPPATH . 'migrations/';

--- a/application/migrations/001_add_genre_sort.php
+++ b/application/migrations/001_add_genre_sort.php
@@ -1,0 +1,48 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Add_genre_sort extends CI_Migration {
+
+        public function up()
+        {
+                // Fix 'lineage' being required.  It is set immediately _after_ a genre is created.
+                $fields = array(
+                        'lineage' => array(
+                                'type' => 'text',
+                                'default' => ''
+                        )
+                );
+                $this->dbforge->modify_column('genres', $fields);
+
+                // Add 'sort_order'.  This is relative to other items within the same sub-menu.
+                $fields = array(
+                        'sort_order' => array(
+                                'type' => 'INT',
+                                'default' => '20',
+                                'after' => 'meta_in_progress'
+                        )
+                );
+                $this->dbforge->add_column('genres', $fields);
+
+                // Set the desired sort order for existing genre items
+                $explicit_orders = array(
+                        array('id' => 52, 'sort_order' => 15), // General fiction -> Published before 1800
+
+                        array('id' => 113, 'sort_order' => 10), // Non-Fiction -> History -> Antiquity
+                        array('id' => 114, 'sort_order' => 15), // Non-Fiction -> History -> Middle Ages/Middle History
+
+                        array('id' => 123, 'sort_order' => 10), // Non-Fiction -> Philosophy -> Ancient
+                        array('id' => 124, 'sort_order' => 15), // Non-Fiction -> Philosophy -> Medieval
+                        array('id' => 127, 'sort_order' => 25), // Non-Fiction -> Philosophy -> Contemporary
+                        array('id' => 143, 'sort_order' => 30), // Non-Fiction -> Philosophy -> Atheism & Agnosticism
+                );
+                $this->db->update_batch('genres', $explicit_orders, 'id');
+        }
+
+        public function down()
+        {
+                $this->dbforge->drop_column('genres', 'sort_order');
+        }
+}
+

--- a/application/tests/libraries/Mahana_hierarchy_test.php
+++ b/application/tests/libraries/Mahana_hierarchy_test.php
@@ -1,0 +1,293 @@
+<?php
+use PhpParser\Builder\Property;
+use function PHPUnit\Framework\assertEquals;
+
+class Mahana_hierarchy_test extends TestCase
+{
+	public function setUp(): void
+	{
+		$this->resetInstance();
+		$this->CI->load->library('Mahana_hierarchy');
+	}
+
+	/**
+	* @dataProvider provider
+	*/
+	public function test__recurseSort($nodeList, $parent_id, $expected) {
+		$actual = $this->CI->mahana_hierarchy->_recurseSort($nodeList, $parent_id);
+
+		assertEquals(count($expected), count($actual));
+		foreach ($actual as $ndx => $item) {
+			assertEquals($expected[$ndx], $item['id']);
+		}
+	}
+
+
+
+
+	function _flatten($node, $depth, &$nodeList) {
+		if (isset($node['children'])) {
+			foreach ($node['children'] as $child) {
+				$nodeList[] = array('id' => $child['id'], 'depth' => $depth);
+				$this->_flatten($child, $depth + 1, $nodeList);
+			};
+		};
+	}
+
+	/**
+	* @dataProvider provider
+	*/
+	public function test__findChildren($nodeList, $parent_id, $expected, $e_depths) {
+		$actual = $this->CI->mahana_hierarchy->_findChildren($nodeList, $parent_id);
+		$flattened = array();
+		$this->_flatten(array('children' => $actual), 0, $flattened);
+		foreach ($expected as $ndx => $id) {
+			assertEquals($id, $flattened[$ndx]['id']);
+			assertEquals($e_depths[$ndx], $flattened[$ndx]['depth']);
+		}
+	}
+
+	public static function provider() {
+		$cases = array(
+			
+			// Simple case - flat structure, sorted alphabetically regardless of ID or order of appearance.
+			array(  
+				array(
+					7 => array(
+						'id' => 7,
+						'name' => '1st item',
+						'parent_id' => 0,
+						'sort_order' => 0
+					),
+					1 => array(
+						'id' => 1,
+						'name' => '3rd item',
+						'parent_id' => 0,
+						'sort_order' => 0
+					),
+					9 => array(
+						'id' => 9,
+						'name' => '2nd item',
+						'parent_id' => 0,
+						'sort_order' => 0
+					),
+				),
+				0,
+				array(7, 9, 1),
+				array(0, 0, 0)
+			),
+
+			// Mixed sort - by sort_order and then alphabetically, not by ID
+			array(  
+				array(
+					7 => array(
+						'id' => 7,
+						'name' => 'bbb - 3rd item',
+						'parent_id' => 0,
+						'sort_order' => 0
+					),
+					8 => array(
+						'id' => 8,
+						'name' => 'zzz - 1st item',
+						'parent_id' => 0,
+						'sort_order' => -1
+					),
+					 9 => array(
+						'id' => 9,
+						'name' => 'aaa - 2nd item',
+						'parent_id' => 0,
+						'sort_order' => 0
+					),
+				),
+				0,
+				array(8, 9, 7),
+				array(0,0,0)
+			),
+
+			/* Add sub-items
+			| Sub-items should immediately follow their parent:
+			| * Items at the same 'depth', but with different parents should never be adjacent
+			| * Items without a reachable parent should not be listed at all
+			*/
+			array(  
+				array(
+					8 => array(
+						'id' => 8,
+						'name' => 'zzz - 1st item at top level',
+						'parent_id' => 0,
+						'sort_order' => -1
+					),
+					9 => array(
+						'id' => 9,
+						'name' => 'aaa - 2nd item at top level',
+						'parent_id' => 0,
+						'sort_order' => 0
+					),
+					2 => array(
+						'id' => 2,
+						'name' => 'zzz - sub-item of the first item',
+						'parent_id' => 8,
+						'sort_order' => 0
+					),
+					1 => array(
+						'id' => 1,
+						'name' => 'aaa - sub-item of the second item',
+						'parent_id' => 9,
+						'sort_order' => 0
+					),
+					404 => array(
+						'id' => 404,
+						'name' => 'un-parented item, which should not appear',
+						'parent_id' => 404,
+						'sort_order' => 404
+					),
+				),
+				0,
+				array(8, 2, 9, 1),
+				array(0, 1, 0, 1)
+			),
+
+			// Add a few more...
+			array(  
+				array(
+					45 => array(
+						'id' => 45,
+						'name' => 'zzz - 1st item at top level',
+						'parent_id' => 0,
+						'sort_order' => 50
+					),
+					900 => array(
+						'id' => 900,
+						'name' => 'aaa - 2nd item at top level',
+						'parent_id' => 0,
+						'sort_order' => 51
+					),
+					77 => array(
+						'id' => 77,
+						'name' => 'bbb - 3rd item at top level',
+						'parent_id' => 0,
+						'sort_order' => 51
+					),
+					2 => array(
+						'id' => 2,
+						'name' => 'zzz - sub-item of the first item',
+						'parent_id' => 45,
+						'sort_order' => 0
+					),
+					85 => array(
+						'id' => 85,
+						'name' => 'aaa - first sub-item of the second item',
+						'parent_id' => 900,
+						'sort_order' => 0
+					),
+					64 => array(
+						'id' => 64,
+						'name' => 'ccc - sub-item of the first item',
+						'parent_id' => 45,
+						'sort_order' => 0
+					),
+					5 => array(
+						'id' => 5,
+						'name' => 'aaa - last sub-item of the first item',
+						'parent_id' => 45,
+						'sort_order' => 1
+					),
+					13 => array(
+						'id' => 13,
+						'name' => 'sub-sub item',
+						'parent_id' => 5,
+						'sort_order' => 1
+					),
+					72 => array(
+						'id' => 72,
+						'name' => 'sub-sub item',
+						'parent_id' => 5,
+						'sort_order' => 0
+					),
+					33 => array(
+						'id' => 33,
+						'name' => 'second sub-item of the second top-level item',
+						'parent_id' => 900,
+						'sort_order' => 0
+					),
+				),
+				0,
+				array(45, 64, 2, 5, 72, 13, 900, 85, 33, 77),
+				array( 0,  1, 1, 1,  2,  2,   0,  1,  1,  0)
+			),
+		);
+
+		// Test sorting the same tree, but one level down - #45 as the parent.
+		$cases[] = array(
+			array(
+				45 => array(
+					'id' => 45,
+					'name' => 'final test - 1st item at top level',
+					'parent_id' => 0,
+					'sort_order' => 50
+				),
+				900 => array(
+					'id' => 900,
+					'name' => 'aaa - 2nd item at top level',
+					'parent_id' => 0,
+					'sort_order' => 51
+				),
+				77 => array(
+					'id' => 77,
+					'name' => 'bbb - 3rd item at top level',
+					'parent_id' => 0,
+					'sort_order' => 51
+				),
+				2 => array(
+					'id' => 2,
+					'name' => 'zzz - sub-item of the first item',
+					'parent_id' => 45,
+					'sort_order' => 0
+				),
+				85 => array(
+					'id' => 85,
+					'name' => 'aaa - first sub-item of the second item',
+					'parent_id' => 900,
+					'sort_order' => 0
+				),
+				64 => array(
+					'id' => 64,
+					'name' => 'ccc - sub-item of the first item',
+					'parent_id' => 45,
+					'sort_order' => 0
+				),
+				5 => array(
+					'id' => 5,
+					'name' => 'aaa - last sub-item of the first item',
+					'parent_id' => 45,
+					'sort_order' => 1
+				),
+				13 => array(
+					'id' => 13,
+					'name' => 'sub-sub item',
+					'parent_id' => 5,
+					'sort_order' => 1
+				),
+				72 => array(
+					'id' => 72,
+					'name' => 'sub-sub item',
+					'parent_id' => 5,
+					'sort_order' => 0
+				),
+				33 => array(
+					'id' => 33,
+					'name' => 'second sub-item of the second top-level item',
+					'parent_id' => 900,
+					'sort_order' => 0
+				),
+			),
+			45,
+			array(64, 2, 5, 72, 13),
+			array( 0, 0, 0,  1,  1)
+		);
+
+		return $cases;
+	}
+}
+
+?>

--- a/application/views/admin/genre_manager/index.php
+++ b/application/views/admin/genre_manager/index.php
@@ -10,14 +10,15 @@
 		<table>
 			<thead>
 				<tr>
-					<th>Genre</th><th>Parent</th><th></th>
+					<th>Genre</th><th>Parent</th><th>Sort Order</th><th></th>
 				</tr>
 			</thead>			
 
 			<tbody>
 				<tr>
 					<td><input id="genre_0"  style="width:350px;"/></td>
-					<td style="width:350px;"> <?= form_dropdown('parent_id_0' , $genre_dropdown, 0, 'id="parent_id_0"');?> </td>
+					<td style="width:320px;"> <?= form_dropdown('parent_id_0' , $genre_dropdown, 0, 'id="parent_id_0"');?> </td>
+					<td><input id="sort_order_0" style="width:30px; text-align:right" value="20"></input></td>
 					<td><button class="btn btn-small btn-primary save_genre" data-genre_id="0">Save</button></td>
 				</tr>
 			</tbody>
@@ -31,7 +32,12 @@
 
 		<thead>
 			<tr>
-				<th>Genre</th><th>Parent</th><th></th>
+				<th>Genre</th>
+				<th>Parent</th>
+				<th rel="tooltip" class="tooltip-host" data-original-title="Override the order of items in each menu.  Lower numbers are sorted first.  Matching numbers are sorted alphabetically.">
+					Sort Order
+				</th>
+				<th></th>
 			</tr>
 		</thead>
 
@@ -39,7 +45,8 @@
 		<?php foreach ($genres as $key=>$genre): ?>
 			<tr>
 				<td><input id="genre_<?= $genre['id']?>" value="<?= $genre['name']?>"  style="width:350px;margin-left:<?= $genre['deep'] * 40?>px; "/></td>
-				<td style="width:350px;"> <?= form_dropdown('parent_id_'.$genre['id'] , $genre_dropdown, $genre['parent_id'], 'id="parent_id_'.$genre['id'].'"');?> </td>
+				<td style="width:320px;"> <?= form_dropdown('parent_id_'.$genre['id'] , $genre_dropdown, $genre['parent_id'], 'id="parent_id_'.$genre['id'].'"');?> </td>
+				<td><input style="width:30px; text-align:right" id="sort_order_<?= $genre['id']?>" value="<?= $genre['sort_order'];?>"> </input></td>
 				<td><button class="btn btn-small btn-primary save_genre" data-genre_id="<?= $genre['id']?>">Save</button></td>
 			</tr>
 		<?php endforeach; ?>

--- a/public_html/js/admin/genre_manager/index.js
+++ b/public_html/js/admin/genre_manager/index.js
@@ -1,15 +1,18 @@
-
+$(document).ready(function(){
+  $('.tooltip-host').tooltip();
+});
 
 $('.save_genre').live('click', function(){
 
     var genre_id 	= $(this).attr('data-genre_id');
     var name 		= $('#genre_'+ genre_id).val();
     var parent_id 	= $('#parent_id_'+ genre_id).val();
+    var sort_order 	= $('#sort_order_'+ genre_id).val();
     
     $.ajax({
           url: CI_ROOT + 'admin/genre_manager/update_genre',
           type: 'post',
-          data: {'id' : genre_id, 'name' : name, 'parent_id': parent_id },
+          data: {'id' : genre_id, 'name' : name, 'parent_id': parent_id, 'sort_order': sort_order },
           complete: function(r){
             var response_obj = jQuery.parseJSON(r.responseText);
 

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -282,13 +282,18 @@ class CI_Migration {
 			include_once($file);
 			$class = 'Migration_'.ucfirst(strtolower($this->_get_migration_name(basename($file, '.php'))));
 
+			// Add the following line as part of change to allow compatibility with PHP 8
+			$instance = new $class;
+
 			// Validate the migration file structure
 			if ( ! class_exists($class, FALSE))
 			{
 				$this->_error_string = sprintf($this->lang->line('migration_class_doesnt_exist'), $class);
 				return FALSE;
 			}
-			elseif ( ! is_callable(array($class, $method)))
+
+			// The following modification is required for PHP 8
+			elseif ( ! is_callable(array($instance, $method)))
 			{
 				$this->_error_string = sprintf($this->lang->line('migration_missing_'.$method.'_method'), $class);
 				return FALSE;


### PR DESCRIPTION
Consensus: :+1: 
Resolves #57 - if we can adjust the ordering within the existing genre drop-down, it doesn't need to be split in two.  :grin: 

Adds a new 'Sort Order' field in Genre Manager.  Changing this number overrides the otherwise-alphabetical sorting.

Also fixes two unfiled bugs:
* The `genre.lineage` column did not have a default, so new genres could not be created.
* Genre Manager allowed setting a genre's parent as... itself, or one of its sub-items.  These genres would then need to be re-created, or fixed directly from the database.

More details in each commit, and: a special thanks to @peterjdann for figuring out that migration bug.  In case this branch makes it live before yours does, I've added you as co-author for the commit that does it here.  :+1: 