### PR TITLE
Remove extra slashes from zip_url

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -2,5 +2,5 @@
 
 $config['migration_enabled'] = TRUE;
 $config['migration_type'] = 'sequential';
-$config['migration_version'] = 1;
+$config['migration_version'] = 2;
 $config['migration_path'] = APPPATH . 'migrations/';

--- a/application/migrations/002_fix_zip_urls.php
+++ b/application/migrations/002_fix_zip_urls.php
@@ -1,0 +1,18 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Fix_zip_urls extends CI_Migration {
+
+        public function up()
+        {
+                $this->db->query('
+                        UPDATE projects
+                        SET zip_url = REGEXP_REPLACE(zip_url, "download//", "download/")
+                        WHERE zip_url LIKE "https://www.archive.org/download//%"
+                ');
+        }
+
+        public function down(): void
+        {}
+}


### PR DESCRIPTION
After Archive's recent updates, these URLs with double-slashes are no longer usable.  We get 'missing required path parameter'.  Remove the extra slash, and these projects are downloadable again!

If you'd like to test this out, here's one test case:
https://librivox.org/boy-the-wandering-dog-by-marshall-saunders/
Currently on live, the zip link doesn't work.  In localdev with this migration, it does.  :grin: 