### PR TITLE
Author manager updates

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -80,6 +80,9 @@ $route['validator']				= 'private/validator/index';
 $route['validator/(:num)']		= 'private/validator/index/$1';
 $route['validator/adjust_file_volume/(:num)']		= 'private/validator/adjust_file_volume/$1';
 
+$route['admin/author_manager/(:num)']   = 'admin/author_manager/index/id/$1';
+$route['admin/author_manager/(all|unconfirmed)']   = 'admin/author_manager/index/$1';
+
 $route['volunteers']			= 'private/volunteers/index';
 $route['volunteers/(:any)']		= 'private/volunteers/index/$1';
 

--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -81,6 +81,7 @@ $route['validator/(:num)']		= 'private/validator/index/$1';
 $route['validator/adjust_file_volume/(:num)']		= 'private/validator/adjust_file_volume/$1';
 
 $route['admin/author_manager/(:num)']   = 'admin/author_manager/index/id/$1';
+$route['admin/author_manager/(project)/(:num)']   = 'admin/author_manager/index/$1/$2';
 $route['admin/author_manager/(all|unconfirmed)']   = 'admin/author_manager/index/$1';
 
 $route['volunteers']			= 'private/volunteers/index';

--- a/application/controllers/admin/Author_manager.php
+++ b/application/controllers/admin/Author_manager.php
@@ -174,7 +174,7 @@ class Author_manager extends Private_Controller
 			$message = 'Deleted';
 		}
 
-		$this->ajax_output(array('message' => $message), TRUE, FALSE);
+		$this->ajax_output(array('message' => $message), (bool)$fields['id'], FALSE);
 	}
 
 	public function add_new_author()
@@ -191,7 +191,7 @@ class Author_manager extends Private_Controller
 			$message = 'Added';
 		}
 
-		$this->ajax_output(array('message' => $message), TRUE, FALSE);
+		$this->ajax_output(array('message' => $message), (bool)$insert_id, FALSE);
 	}
 
 	//// ********* TESTING ************/////

--- a/application/controllers/admin/Author_manager.php
+++ b/application/controllers/admin/Author_manager.php
@@ -40,6 +40,25 @@ class Author_manager extends Private_Controller
 			ini_set('memory_limit', '-1'); // Still a hack
 			$this->data['authors'] = $this->author_model->order_by('id', 'asc')->get_many_by(array('linked_to' => '0'));
 		}
+		elseif ($route == 'project')
+		{
+			// Authors and translators by project ID
+			$this->data['authors'] = array();
+			$results_to_cast = array();
+			$this->load->model('project_model');
+
+			$project_authors = $this->project_model->get_authors_by_project($id, 'author', include_sections: true);
+			if ($project_authors) $results_to_cast = array_merge($results_to_cast, $project_authors);
+
+			$project_translators = $this->project_model->get_authors_by_project($id, 'translator');
+				if ($project_translators) $results_to_cast = array_merge($results_to_cast, $project_translators);
+
+			// Hack: get_authors_by_project returns an array of *arrays*.
+			// We need to cast them as objects, to match types with the db->get*() results
+			foreach ($results_to_cast as $person) {
+				$this->data['authors'][] = (object) $person;
+			}
+		}
 
 		$this->insertMethodCSS();
 		$this->insertMethodJS();

--- a/application/controllers/admin/Author_manager.php
+++ b/application/controllers/admin/Author_manager.php
@@ -16,17 +16,30 @@ class Author_manager extends Private_Controller
 		$this->template->add_js('js/libs/jquery.jeditable.js');
 	}
 
-	public function index()
+	public function index($route = 'unconfirmed', $id = 0)
 	{
-		ini_set('memory_limit', '-1'); //we need to see about chunking this
-
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 		$this->data['author_blurb_modal'] = $this->load->view('admin/author_manager/author_blurb_modal', $this->data, TRUE);
 		$this->data['author_projects_modal'] = $this->load->view('admin/author_manager/author_projects_modal', $this->data, TRUE);
 		$this->data['author_pseudonyms_modal'] = $this->load->view('admin/author_manager/author_pseudonyms_modal', $this->data, TRUE);
 		$this->data['author_new_modal'] = $this->load->view('admin/author_manager/author_new_modal', $this->data, TRUE);
 
-		$this->data['authors'] = $this->author_model->order_by('id', 'asc')->get_many_by(array('linked_to' => '0')); //limit(100)->
+		if ($route == 'unconfirmed')
+		{
+			// Default: view unconfirmed authors
+			$this->data['authors'] = $this->author_model->order_by('id', 'asc')->get_many_by(array('linked_to' => '0', 'confirmed' => '0'));
+		}
+		elseif ($route == 'id')
+		{
+			// Individual: view author by ID
+			$this->data['authors'] = array($this->author_model->get($id));
+		}
+		elseif ($route == 'all')
+		{
+			// Old way: view all non-duplicate authors (very slow!)
+			ini_set('memory_limit', '-1'); // Still a hack
+			$this->data['authors'] = $this->author_model->order_by('id', 'asc')->get_many_by(array('linked_to' => '0'));
+		}
 
 		$this->insertMethodCSS();
 		$this->insertMethodJS();

--- a/application/controllers/catalog/Author.php
+++ b/application/controllers/catalog/Author.php
@@ -17,6 +17,7 @@ class Author extends Catalog_controller
 
 		$this->load->model('author_model');
 		$this->data['author'] = $this->author_model->get($author_id);
+		$this->data['edit_link'] = $this->_get_edit_link($author_id);
 
 		$this->data['search_category'] = 'author';
 
@@ -142,5 +143,31 @@ class Author extends Catalog_controller
 		}
 
 		return $projects;
+	}
+
+	function _get_edit_link($author_id)
+	{
+		$link = '';
+		$auth_checker = new Librivox_auth();
+
+		if (empty($author_id))
+		{
+			return $link;
+		}
+
+		$user_id = $auth_checker->get_user_id();
+		if ($user_id < 1) {
+			return $link;
+		}
+
+		//check permissions
+		$allowed_groups = array(PERMISSIONS_ADMIN, PERMISSIONS_MCS);		
+		if ($auth_checker->has_permission($allowed_groups, $user_id))
+		{
+			$link = base_url() . 'admin/author_manager/' . $author_id ;
+			return $link;
+		}
+
+		return $link;
 	}
 }

--- a/application/controllers/private/Projects.php
+++ b/application/controllers/private/Projects.php
@@ -30,10 +30,12 @@ class Projects extends Private_Controller
 		$this->data['project_statuses'] = $this->config->item('project_statuses');
 
 		$this->data['view_validator'] = false;
+		$this->data['view_author_manager'] = false;
 		$allowed_groups = array(PERMISSIONS_ADMIN, PERMISSIONS_MCS);
 		if ($this->librivox_auth->has_permission($allowed_groups, $this->data['user_id']))
 		{
 			$this->data['view_validator'] = true;
+			$this->data['view_author_manager'] = true;
 		}
 
 		if (!empty($this->data['projects']))

--- a/application/models/Project_model.php
+++ b/application/models/Project_model.php
@@ -482,7 +482,7 @@ class Project_model extends MY_Model
     }
 
 
-    public function get_authors_by_project($project_id, $type= 'author')
+    public function get_authors_by_project($project_id, $type= 'author', $include_sections = false)
     {
         $sql = '
         SELECT a.*
@@ -490,8 +490,20 @@ class Project_model extends MY_Model
         JOIN authors a ON (pa.author_id = a.id)
         WHERE pa.project_id = ?
         AND pa.type = ? ';
+        $bind = array($project_id, $type);
 
-        $query = $this->db->query($sql, array($project_id, $type));
+        if ($include_sections and $this->get($project_id)->is_compilation) {
+            $sql .= '
+            UNION
+            SELECT a.*
+            FROM sections s
+            JOIN authors a ON (s.author_id = a.id)
+            WHERE s.project_id = ?';
+
+            $bind[] = $project_id;
+        }
+
+        $query = $this->db->query($sql, $bind);
 
         if ($query->num_rows() > 0) return $query->result_array();
 

--- a/application/views/admin/author_manager/index.php
+++ b/application/views/admin/author_manager/index.php
@@ -8,6 +8,11 @@
     white-space: nowrap;
     overflow: hidden;
 }
+/* Tweak dataTables "Show X entries" control, so that it lines up with other buttons */
+.dataTables_length {
+	float: none;
+	display: inline;
+}
 
 </style>
 
@@ -16,13 +21,12 @@
 
 	<h4>Author Manager</h4>
 
-	<div data-filter="status_filter" id="status_filter" style="margin-bottom: 20px;">	
-		<span style="vertical-align:middle;" >Show only unconfirmed authors: </span>
-		<input style="margin-left:10px;vertical-align:middle;" class="status_group" name="status_group[]" type="radio" id="active_status" value="1" checked> 
-		<span style="margin-left:10px;vertical-align:middle;" >Show all authors: </span>
-		<input style="margin-left:10px;vertical-align:middle;" class="status_group"  name="status_group[]" type="radio" id="all_status" value="all" > 	
-
-		<input style="margin-left:20px;vertical-align:middle;" class="btn"  name="new_author_modal_btn" type="button" id="new_author_modal_btn" value="New Author" >
+	<div class="controls center" style="float:left;">
+		<a style="display:inline;margin-right:10px;" class="btn" role="button" href="/admin/author_manager/unconfirmed">Load unconfirmed</a>
+		<a style="display:inline;margin-right:10px;" class="btn" role="button" href="/admin/author_manager/all">Load all</a>
+		<input style="display:inline;margin-right:10px;" class="btn" name="new_author_modal_btn" type="button" role="button" id="new_author_modal_btn" value="Add author" >
+		<label style="display:inline;margin-right:5px;" for="author_search">Load author by name:</label>
+		<input style="width:200px;display:inline;margin-right:10px;vertical-align:top;" type="text" id="search_author" class="autocomplete" data-search_field="full_name" data-search_area="author" data-search_func="autocomplete_author">
 	</div>
 
 

--- a/application/views/admin/author_manager/index.php
+++ b/application/views/admin/author_manager/index.php
@@ -21,6 +21,8 @@
 
 	<h4>Author Manager</h4>
 
+	<div id="response_message_authormanager" class="alert" style="display:none;"></div>
+
 	<div class="controls center" style="float:left;">
 		<a style="display:inline;margin-right:10px;" class="btn" role="button" href="/admin/author_manager/unconfirmed">Load unconfirmed</a>
 		<a style="display:inline;margin-right:10px;" class="btn" role="button" href="/admin/author_manager/all">Load all</a>

--- a/application/views/admin/author_manager/index.php
+++ b/application/views/admin/author_manager/index.php
@@ -31,7 +31,7 @@
 			<tr> <th>Status</th> <th>Id</th> <th>First name</th> <th>Last name</th> <th>Pseudonyms</th> 
 				<th>Url</th> <th>Blurb</th> <th>DOB</th> <th>DOD</th> 
 				<th  class="data_filter" data-filter="status_filter">Confirm</th> 
-				<th>Link to</th> <th>Wiki</th> <th>Image URL</th></tr>
+				<th>Link to</th> <th>Wiki</th></tr>
 		</thead>
 
 		<tbody>
@@ -96,10 +96,7 @@
 
 					?>
 
-
-					<td><a href="<?= $url?>" target = "_blank"><i class="icon-edit"></i></a></td>
-
-					<td  id="image_url-<?= $author->id ?>"  class="edit" ><?= $author->image_url;?></td>					
+					<td><a href="<?= $url?>" target = "_blank"><i class="icon-edit"></i></a></td>		
 				</tr>
 
 			<?php endforeach; ?>

--- a/application/views/catalog/author.php
+++ b/application/views/catalog/author.php
@@ -15,13 +15,16 @@
 				<p class="description"><?= $author->blurb ?></p>
 				
 				<div class="page-header-half">
-					<p><span>External Links</span></p>
+					<p><span>Links</span></p>
 					<?php 
 						if (!empty($author->author_url))
 						{
 							echo '<p>' . format_author($author, FMT_AUTH_WIKI) . '</p>';
 						}	
-					 	
+						if (!empty($edit_link))
+						{
+							echo '<p><a href="' . $edit_link . '">Edit this page</a></p>';
+						}
 					 ?>				 
 				</div>
 				

--- a/application/views/private/projects/index.php
+++ b/application/views/private/projects/index.php
@@ -43,7 +43,12 @@
 					<?php endif;?>
 
 					<td id="title-<?= $project->id ?>" ><?= $project->title ?></td>
-					<td id="author-<?= $project->id ?>" ><?= $project->author ?></td>
+					<td id="author-<?= $project->id ?>" >
+						<?php if ($view_author_manager):?>
+							<a href="<?= base_url().'admin/author_manager/project/'.$project->id ?>"><i class="icon-search meta_data"></i></a>
+						<?php endif;?>
+						<?= $project->author ?>
+					</td>
 					<td id="status-<?= $project->id ?>" ><?= $project_statuses[$project->status] ?></td>
 					<td id="url_forum-<?= $project->id ?>" ><a href="<?= $project->url_forum ?>">link</a></td>
 					<td id="url_librivox-<?= $project->id ?>" ><a href="<?= $project->url_librivox ?>">link</a></td>

--- a/public_html/js/admin/author_manager/index.js
+++ b/public_html/js/admin/author_manager/index.js
@@ -24,8 +24,10 @@ $(document).ready(function() {
 
     bind_edit();
 
+    var table_size = $('#authors_table').find('tr').length;
+
     $.extend( $.fn.dataTable.defaults, {
-        "bFilter": true,
+        "bFilter": table_size > 10 + 1, // Header row counts!
         "bPaginate" : true,
         "bInfo" : true,
         "sPaginationType": "full_numbers",
@@ -39,29 +41,6 @@ $(document).ready(function() {
     var oTable = $('#authors_table').dataTable();
 
     oTable.fnSort([[1, 'asc']]);
-    
-
-    //default  -only unconfirmed
-    // need to make this check which radio button is checked
-    var checked_radio = $('input[class=status_group]:checked').val();    
-    apply_filter(checked_radio);  
-
-    $('.status_group').live('click', function(){   
-        apply_filter( $(this).val());
-    }) ; 
-
-    function apply_filter(filter_value)
-    {
-        if (filter_value == '1') 
-        {
-            oTable.fnFilter( 0, 0 );
-        }
-        else
-        {
-            oTable.fnFilter('', 0);
-            //oTable.fnFilter( '' );
-        }   
-    }
 
     function bind_edit()
     {
@@ -126,11 +105,6 @@ $(document).ready(function() {
                 var row_id = oTable.fnGetPosition(row);
 
                 update_author_status(value, row_id);
-
-                //the one from above was static
-                var sub_checked_radio = $('input[class=status_group]:checked').val();
-                apply_filter(sub_checked_radio);
-     
               },
         });   
 
@@ -337,3 +311,28 @@ $(document).ready(function() {
     });
 
 });
+
+
+// Autocomplete the "Load author by name" search
+
+function autocomplete_assign_vars(item)
+{
+    var name_field;
+    if (item.username == undefined) {
+        name_field = author_string(item);
+    } else {
+        name_field = item.username;
+    }
+
+    return {
+        label: name_field,
+        value: name_field,
+        source_id: item.id,
+        source_name: name_field,
+    }
+}
+
+function autocomplete_assign_elements(search_area, ui)
+{
+    window.location.href = CI_ROOT + 'admin/author_manager/' + ui.item.source_id
+}

--- a/public_html/js/admin/author_manager/index.js
+++ b/public_html/js/admin/author_manager/index.js
@@ -122,11 +122,12 @@ $(document).ready(function() {
               type: 'post',
               data: $('#add_new_author_form').serialize(),
               complete: function(r){
-                //var response_obj = jQuery.parseJSON(r.responseText);
-
-                alert('You will need to refresh the page in order to see your newly added author. This can be slow, so we let you do it manually when you are ready.')
                 $('#author_new_modal').modal('hide');
-     
+                json_set_message(
+                    'response_message_authormanager', r.responseText,
+                    'Author added!  Click "Load unconfirmed" or load the author by name to view.<br>Message from server: ',
+                    'The author may not have been added.  Click "Load unconfirmed" or search by name to verify.<br>Message from server: '
+                );
               },
         }); 
     });
@@ -248,11 +249,9 @@ $(document).ready(function() {
               url: CI_ROOT + 'admin/author_manager/update_add_pseudonym',
               type: 'post',
               data: {'id' : id, 'author_id' : author_id, 'first_name': first_name, 'last_name': last_name },
-              complete: function(r){
-                var response_obj = jQuery.parseJSON(r.responseText);
-                
+              complete: function(r){               
                 $('#author_pseudonyms_modal').modal('hide');
-                alert(response_obj.data.message);
+                json_set_message('response_message_authormanager', r.responseText);
               },
         });   
 
@@ -268,10 +267,8 @@ $(document).ready(function() {
               type: 'post',
               data: {'id' : id },
               complete: function(r){
-                var response_obj = jQuery.parseJSON(r.responseText);
-                
                 $('#author_pseudonyms_modal').modal('hide');
-                alert(response_obj.data.message);
+                json_set_message('response_message_authormanager', r.responseText);
               },
         });   
 

--- a/public_html/js/common/application.js
+++ b/public_html/js/common/application.js
@@ -56,6 +56,24 @@ function set_message(element, message, addClass)
 
 }
 
+// safe messaging, given a (possibly faulty) JSON response from the server
+function json_set_message(element, responseText, intro_success, intro_fail)
+{
+    var message, success;
+    try {
+        var response_obj = jQuery.parseJSON(responseText);
+        if (response_obj.status == "SUCCESS") {
+            message = (intro_success ? intro_success : '') + (response_obj.data.message ? response_obj.data.message : '');
+            success = true;
+        } else {
+            message = (intro_fail ? intro_fail : '') + (response_obj.data.message ? response_obj.data.message : '');
+        }
+    } catch {
+        message = (intro_fail ? intro_fail : '') + 'No message';
+    }
+    return set_message(element, message, success ? 'alert-success' : 'alert-error')
+}
+
 
 //toggle forms
 $('.toggle_form_btn').live('click', function(){


### PR DESCRIPTION
This PR does add more code than it removes... but hopefully it's clean and easy to follow.  Each commit is separable, if just one part needs to go.  There having been no objections on the admin side, I'm getting this up while it's still (re-)fresh in mind.

Resolves #91: after further discussion, we don't need that column visible for the foreseeable future.  :grin: 

Resolves #24... hopefully.  New endpoints for authors by ID, by project, or by confirmation status (the default use-case), and some hopefully-intuitive ways of navigating them.  :crossed_fingers: 

Also, a nicer way of handling malformed responses to AJAX requests.  Seeing an unhelpful message is better than having the application freeze, as seen in #31.  Thankfully, that's rare on live these days.  When testing with warnings enabled, not so rare.  :wink: 