### PR TITLE
Add cache to .gitignore, and migrate to 'archive.org/compress' for zip URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+application/cache/
 application/config/config.php
 application/config/database.php
 application/config/iarchive_uploader.php

--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -2,5 +2,5 @@
 
 $config['migration_enabled'] = TRUE;
 $config['migration_type'] = 'sequential';
-$config['migration_version'] = 4;
+$config['migration_version'] = 5;
 $config['migration_path'] = APPPATH . 'migrations/';

--- a/application/controllers/private/Iarchive_upload.php
+++ b/application/controllers/private/Iarchive_upload.php
@@ -72,7 +72,7 @@ class Iarchive_upload extends Private_Controller
 
 		//update the project
 		$update['url_iarchive'] = $config['iarchive_project_page'] . '/' . $params['project_slug'];
-		$update['zip_url'] = 'https://www.archive.org/download/' . $params['project_slug'] . '/' . $params['project_slug'] . '_64kb_mp3.zip';
+		$update['zip_url'] = 'https://archive.org/compress/' . $params['project_slug'] . '/formats=64KBPS MP3&file=/' . $params['project_slug'] . '.zip';
 
 		$this->project_model->update($project->id, $update);
 

--- a/application/migrations/005_fix_zip_urls_2.php
+++ b/application/migrations/005_fix_zip_urls_2.php
@@ -1,0 +1,18 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Fix_zip_urls_2 extends CI_Migration {
+
+        public function up()
+        {
+                $this->db->query('
+                        UPDATE projects
+                        SET zip_url = REGEXP_REPLACE(zip_url, ".*archive.org/download/(.*)/(.*)_[0-9]+kb_mp3.zip", "https://archive.org/compress/\\\1/formats=64KBPS MP3&file=/\\\2.zip")
+                        WHERE zip_url LIKE "%archive.org/download/%"
+                ');
+        }
+
+        public function down(): void
+        {}
+}


### PR DESCRIPTION
This switches our `zip_url` links over from www.archive.org to just archive.org as the host.  It also switches to the '/compress/...' URL style that they seem to use, themselves, instead of '/download/...'.  Some number of their servers block '/download', giving 403 codes when listeners try to get the zip!  :face_with_open_eyes_and_hand_over_mouth: 