### PR TITLE
Fix zero-sized files (and some warnings)

### DIFF
--- a/application/controllers/private/Validator.php
+++ b/application/controllers/private/Validator.php
@@ -324,7 +324,7 @@ class Validator extends Private_Controller
 			$this->librivox_id3tag->_update_section($section->id, array('file_name' => $file_name, 'playtime' => $playtime));
 		}
 
-		$this->ajax_output(array('message' => 'Files copied.', 'tags' => $tag_data, 'full_tags' => $fullid3_tags), TRUE);
+		$this->ajax_output(array('message' => 'Files copied.'), TRUE);
 	}
 
 	function get_file_tags()

--- a/application/controllers/private/Validator.php
+++ b/application/controllers/private/Validator.php
@@ -298,12 +298,8 @@ class Validator extends Private_Controller
 			{
 				$file_name = $this->_copy_file($local_file, $copy_to_dir);
 			}
-			else
-			{
-				$file_name = $this->_get_file($section->listen_url, $copy_to_dir);
-			}
 
-			if (!$file_name) continue;
+			if (!$local_file or !$file_name) continue;
 
 			$file_name = trim($file_name);
             $file_path = $copy_to_dir . '/' . $file_name;
@@ -526,38 +522,6 @@ class Validator extends Private_Controller
 		$file_name = trim(end($file_array));
 		$copied = copy($local_file, $copy_to_dir . '/' . $file_name);
 		return ($copied) ? $file_name : false;
-	}
-
-	function _get_file($file_url, $copy_to_dir)
-	{
-		set_time_limit(0);
-
-		$file_name = $this->_get_file_name_from_url($file_url);
-
-		$fp = fopen($copy_to_dir . '/' . $file_name, 'w');
-
-		$ch = curl_init($file_url);
-
-		curl_setopt_array($ch, array(
-			CURLOPT_URL => $file_url,
-			CURLOPT_RETURNTRANSFER => 1,
-			//CURLOPT_FILE           => $fp,
-			CURLOPT_TIMEOUT => 50
-
-		));
-
-		$results = curl_exec($ch);
-		if (curl_errno($ch))
-		{
-			return false;
-		}
-
-		curl_close($ch);
-
-		fwrite($fp, $results); //old style, let me debug something. TODO: update
-		fclose($fp);
-
-		return $file_name;
 	}
 
 	function _get_file_name_from_url($url)
@@ -851,15 +815,6 @@ class Validator extends Private_Controller
 		echo $copied;
 	}
 
-	function test_copy_remote_file()
-	{
-		$listen_url = 'http://upload.librivox.org/share/uploads/rg/aristopia_00_holford.mp3';
-		$listen_url = 'https://librivox.local/librivox-validator-books/the_secret_garden_1308/aristopia_00_holford.mp3';
-		$copy_to_dir = 'C:/test_files/';
-
-		$this->_get_file($listen_url, $copy_to_dir);
-	}
-
 	function test_get_file()
 	{
 		//echo 'TEST';
@@ -897,12 +852,8 @@ class Validator extends Private_Controller
 		{
 			$file_name = $this->_copy_file($local_file, $copy_to_dir);
 		}
-		else
-		{
-			$file_name = $this->_get_file($section->listen_url, $copy_to_dir);
-		}
 
-		if (!$file_name)
+		if (!$local_file or !$file_name)
 		{
 			echo 'No file name';
 			return;


### PR DESCRIPTION
The first fixes #119, by removing the Validator code that would fetch MP3 files from remote servers.  A bad fetch (from a typo) would often result in a zero-sized file in the Validator folder.
This 'fetch' feature was handy before Uploader became prevalent, but is no longer used.  Better to remove than to fix.  Admin discussion:
https://forum.librivox.org/viewtopic.php?p=2409190#p2409190

The next fixes #31 on *dev*, where mere warnings still cause a hang.  In prod, the only cause I see for hanging is those zero-sized files we just addressed.  We can consider this fixed as well, until we hear otherwise.

Future-musings:
This does look ripe for a re-factor (now `_local_file` and `_copy_file` can be merged, for example), but I'll leave that be for now.  I wouldn't mind removing the `test_*` functions either (they don't look to automate well), but we might as well keep them in sync while they remain.