### PR TITLE
Add page titles to catalog and Workflow apps

### DIFF
--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -63,6 +63,7 @@ class Auth extends MY_Controller
 		}
 
 		$this->data['title'] = "Login";
+		$this->data['page_title'] = $this->data['title'];
 
 		//validate form input
 		$this->form_validation->set_rules('identity', 'Identity', 'required');
@@ -116,6 +117,7 @@ class Auth extends MY_Controller
 			$this->data['redirect_url'] = $redirect_url;
 
 			//$this->load->view('auth/login', $this->data);
+			$this->template->write_view('head', 'common/workflow_head.php', $this->data);
 			$this->template->write_view('content_left', build_view_path(__METHOD__), $this->data);
 			$this->template->render();
 		}

--- a/application/controllers/admin/Author_manager.php
+++ b/application/controllers/admin/Author_manager.php
@@ -63,8 +63,7 @@ class Author_manager extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function update_author_value()

--- a/application/controllers/admin/Genre_manager.php
+++ b/application/controllers/admin/Genre_manager.php
@@ -30,8 +30,7 @@ class Genre_manager extends Private_Controller
 
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function update_genre()

--- a/application/controllers/admin/Genre_manager.php
+++ b/application/controllers/admin/Genre_manager.php
@@ -15,6 +15,7 @@ class Genre_manager extends Private_Controller
 
 	public function index()
 	{
+		$this->data['page_title'] = 'Genre Manager';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->data['genres'] = $this->mahana_hierarchy->get_sorted_children();

--- a/application/controllers/admin/Language_manager.php
+++ b/application/controllers/admin/Language_manager.php
@@ -27,8 +27,7 @@ class Language_manager extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function update_language_value()

--- a/application/controllers/admin/Language_manager.php
+++ b/application/controllers/admin/Language_manager.php
@@ -20,6 +20,7 @@ class Language_manager extends Private_Controller
 	{
 		ini_set('memory_limit', '-1'); //we need to see about chunking this
 
+		$this->data['page_title'] = 'Language Manager';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->data['languages'] = $this->language_model->order_by('common', 'desc')->order_by('language', 'asc')->get_all(); //

--- a/application/controllers/catalog/Author.php
+++ b/application/controllers/catalog/Author.php
@@ -26,6 +26,8 @@ class Author extends Catalog_controller
 		$matches = $this->_get_all_author($author_id);
 		$this->data['matches'] = count($matches);
 
+		$this->data['page_title'] = 'Works by '. format_author($this->data['author']);
+
 		$this->data['search_order'] = $this->input->get('search_order');
 
 		$this->_render('catalog/author');

--- a/application/controllers/catalog/Group.php
+++ b/application/controllers/catalog/Group.php
@@ -25,6 +25,8 @@ class Group extends Catalog_controller
 		$matches = $this->_get_all_group_projects($group_id, 0, 1000000);
 		$this->data['matches'] = count($matches);
 
+		$this->data['page_title'] = 'Works in "' . $this->data['group']->name . '"';
+
 		$this->data['search_order'] = $this->input->get('search_order');
 
 		$this->_render('catalog/group');

--- a/application/controllers/catalog/Keywords.php
+++ b/application/controllers/catalog/Keywords.php
@@ -29,6 +29,7 @@ When passed a keywords_id, display a list of projects that have that keyword
 		$params['search_order'] = $this->input->get('search_order');
 		$matches = $this->_get_projects_by_keywords_id($params);
 		$this->data['matches'] = count($matches);		
+		$this->data['page_title'] = 'Works tagged with "' . $this->data['keywords']->value . '"';
 		$this->_render('catalog/keywords');
 		return;
 	}

--- a/application/controllers/catalog/Page.php
+++ b/application/controllers/catalog/Page.php
@@ -38,6 +38,10 @@ class Page extends Catalog_controller
 		//create link to project editing page for logged in user with appropriate permissions
 		$this->data['project']->edit_link = $this->_get_edit_link($this->data['project']->id);
 
+		// **** TITLE ****//
+		// Used for HTML page title, and also views/catalog/page.php
+		$this->data['page_title'] = create_full_title($this->data['project']);
+
 		// **** AUTHORS ****//
 		$this->data['authors_string'] = '';
 

--- a/application/controllers/catalog/Reader.php
+++ b/application/controllers/catalog/Reader.php
@@ -32,6 +32,8 @@ class Reader extends Catalog_controller
 		$matches = $this->_get_all_reader($reader_id);
 		$this->data['matches'] = count($matches);
 
+		$this->data['page_title'] = 'Works read by '. $this->data['reader']['display_name'];
+
 		$this->data['search_order'] = $this->input->get('search_order');
 
 		$this->_render('catalog/reader');

--- a/application/controllers/catalog/Sections.php
+++ b/application/controllers/catalog/Sections.php
@@ -78,6 +78,8 @@ class Sections extends Catalog_controller
 		$matches = $this->_get_all_reader($user_id);
 		$this->data['matches'] = count($matches);
 
+		$this->data['page_title'] = 'Section details for ' . $this->data['reader']->display_name;
+
 		$this->_render('catalog/sections');
 		return;
 	}

--- a/application/controllers/private/Administer_projects.php
+++ b/application/controllers/private/Administer_projects.php
@@ -34,6 +34,10 @@ class Administer_projects extends Private_Controller
 	public function add_catalog_item($project_id = 0)
 	{
 		//We might be new here, we might be looking up the project launch data, or we might be submitting our new data
+		// Set titles that match the link we took to this page:
+		$this->data['page_title'] = 'Project Screen';
+		if ($project_id == 'new') $this->data['page_title'] = 'Add New Project | '. $this->data['page_title'];
+		elseif ($project_id == 'search') $this->data['page_title'] = 'Search Projects | '. $this->data['page_title'];
 
 		$prototype = $this->catalog_item->get_prototype();
 
@@ -59,6 +63,8 @@ class Administer_projects extends Private_Controller
 		{
 			$this->load->model('project_model');
 			$project = $this->project_model->get($project_id);
+
+			if ($project) $this->data['page_title'] = create_full_title($project) .' | '. $this->data['page_title'];
 
 			$volunteers = array('bc', 'altbc', 'mc', 'pl');
 

--- a/application/controllers/private/Administer_projects.php
+++ b/application/controllers/private/Administer_projects.php
@@ -28,8 +28,7 @@ class Administer_projects extends Private_Controller
 	{
 		$prototype['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $prototype);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $prototype);
 	}
 
 	public function add_catalog_item($project_id = 0)
@@ -114,8 +113,7 @@ class Administer_projects extends Private_Controller
 		$this->template->add_css('css/private/administer_projects/new_project_form.css');
 		$this->template->add_js('js/private/administer_projects/new_project_form.js');
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $prototype);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $prototype);
 	}
 
 	public function ajax_lookup_project_code()

--- a/application/controllers/private/Groups.php
+++ b/application/controllers/private/Groups.php
@@ -18,8 +18,7 @@ class Groups extends Private_Controller
 
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function update_group()

--- a/application/controllers/private/Groups.php
+++ b/application/controllers/private/Groups.php
@@ -5,6 +5,7 @@ class Groups extends Private_Controller
 
 	public function index()
 	{
+		$this->data['page_title'] = 'Group Manager';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->load->model('group_model');

--- a/application/controllers/private/Projects.php
+++ b/application/controllers/private/Projects.php
@@ -61,8 +61,7 @@ class Projects extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function ajax_search_catalog()

--- a/application/controllers/private/Projects.php
+++ b/application/controllers/private/Projects.php
@@ -21,6 +21,7 @@ class Projects extends Private_Controller
 
 		$this->data['project_search'] = empty($params['project_search']) ? '' : $params['project_search'];
 
+		$this->data['page_title'] = 'Projects';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		//load volunteers AFTER the menu_header

--- a/application/controllers/private/Section_compiler.php
+++ b/application/controllers/private/Section_compiler.php
@@ -73,8 +73,7 @@ class Section_compiler extends Private_Controller
 
 		$this->template->add_js('js/common/autocomplete.js');
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function select_project()
@@ -90,8 +89,7 @@ class Section_compiler extends Private_Controller
 		$this->template->add_css('css/private/administer_projects/new_project_form.css'); //reuse results styling
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function order_sections()

--- a/application/controllers/private/Section_compiler.php
+++ b/application/controllers/private/Section_compiler.php
@@ -35,6 +35,8 @@ class Section_compiler extends Private_Controller
 		$this->load->model('project_model');
 		$this->data['project'] = $this->project_model->get($project_id);
 
+		$this->data['page_title'] = create_full_title($this->data['project']) .' | Section Compiler';
+
 		$this->data['admin_mc'] = 0;
 
 		$allowed_groups = array(PERMISSIONS_ADMIN, PERMISSIONS_MCS);
@@ -78,6 +80,7 @@ class Section_compiler extends Private_Controller
 
 	public function select_project()
 	{
+		$this->data['page_title'] = 'Search Projects | Section Compiler';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->data['statuses'] = $this->config->item('project_statuses');

--- a/application/controllers/private/Stats.php
+++ b/application/controllers/private/Stats.php
@@ -25,8 +25,7 @@ class Stats extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function mc_stats()
@@ -46,8 +45,7 @@ class Stats extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function monthly_stats()
@@ -61,8 +59,7 @@ class Stats extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function general_stats()
@@ -83,8 +80,7 @@ class Stats extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function chapters_count($user_id = 0)
@@ -97,8 +93,7 @@ class Stats extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function sections($user_id = 0)
@@ -164,8 +159,7 @@ class Stats extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	//updates stats
@@ -224,8 +218,7 @@ class Stats extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 }

--- a/application/controllers/private/Stats.php
+++ b/application/controllers/private/Stats.php
@@ -18,6 +18,7 @@ class Stats extends Private_Controller
 	{
 		$user_id = ($user_id) ? $user_id : $this->librivox_auth->get_user_id();
 
+		$this->data['page_title'] = 'Stats';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->load->model('project_model');
@@ -38,6 +39,7 @@ class Stats extends Private_Controller
 		}
 
 		//https://catalog.librivox.org/MCstats.php
+		$this->data['page_title'] = 'MC Stats';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->data['volunteers'] = $this->stats_model->mc_stats();
@@ -51,6 +53,7 @@ class Stats extends Private_Controller
 	public function monthly_stats()
 	{
 		//https://catalog.librivox.org/monthly.php
+		$this->data['page_title'] = 'Monthly Stats';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->data['monthly_stats'] = $this->stats_model->monthly_stats();
@@ -65,6 +68,7 @@ class Stats extends Private_Controller
 	public function general_stats()
 	{
 		//https://catalog.librivox.org/stats.php -- general stats page
+		$this->data['page_title'] = 'General Stats';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		//$this->data['stats'] = $this->stats_model->monthly_stats();
@@ -88,6 +92,7 @@ class Stats extends Private_Controller
 		$user_id = ($user_id) ? $user_id : $this->librivox_auth->get_user_id();
 
 		//https://catalog.librivox.org/chapters_count.php
+		$this->data['page_title'] = 'Chapters Count';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->insertMethodCSS();
@@ -101,6 +106,7 @@ class Stats extends Private_Controller
 		$user_id = ($user_id) ? $user_id : $this->librivox_auth->get_user_id();
 
 		//https://catalog.librivox.org/chapters_count.php
+		$this->data['page_title'] = 'Sections';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->load->model('section_model');
@@ -185,6 +191,7 @@ class Stats extends Private_Controller
 			redirect(base_url() . '/auth/error_no_permission');
 		}
 
+		$this->data['page_title'] = 'Active Projects';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->data['projects'] = $this->stats_model->active_projects();

--- a/application/controllers/private/Validator.php
+++ b/application/controllers/private/Validator.php
@@ -114,8 +114,7 @@ class Validator extends Private_Controller
 		$this->template->add_js('js/uploader/jquery.fileupload-ui.js');
 		$this->template->add_js('js/uploader/main-validator.js');
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	public function select_project()
@@ -131,8 +130,7 @@ class Validator extends Private_Controller
 		$this->template->add_css('css/private/administer_projects/new_project_form.css'); //reuse results styling
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 

--- a/application/controllers/private/Validator.php
+++ b/application/controllers/private/Validator.php
@@ -60,6 +60,8 @@ class Validator extends Private_Controller
 		$this->data['project']->author_full_name = $this->_get_author_by_project($project_id);
 		$this->data['project']->author_last_name = $this->_get_author_by_project($project_id, 'last');
 
+		$this->data['page_title'] = $this->data['project']->full_title .' | Validator';
+
 		//section info
 		$this->load->model('section_model');
 		$sections = $this->section_model->as_array()->get_many_by(array('project_id' => $project_id));
@@ -119,6 +121,7 @@ class Validator extends Private_Controller
 
 	public function select_project()
 	{
+		$this->data['page_title'] = 'Search Projects | Validator';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		$this->data['statuses'] = $this->config->item('project_statuses');

--- a/application/controllers/private/Volunteers.php
+++ b/application/controllers/private/Volunteers.php
@@ -23,6 +23,7 @@ class Volunteers extends Private_Controller
 
 		$this->data['search_term'] = empty($params['user_search']) ? '' : $params['user_search'];
 
+		$this->data['page_title'] = 'Search People';
 		$this->data['menu_header'] = $this->load->view('private/common/menu_header', $this->data, TRUE);
 
 		//load volunteers AFTER the menu_header

--- a/application/controllers/private/Volunteers.php
+++ b/application/controllers/private/Volunteers.php
@@ -39,8 +39,7 @@ class Volunteers extends Private_Controller
 		$this->insertMethodCSS();
 		$this->insertMethodJS();
 
-		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
-		$this->template->render();
+		$this->_render($this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 	}
 
 	// prolly obsolete now - we use ion_auth add_user()

--- a/application/controllers/public/Home.php
+++ b/application/controllers/public/Home.php
@@ -7,7 +7,9 @@ class Home extends Public_Controller
 	{
 		$this->template->set_template('single_column');
 		$this->loadGenericAssets();
+		$this->data['page_title'] = "Workflow Tool";
 
+		$this->template->write_view('head', 'common/workflow_head.php', $this->data);
 		$this->template->write_view('content', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 		$this->template->render();
 	}

--- a/application/controllers/public/Project_launch.php
+++ b/application/controllers/public/Project_launch.php
@@ -44,6 +44,8 @@ class Project_launch extends Public_Controller
 		$this->load->config('librivox');
 		$this->data['languages'] = $this->config->item('languages');
 
+		$this->data['page_title'] = 'Project Template Generator';
+
 		$this->load->model('language_model');
 		$this->data['recorded_languages'] = full_languages_dropdown('recorded_language');
 		//$this->data['recorded_languages'] = $this->language_model->dropdown('id', 'language');   //as_array()->get_all();
@@ -71,6 +73,7 @@ class Project_launch extends Public_Controller
 		$this->template->add_js('js/common/jquery.tagsinput.min.js');
 		$this->template->add_css('css/common/jquery.tagsinput.css');
 
+		$this->template->write_view('head', 'common/workflow_head.php', $this->data);
 		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 		$this->template->render();
 	}
@@ -135,6 +138,7 @@ class Project_launch extends Public_Controller
 		$data['summaryauthor'] = summary_author($fields);
 
 		$data['titlelc'] = clean_title($fields['title']);
+		$data['page_title'] = $data['titlelc'];
 		$data['title_filename'] = format_filename($data['titlelc']);
 
 		$data['date'] = concat_date($fields['expected_completion_year'], $fields['expected_completion_month'], $fields['expected_completion_day']);
@@ -158,7 +162,7 @@ class Project_launch extends Public_Controller
 
 		$this->{$fields['project_type'] . '_work'}($data);
 
-		//return $this->load->view($this->base_path.'/'.build_view_path(__METHOD__), $data, true);
+		$this->template->write_view('head', 'common/workflow_head.php', $data);
 		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $data);
 		$this->template->render();
 	}

--- a/application/controllers/public/Uploader.php
+++ b/application/controllers/public/Uploader.php
@@ -74,6 +74,7 @@ class Uploader extends Public_Controller
 	public function index()
 	{
 		$this->load->config('librivox');
+		$this->data['page_title'] = "Uploader";
 		$this->data['languages'] = $this->config->item('languages');
 
 		$this->data['current_lang'] = $this->session->userdata('lang_code');
@@ -101,6 +102,7 @@ class Uploader extends Public_Controller
 		$this->template->add_js('js/uploader/jquery.fileupload-ui.js');
 		$this->template->add_js('js/uploader/main.js');
 
+		$this->template->write_view('head', 'common/workflow_head.php', $this->data);
 		$this->template->write_view('content_left', $this->base_path . '/' . build_view_path(__METHOD__), $this->data);
 		$this->template->render();
 	}

--- a/application/core/Private_Controller.php
+++ b/application/core/Private_Controller.php
@@ -76,4 +76,10 @@ class Private_Controller extends MY_Controller
 
 		$this->data['profile_modal'] = $this->load->view('private/common/profile_modal', $this->roles, true);
 	}
+
+	public function _render($view, $data)
+	{
+		$this->template->write_view('content_left', $view, $data);
+		$this->template->render();
+	}
 }

--- a/application/core/Private_Controller.php
+++ b/application/core/Private_Controller.php
@@ -79,6 +79,7 @@ class Private_Controller extends MY_Controller
 
 	public function _render($view, $data)
 	{
+		$this->template->write_view('head', 'common/workflow_head.php', $data);
 		$this->template->write_view('content_left', $view, $data);
 		$this->template->render();
 	}

--- a/application/views/catalog/page.php
+++ b/application/views/catalog/page.php
@@ -23,7 +23,7 @@
 
 				</div>
 				
-				<h1><?= create_full_title($project)?></h1>
+				<h1><?= $project->full_title ?></h1>
 				
 				<p class="book-page-author"><?= $authors_string ?></p>
 				

--- a/application/views/catalog/partials/header.php
+++ b/application/views/catalog/partials/header.php
@@ -13,7 +13,7 @@
 <head>
   <meta content="text/html; charset=utf-8" http-equiv="content-type">
 
-  <title>LibriVox</title>
+  <title><?= (isset($page_title) ? $page_title : 'Browse Catalog') . ' | LibriVox' ?></title>
   <meta name="description" content="LibriVox" />
   <meta name="author" content="LibriVox" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/application/views/common/workflow_head.php
+++ b/application/views/common/workflow_head.php
@@ -1,0 +1,1 @@
+<title><?= isset($page_title) ? $page_title : 'Workflow' ?> | LibriVox</title>


### PR DESCRIPTION
Adds dynamic HTML -> head -> title elements to all pages.  No more tabs that are just called 'LibriVox'!  :wink: 

* First commit deals with the catalog pages, which already share a common 'partials/header' view that we can adjust.  Simple enough!
* Second commit is a tiny refactor for Private_Controller, so that private pages will share code like the catalog pages do.  This doesn't actually change behavior yet, just makes it easy for later...
* Third commit adds titles to those private pages!  Also adds titles to Uploader, Template Generator, and Login pages - those haven't been refactored, so you'll see some duplication of common code there.