### PR TITLE
Update author stats correctly, and show plurality

### DIFF
--- a/application/controllers/cron/Project_status_stats.php
+++ b/application/controllers/cron/Project_status_stats.php
@@ -22,6 +22,14 @@ class Project_status_stats extends CI_Controller
 
 	public function author()
 	{
+		// Reset completion and in-progress counts for all authors
+		// This avoids an edge-case in the later queries: if there are no projects with the given author or status, they leave meta_complete
+		//  and meta_in_progress untouched, resulting in 'phantom' project counts.
+		$this->db->query('
+			UPDATE authors
+			SET meta_complete = 0,
+				meta_in_progress = 0');
+
 		$sql = '
 			UPDATE authors
 			JOIN 

--- a/application/helpers/previewer_helper.php
+++ b/application/helpers/previewer_helper.php
@@ -255,3 +255,9 @@ function format_playtime($seconds)
 	$hours     = ($remainder - $minutes) / 60;
 	return sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);
 }
+
+/** Example: translate_plural("%d book", "%d books", $n) => "1 book" or "13 books" */
+function translate_plural($one, $other, $n)
+{
+	return sprintf(ngettext($one, $other, $n), $n);
+}

--- a/application/views/catalog/item_blades/author_blade.php
+++ b/application/views/catalog/item_blades/author_blade.php
@@ -6,7 +6,10 @@
 
 	<div class="result-data">
 		<h3><?= format_author($item, FMT_AUTH_YEARS|FMT_AUTH_HTML|FMT_AUTH_LINK) ?></h3>
-		<p class="book-meta">Completed: <span><?= $item['meta_complete']?> books</span> | In progress: <span><?= $item['meta_in_progress']?> books</span></p>
+		<p class="book-meta">
+			Completed: <span><?= translate_plural("%d book", "%d books", $item['meta_complete']) ?></span>
+			| In progress: <span><?= translate_plural("%d book", "%d books", $item['meta_in_progress']) ?></span>
+		</p>
 	</div>	
 	<a href="<?= base_url('author/'. $item['author_id']) ?>" class="more-result">more results</a>		
 </li>


### PR DESCRIPTION
Replaces #14 - we may as well benefit from fixing the in-progress statistic, and showing plurality for "book" vs "books".  Removing the statistics line isn't something we're sure we want.  Better to add to it instead, when we get around to that.  :wink: 