### PR TITLE
Section compiler fixes

### DIFF
--- a/application/controllers/private/Section_compiler.php
+++ b/application/controllers/private/Section_compiler.php
@@ -125,6 +125,10 @@ class Section_compiler extends Private_Controller
 		$value = $this->input->post('value', true);
 
 		list($field, $section_number) = explode('-', $id);
+		if ($field == 'title')
+		{
+			$value = strip_tags($value);
+		}
 
 		$this->section_model->update($section_number, array($field => trim($value)));
 
@@ -137,6 +141,11 @@ class Section_compiler extends Private_Controller
 	public function add_section()
 	{
 		$fields = $this->input->post(null, true);
+		$fields['title'] = strip_tags($fields['title']);
+		foreach ($fields as $field => $value)
+		{
+			$fields[$field] = trim($value);
+		}
 
 		$max_section_number = $this->section_model->get_max_section_number($fields['project_id']);
 
@@ -230,6 +239,11 @@ class Section_compiler extends Private_Controller
 	public function add_meta_data()
 	{
 		$fields = $this->input->post(null, true);
+
+		foreach ($fields as $field => $value)
+		{
+			$fields[$field] = trim($value);
+		}
 
 		$fields['playtime'] = time_string_to_secs($fields['playtime']);
         $fields['language_id'] = $fields['language_id'] ? $fields['language_id'] : NULL;

--- a/public_html/js/private/section_compiler/index.js
+++ b/public_html/js/private/section_compiler/index.js
@@ -185,13 +185,9 @@ $(document).ready(function() {
 	        type: 'post',
 	        data: {'section_id': section_id},
 	        complete: function(r){
-	        	var deleted_row = btn.closest('tr').get(0);
-
-	  			oTable.fnDeleteRow(
-					oTable.fnGetPosition(
-						deleted_row
-					)
-				);	
+	            btn.closest('tr').remove();
+	            order_sections();
+	            relabel_section_numbers();
 	        }	
 	    });
 


### PR DESCRIPTION
Fixes #168.  Sections that you have moved do not "jump back" to their previous locations when you delete another section.

Progress toward #36, removing white-space from inputs in Section Compiler.  There are still edge-cases elsewhere, though.

