### PR TITLE
Fix combined title+author API query producing invalid SQL (#268)

### DIFF
--- a/application/libraries/Librivox_API.php
+++ b/application/libraries/Librivox_API.php
@@ -98,6 +98,22 @@ class Librivox_API{
 
 		*/
 
+		// Run subqueries first, while the query builder is clean. The
+		// builder is stateful: WHERE clauses accumulate until a ->get()
+		// consumes and resets them. If we added main query clauses (e.g.
+		// p.title) before running these subqueries, they would leak into
+		// the subqueries (which query different tables without a 'p'
+		// alias), producing invalid SQL.
+		if (!empty($params['author']))
+		{
+			$author_project_id_list = $this->_build_author_project_id_list($params['author']);
+		}
+
+		if (!empty($params['genre']))
+		{
+			$genre_project_id_list = $this->_build_genre_project_id_list($params['genre']);
+		}
+
 		if ($params['id']) $this->db->where('p.id', $params['id']);
 
 		if ($params['since']) $this->db->where('UNIX_TIMESTAMP(STR_TO_DATE(p.date_catalog, "%Y-%m-%d")) >=  ', $params['since']);
@@ -116,17 +132,14 @@ class Librivox_API{
 			}
 		}
 
-
-		if (!empty($params['author']))
+		if (!empty($author_project_id_list))
 		{
-			$project_id_list = $this->_build_author_project_id_list($params['author']);
-			$this->db->where_in('p.id', $project_id_list);
+			$this->db->where_in('p.id', $author_project_id_list);
 		}
 
-		if (!empty($params['genre']))
+		if (!empty($genre_project_id_list))
 		{
-			$project_id_list = $this->_build_genre_project_id_list($params['genre']);
-			$this->db->where_in('p.id', $project_id_list);
+			$this->db->where_in('p.id', $genre_project_id_list);
 		}
 
 
@@ -311,11 +324,8 @@ class Librivox_API{
 			->result_array();
 
 		require_once(APPPATH.'libraries/Underscore.php');
-
 		$project_ids = __()->pluck($result , 'project_id');
-
-		return (empty($project_ids)) ? 0 : $project_ids;
-		//return implode(', ', $project_ids);
+		return $project_ids;
 
 	}
 
@@ -336,13 +346,9 @@ class Librivox_API{
 			->get('genres g')
 			->result_array();
 
-		//return $result;
-
 		require_once(APPPATH.'libraries/Underscore.php');
-
-		return $project_ids = __()->pluck($result , 'project_id');
-		//return implode(', ', $project_ids);
-
+		$project_ids = __()->pluck($result , 'project_id');
+        return $project_ids;
 	}
 
 }

--- a/application/tests/controllers/api/Feed_audiobooks_test.php
+++ b/application/tests/controllers/api/Feed_audiobooks_test.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Regression test for part of issue #268:
+ * https://github.com/LibriVox/librivox-catalog/issues/268
+ *
+ * When both title and author params are provided in _build_data_set(), the
+ * subqueries (author, genre) must run before any main query WHERE clauses are
+ * added to the shared query builder, otherwise clauses like 'p.title' leak
+ * into subqueries that don't have a 'p' table alias, producing invalid SQL.
+ */
+class Feed_audiobooks_test extends TestCase {
+
+    /**
+    * @link https://github.com/LibriVox/librivox-catalog/issues/268
+    */
+    public function test_title_and_author_combined_does_not_error() {
+        $output = $this->request(
+            'GET',
+            'api/feed/audiobooks?format=json&title=test&author=NONEXISTENT'
+        );
+        $this->assertResponseCode(200);
+    }
+}


### PR DESCRIPTION
Previously, _build_author_project_id_list() and
_build_genre_project_id_list() ran their subqueries after the main
query's WHERE clauses (e.g. p.title) had already been added to
CodeIgniter's shared query builder. Because the builder is stateful
and accumulates WHERE clauses until a ->get() consumes them, clauses
referencing the 'p' alias leaked into the author/genre subqueries,
which query different tables without a 'p' alias, producing invalid
SQL. Additionally, _build_author_project_id_list() could return 0
instead of an empty array when no authors matched, which
where_in() would not handle correctly.

With this patch, both subqueries are moved to the top of
_build_data_set(), before any main query WHERE clauses are added to
the builder, so the builder is still clean when they execute. Both
helper methods now also always return a results array (never 0),
making the subsequent empty() guard and where_in() behave correctly
in all cases. Together, these changes fix both underlying root
causes: the WHERE clause leaking into the subqueries, and the
potential return of 0 being unhandled.

A regression test is included that requests the API with both title
and author params and asserts a 200 response.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>