### PR TITLE
Some boundaries for nice bots

### DIFF
--- a/application/controllers/catalog/Page.php
+++ b/application/controllers/catalog/Page.php
@@ -31,6 +31,7 @@ class Page extends Catalog_controller
 		{
 			$this->data['message'] = 'We weren\'t able to find that project. You must include either the Project Id or the Project Slug (i.e., "tom_sawyer_by_mark_twain" , without any other link info)';
 			$this->_render('catalog/not_found');
+			$this->output->set_status_header(404);
 			return;
 		}
 		

--- a/public_html/robots.txt
+++ b/public_html/robots.txt
@@ -2,3 +2,7 @@
 # http://code.google.com/web/controlcrawlindex/
 
 User-agent: *
+Disallow: /uploads/
+Disallow: /librivox-validator-books/
+Disallow: /public_readers_iframe/
+Disallow: /auth/


### PR DESCRIPTION
Updated robots.txt with some areas that no bot needs.

Also, since even good bots can get bad links, we can return a 404 code along with the catalog's "project not found" message.  The screen *as seen by the user* remains the same, but now the bots can get a clue too.