### PR TITLE
Template Generator: move app language selector

### DIFF
--- a/application/views/public/project_launch/index.php
+++ b/application/views/public/project_launch/index.php
@@ -18,14 +18,19 @@
                <a href="<?= base_url()?>workflow" class="menu_link">LibriVox Dashboard</a>
                <a href="https://forum.librivox.org" class="menu_link">LibriVox Forum</a>
                <a href="<?= base_url()?>pages/workflow-help" class="menu_link">Help</a>
-               <br />
-               <?= form_dropdown('lang_select', $languages, $current_lang , 'id="lang_select" style="float:right;margin-top:20px;"'); ?>
           </div>
      </div>
 
      <div class="clearfix"></div>
 
      <div style='margin-top: 20px;'>
+
+               <div class="control-group">
+                    <div class="controls center">
+                         <?= form_label(lang('proj_launch_choose_lang'),  'lang_select', array('class'=>'span3')); ?>
+                         <?= form_dropdown('lang_select', $languages, $current_lang , 'id="lang_select"'); ?>
+                    </div>
+               </div>
           
 
                <?= validation_errors('<div class="alert alert-error">', '</div>'); ?>


### PR DESCRIPTION
Resolves #74. The selection box that changes the language for the final
 template, and for the form itself, is now front-and-center.

Thanks to someone's foresight, we already have translations for the new label string - the bit that is, in English, 'Select a language for your template'.